### PR TITLE
fix: remove incorrect else branch causing flatten command regression

### DIFF
--- a/tools/flattener/main.js
+++ b/tools/flattener/main.js
@@ -127,11 +127,6 @@ program
           path.join(inputDir, "flattened-codebase.xml"),
         );
       }
-    } else {
-      console.error(
-        "Could not auto-detect a project root and no arguments were provided. Please specify -i/--input and -o/--output.",
-      );
-      process.exit(1);
     }
 
     // Ensure output directory exists


### PR DESCRIPTION
## Description
This PR fixes a regression bug in the `bmad-method flatten` command that causes it to fail with an error message even when valid arguments were provided.

## The Problem
All variations of the flatten command fail with the error:
Could not auto-detect a project root and no arguments were provided. Please specify -i/--input and -o/--output.

This happens even when arguments ARE provided.

## Root Cause
The else branch at lines 130-134 in `tools/flattener/main.js` incorrectly handles the case when users provide arguments, showing a misleading error message.

## Bug History
This is a regression bug:
- First introduced in commit 0fdbca7 (#417)
- Fixed in commit fab9d5e (v5.0.0-beta.2) (#422)
- Accidentally reintroduced in commit ed53943 (#450)

## The Fix
Remove the incorrect else branch (lines 130-134) that was causing the issue.

## Testing
After this fix, all these commands work correctly:
- `npx bmad-method flatten`
- `npx bmad-method flatten --input /path`
- `npx bmad-method flatten --output file.xml`
- `npx bmad-method flatten --input /path --output file.xml`