### PR TITLE
refactor: nest Claude Code commands under BMad subdirectory

### DIFF
--- a/docs/agentic-tools/claude-code-guide.md
+++ b/docs/agentic-tools/claude-code-guide.md
@@ -7,7 +7,7 @@ For the complete workflow, see the [BMad Workflow Guide](../bmad-workflow-guide.
 When running `npx bmad-method install`, select **Claude Code** as your IDE. This creates:
 
 - `.bmad-core/` folder with all agents
-- `.claude/commands/` folder with agent command files (`.md`)
+- `.claude/commands/BMad` folder with agent command files (`.md`)
 
 ## Using BMad Agents in Claude Code
 

--- a/tools/installer/config/install.config.yaml
+++ b/tools/installer/config/install.config.yaml
@@ -21,7 +21,7 @@ ide-configurations:
       # 3. The agent will adopt that persona for the conversation
   claude-code:
     name: Claude Code
-    rule-dir: .claude/commands/
+    rule-dir: .claude/commands/BMad/
     format: multi-file
     command-suffix: .md
     instructions: |

--- a/tools/installer/lib/ide-setup.js
+++ b/tools/installer/lib/ide-setup.js
@@ -131,7 +131,7 @@ class IdeSetup {
   }
 
   async setupClaudeCode(installDir, selectedAgent) {
-    const commandsDir = path.join(installDir, ".claude", "commands");
+    const commandsDir = path.join(installDir, ".claude", "commands", "BMad");
     const agents = selectedAgent ? [selectedAgent] : await this.getAllAgentIds(installDir);
 
     await fileManager.ensureDirectory(commandsDir);

--- a/tools/upgraders/v3-to-v4-upgrader.js
+++ b/tools/upgraders/v3-to-v4-upgrader.js
@@ -558,7 +558,7 @@ class V3ToV4Upgrader {
     try {
       const ideMessages = {
         cursor: "Rules created in .cursor/rules/",
-        "claude-code": "Commands created in .claude/commands/",
+        "claude-code": "Commands created in .claude/commands/BMad/",
         windsurf: "Rules created in .windsurf/rules/",
         trae: "Rules created in.trae/rules/",
         roo: "Custom modes created in .roomodes",


### PR DESCRIPTION
## Summary
- Nested Claude Code commands under `.claude/commands/BMad/` subdirectory for better organization

## What
- Updated installer configuration to use `.claude/commands/BMad/` instead of `.claude/commands/`
- Modified the setupClaudeCode function to create the nested directory structure

## Why
- Improves organization by grouping all BMad-specific commands together
- Keeps the `.claude/commands/` directory cleaner and more manageable

## How
- Changed `rule-dir` in `install.config.yaml` from `.claude/commands/` to `.claude/commands/BMad/`
- Updated `setupClaudeCode` function in `ide-setup.js` to use nested path
- Updated documentation and upgrader to reflect the new command location

## Testing
- Tested installer creates commands in the correct nested directory
- Verified existing functionality remains intact

#306 