### PR TITLE
fix(docs): fix broken link in GUIDING-PRINCIPLES.md

### DIFF
--- a/docs/GUIDING-PRINCIPLES.md
+++ b/docs/GUIDING-PRINCIPLES.md
@@ -65,7 +65,7 @@ See [Expansion Packs Guide](../docs/expansion-packs.md) for detailed examples an
 
 ### Template Rules
 
-Templates follow the [BMad Document Template](common/utils/bmad-doc-template.md) specification using YAML format:
+Templates follow the [BMad Document Template](../common/utils/bmad-doc-template.md) specification using YAML format:
 
 1. **Structure**: Templates are defined in YAML with clear metadata, workflow configuration, and section hierarchy
 2. **Separation of Concerns**: Instructions for LLMs are in `instruction` fields, separate from content


### PR DESCRIPTION
## What

Fix broken link to BMad Document Template in GUIDING-PRINCIPLES.md

## Why

The original link was incorrect and didn’t resolve properly.

## How

- Updated the markdown link to use the correct relative path.

## Testing

Previewed the markdown to confirm the link now works.