### PR TITLE
chore: configure changelog file path in semantic-release config

### DIFF
--- a/.releaserc.json
+++ b/.releaserc.json
@@ -13,7 +13,12 @@
   "plugins": [
     "@semantic-release/commit-analyzer",
     "@semantic-release/release-notes-generator",
-    "@semantic-release/changelog",
+    [
+      "@semantic-release/changelog",
+      {
+        "changelogFile": "CHANGELOG.md"
+      }
+    ],
     "@semantic-release/npm",
     "./tools/semantic-release-sync-installer.js",
     "@semantic-release/github"


### PR DESCRIPTION
Fixed the semantic-release config error. The issue was setting changelogTitle: "" (empty string) which is invalid.

Removed the invalid changelogTitle option, kept just changelogFile: "CHANGELOG.md".

