### PR TITLE
fix: add GEMINI.md to agent context files

### DIFF
--- a/tools/installer/lib/ide-setup.js
+++ b/tools/installer/lib/ide-setup.js
@@ -447,6 +447,9 @@ class IdeSetup {
 
     console.log(chalk.green(`\n✓ Created individual agent context files in ${agentsContextDir}`));
 
+    // Add GEMINI.md to the context files array
+    agentContextFiles.push("GEMINI.md");
+
     // Create or update settings.json
     const settingsPath = path.join(geminiDir, "settings.json");
     let settings = {};


### PR DESCRIPTION
Just a small fix for gemini. The PR from @hieusats  was great except, it doesnt load any GEMINI.md. So you get:

![image](https://github.com/user-attachments/assets/b0a966ab-5cf8-477f-aebe-e73c07d3a8eb)

Hierarchical GEMINI.md should allways be loaded for custom instructions, whether it is from ~/.gemini/GEMINI.md or workspace loc:

![image](https://github.com/user-attachments/assets/28cef3db-e8f8-4497-96d6-de5da7b2d413)

So:

```

{
  "contextFileName": [
    "GEMINI.md",
    "agents/ux-expert.md",
    "agents/sm.md",
    "agents/qa.md",
    "agents/po.md",
    "agents/pm.md",
    "agents/dev.md",
    "agents/bmad-orchestrator.md",
    "agents/bmad-master.md",
    "agents/architect.md",
    "agents/analyst.md"
  ],
  
  ```
  
  Added this way every "GEMINI.md" is added to memory
