### PR TITLE
fix: add default current directory to installer prompt

### DIFF
--- a/tools/installer/bin/bmad.js
+++ b/tools/installer/bin/bmad.js
@@ -205,6 +205,7 @@ async function promptInstallation() {
       type: 'input',
       name: 'directory',
       message: 'Enter the full path to your project directory where BMad should be installed:',
+      default: process.cwd(),
       validate: (input) => {
         if (!input.trim()) {
           return 'Please enter a valid project path';


### PR DESCRIPTION
## What
Added default current directory to installer's directory prompt

## Why  
Users had to manually type paths or run pwd first - annoying UX experience when installing BMad

## How
- Added `default: process.cwd()` to inquirer prompt in bmad.js

## Testing
Tested installer now shows current directory as prefilled default value