### PR TITLE
feat: Add Gemini CLI Integration

### DIFF
--- a/tools/installer/bin/bmad.js
+++ b/tools/installer/bin/bmad.js
@@ -50,7 +50,7 @@ program
   .option('-t, --team <team>', 'Install specific team with required agents and dependencies')
   .option('-x, --expansion-only', 'Install only expansion packs (no bmad-core)')
   .option('-d, --directory <path>', 'Installation directory (default: .bmad-core)')
-  .option('-i, --ide <ide...>', 'Configure for specific IDE(s) - can specify multiple (cursor, claude-code, windsurf, roo, cline, other)')
+  .option('-i, --ide <ide...>', 'Configure for specific IDE(s) - can specify multiple (cursor, claude-code, windsurf, roo, cline, gemini, other)')
   .option('-e, --expansion-packs <packs...>', 'Install specific expansion packs (can specify multiple)')
   .action(async (options) => {
     try {
@@ -314,7 +314,8 @@ async function promptInstallation() {
         { name: 'Claude Code', value: 'claude-code' },
         { name: 'Windsurf', value: 'windsurf' },
         { name: 'Roo Code', value: 'roo' },
-        { name: 'Cline', value: 'cline' }
+        { name: 'Cline', value: 'cline' },
+        { name: 'Gemini CLI', value: 'gemini' }
       ]
     }
   ]);

--- a/tools/installer/config/install.config.yml
+++ b/tools/installer/config/install.config.yml
@@ -101,6 +101,16 @@ ide-configurations:
       # 2. Type @agent-name (e.g., "@dev", "@pm", "@architect")
       # 3. The agent will adopt that persona for the conversation
       # 4. Rules are stored in .clinerules/ directory in your project
+  gemini:
+    name: Gemini CLI
+    rule-dir: .gemini/agents/
+    format: context-files
+    instructions: |
+      # To use BMAD agents with the Gemini CLI:
+      # 1. The installer creates a .gemini/ directory in your project.
+      # 2. It also configures .gemini/settings.json to load all agent files.
+      # 3. Simply mention the agent in your prompt (e.g., "As @dev, ...").
+      # 4. The Gemini CLI will automatically have the context for that agent.
 available-agents:
   - id: analyst
     name: Business Analyst


### PR DESCRIPTION
### Description:

This pull request introduces integration for the Google Gemini CLI, allowing users to seamlessly use BMAD Method agents within their projects when using `gemini-cli`.

The setup process now creates a `.gemini/` directory in the user's project, adhering to the official Gemini CLI documentation for providing hierarchical context.

**Key Changes:**

1.  **Installer Option**: Added `gemini` as a selectable IDE option in the installer's command-line interface (`tools/installer/bin/bmad.js`) and interactive prompts.
2.  **Setup Logic**: Implemented a new `setupGeminiCli` function in `tools/installer/lib/ide-setup.js`. This function:
    *   Creates a `.gemini/agents/` directory in the project root.
    *   Copies each agent's markdown file into this directory to serve as an individual context file.
    *   Creates or updates a `.gemini/settings.json` file, setting the `contextFileName` key to an array of all the individual agent files. This ensures the CLI automatically loads all agent personas into its memory.
3.  **Installer Configuration**: Added the necessary `gemini` configuration to `tools/installer/config/install.config.yml`, which resolves the issue of the setup being skipped.

**How to Test:**

1.  Run the installer: `npm run install:bmad`.
2.  In the interactive prompt, select "Gemini CLI" as one of the IDEs.
3.  Complete the installation in a test project directory.
4.  Verify the following structure is created:
    *   A `.gemini/agents/` directory containing markdown files for all BMAD agents (e.g., `dev.md`, `pm.md`).
    *   A `.gemini/settings.json` file with a `contextFileName` key pointing to the agent files (e.g., `"contextFileName": ["agents/analyst.md", "agents/architect.md", ...]`).
5.  Test the integration by running a command like `gemini-cli "As @dev, write a hello world function in Python"`. The CLI should now have the appropriate context.