### PR TITLE
refactor: remove leading '.' from bmad-core path references ♻️

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -38,7 +38,7 @@ CLAUDE.md
 .gemini
 
 # Project-specific
-.bmad-core
+bmad-core
 .bmad-creator-tools
 test-project-install/*
 sample-project/*

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -555,7 +555,7 @@
 - add docs ([48ef875](https://github.com/bmadcode/BMAD-METHOD/commit/48ef875f5ec5b0f0211baa43bbc04701e54824f4))
 - auto semantic versioning fix ([166ed04](https://github.com/bmadcode/BMAD-METHOD/commit/166ed047671cccab2874fd327efb1ac293ae7276))
 - auto semantic versioning fix again ([11260e4](https://github.com/bmadcode/BMAD-METHOD/commit/11260e43950b6bf78d68c759dc3ac278bc13f8a8))
-- BMAD install creates `.bmad-core/.bmad-core/` directory structure + updates ([#223](https://github.com/bmadcode/BMAD-METHOD/issues/223)) ([28b313c](https://github.com/bmadcode/BMAD-METHOD/commit/28b313c01df41961cebb71fb3bce0fcc7b4b4796))
+- BMAD install creates `bmad-core/bmad-core/` directory structure + updates ([#223](https://github.com/bmadcode/BMAD-METHOD/issues/223)) ([28b313c](https://github.com/bmadcode/BMAD-METHOD/commit/28b313c01df41961cebb71fb3bce0fcc7b4b4796))
 - resolve NPM token configuration ([620b09a](https://github.com/bmadcode/BMAD-METHOD/commit/620b09a556ce8d61ad1a4d8ee7c523d263abd69c))
 - resolve NPM token configuration ([b447a8b](https://github.com/bmadcode/BMAD-METHOD/commit/b447a8bd57625d02692d7e2771241bacd120c631))
 - update dependency resolver to support both yml and yaml code blocks ([ba1e5ce](https://github.com/bmadcode/BMAD-METHOD/commit/ba1e5ceb36f4a0bb204ceee40e92725d3fc57c5f))

--- a/bmad-core/data/bmad-kb.md
+++ b/bmad-core/data/bmad-kb.md
@@ -107,7 +107,7 @@ npx bmad-method install
 
 **Verify Installation**:
 
-- `.bmad-core/` folder created with all agents
+- `bmad-core/` folder created with all agents
 - IDE-specific integration files created
 - All agent commands/rules/modes available
 

--- a/bmad-core/tasks/validate-next-story.md
+++ b/bmad-core/tasks/validate-next-story.md
@@ -10,7 +10,7 @@ To comprehensively validate a story draft before implementation begins, ensuring
 
 ### 0. Load Core Configuration and Inputs
 
-- Load `.bmad-core/core-config.yaml`
+- Load `bmad-core/core-config.yaml`
 - If the file does not exist, HALT and inform the user: "core-config.yaml not found. This file is required for story validation."
 - Extract key configurations: `devStoryLocation`, `prd.*`, `architecture.*`
 - Identify and load the following inputs:

--- a/common/tasks/create-doc.md
+++ b/common/tasks/create-doc.md
@@ -17,7 +17,7 @@ When this task is invoked:
 
 ## Critical: Template Discovery
 
-If a YAML Template has not been provided, list all templates from .bmad-core/templates or ask the user to provide another.
+If a YAML Template has not been provided, list all templates from bmad-core/templates or ask the user to provide another.
 
 ## CRITICAL: Mandatory Elicitation Format
 

--- a/dist/agents/analyst.txt
+++ b/dist/agents/analyst.txt
@@ -8,13 +8,13 @@ You are now operating as a specialized AI agent from the BMad-Method framework. 
 
 2. **Resource Navigation**: This bundle contains all resources you need. Resources are marked with tags like:
 
-- `==================== START: .bmad-core/folder/filename.md ====================`
-- `==================== END: .bmad-core/folder/filename.md ====================`
+- `==================== START: bmad-core/folder/filename.md ====================`
+- `==================== END: bmad-core/folder/filename.md ====================`
 
 When you need to reference a resource mentioned in your instructions:
 
 - Look for the corresponding START/END tags
-- The format is always the full path with dot prefix (e.g., `.bmad-core/personas/analyst.md`, `.bmad-core/tasks/create-story.md`)
+- The format is always the full path with dot prefix (e.g., `bmad-core/personas/analyst.md`, `bmad-core/tasks/create-story.md`)
 - If a section is specified (e.g., `{root}/tasks/create-story.md#section-name`), navigate to that section within the file
 
 **Understanding YAML References**: In the agent configuration, resources are referenced in the dependencies section. For example:
@@ -29,8 +29,8 @@ dependencies:
 
 These references map directly to bundle sections:
 
-- `utils: template-format` → Look for `==================== START: .bmad-core/utils/template-format.md ====================`
-- `tasks: create-story` → Look for `==================== START: .bmad-core/tasks/create-story.md ====================`
+- `utils: template-format` → Look for `==================== START: bmad-core/utils/template-format.md ====================`
+- `tasks: create-story` → Look for `==================== START: bmad-core/tasks/create-story.md ====================`
 
 3. **Execution Context**: You are operating in a web environment. All your capabilities and knowledge are contained within this bundle. Work within these constraints to provide the best possible assistance.
 
@@ -39,7 +39,7 @@ These references map directly to bundle sections:
 ---
 
 
-==================== START: .bmad-core/agents/analyst.md ====================
+==================== START: bmad-core/agents/analyst.md ====================
 # analyst
 
 CRITICAL: Read the full YAML, start activation to alter your state of being, follow startup section instructions, stay in this being until told to exit this mode:
@@ -101,9 +101,9 @@ dependencies:
     - market-research-tmpl.yaml
     - project-brief-tmpl.yaml
 ```
-==================== END: .bmad-core/agents/analyst.md ====================
+==================== END: bmad-core/agents/analyst.md ====================
 
-==================== START: .bmad-core/tasks/advanced-elicitation.md ====================
+==================== START: bmad-core/tasks/advanced-elicitation.md ====================
 <!-- Powered by BMAD™ Core -->
 # Advanced Elicitation Task
 
@@ -222,9 +222,9 @@ Choose a number (0-8) or 9 to proceed:
 - **Stay Relevant**: Tie all elicitation back to the specific content being analyzed
 - **Identify Personas**: For multi-persona methods, clearly identify which viewpoint is speaking
 - **Maintain Flow**: Keep the process moving efficiently
-==================== END: .bmad-core/tasks/advanced-elicitation.md ====================
+==================== END: bmad-core/tasks/advanced-elicitation.md ====================
 
-==================== START: .bmad-core/tasks/create-deep-research-prompt.md ====================
+==================== START: bmad-core/tasks/create-deep-research-prompt.md ====================
 <!-- Powered by BMAD™ Core -->
 # Create Deep Research Prompt Task
 
@@ -504,9 +504,9 @@ CRITICAL: collaborate with the user to develop specific, actionable research que
 - Balance comprehensiveness with focus
 - Document assumptions and limitations clearly
 - Plan for iterative refinement based on initial findings
-==================== END: .bmad-core/tasks/create-deep-research-prompt.md ====================
+==================== END: bmad-core/tasks/create-deep-research-prompt.md ====================
 
-==================== START: .bmad-core/tasks/create-doc.md ====================
+==================== START: bmad-core/tasks/create-doc.md ====================
 <!-- Powered by BMAD™ Core -->
 # Create Document from Template (YAML Driven)
 
@@ -525,7 +525,7 @@ When this task is invoked:
 
 ## Critical: Template Discovery
 
-If a YAML Template has not been provided, list all templates from .bmad-core/templates or ask the user to provide another.
+If a YAML Template has not been provided, list all templates from bmad-core/templates or ask the user to provide another.
 
 ## CRITICAL: Mandatory Elicitation Format
 
@@ -609,9 +609,9 @@ User can type `#yolo` to toggle to YOLO mode (process all sections at once).
 - Select options 2-9 from data/elicitation-methods only
 - Provide detailed rationale explaining decisions
 - End with "Select 1-9 or just type your question/feedback:"
-==================== END: .bmad-core/tasks/create-doc.md ====================
+==================== END: bmad-core/tasks/create-doc.md ====================
 
-==================== START: .bmad-core/tasks/document-project.md ====================
+==================== START: bmad-core/tasks/document-project.md ====================
 <!-- Powered by BMAD™ Core -->
 # Document an Existing Project
 
@@ -956,13 +956,13 @@ Apply the advanced elicitation task after major sections to refine based on user
 - Documents technical debt, workarounds, and constraints honestly
 - For brownfield projects with PRD: Provides clear enhancement impact analysis
 - The goal is PRACTICAL documentation for AI agents doing real work
-==================== END: .bmad-core/tasks/document-project.md ====================
+==================== END: bmad-core/tasks/document-project.md ====================
 
-==================== START: .bmad-core/tasks/facilitate-brainstorming-session.md ====================
+==================== START: bmad-core/tasks/facilitate-brainstorming-session.md ====================
 <!-- Powered by BMAD™ Core -->
 ---
 docOutputLocation: docs/brainstorming-session-results.md
-template: '.bmad-core/templates/brainstorming-output-tmpl.yaml'
+template: 'bmad-core/templates/brainstorming-output-tmpl.yaml'
 ---
 
 # Facilitate Brainstorming Session Task
@@ -1096,9 +1096,9 @@ Generate structured document with these sections:
 - Always ask before switching techniques: "Ready to try a different approach?"
 - Offer options: "Should we explore this idea deeper or generate more alternatives?"
 - Respect their process and timing
-==================== END: .bmad-core/tasks/facilitate-brainstorming-session.md ====================
+==================== END: bmad-core/tasks/facilitate-brainstorming-session.md ====================
 
-==================== START: .bmad-core/templates/brainstorming-output-tmpl.yaml ====================
+==================== START: bmad-core/templates/brainstorming-output-tmpl.yaml ====================
 template:
   id: brainstorming-output-template-v2
   name: Brainstorming Session Results
@@ -1255,9 +1255,9 @@ sections:
       ---
 
       *Session facilitated using the BMAD-METHOD™ brainstorming framework*
-==================== END: .bmad-core/templates/brainstorming-output-tmpl.yaml ====================
+==================== END: bmad-core/templates/brainstorming-output-tmpl.yaml ====================
 
-==================== START: .bmad-core/templates/competitor-analysis-tmpl.yaml ====================
+==================== START: bmad-core/templates/competitor-analysis-tmpl.yaml ====================
 # <!-- Powered by BMAD™ Core -->
 template:
   id: competitor-analysis-template-v2
@@ -1565,9 +1565,9 @@ sections:
           - Weekly: {{weekly_items}}
           - Monthly: {{monthly_items}}
           - Quarterly: {{quarterly_analysis}}
-==================== END: .bmad-core/templates/competitor-analysis-tmpl.yaml ====================
+==================== END: bmad-core/templates/competitor-analysis-tmpl.yaml ====================
 
-==================== START: .bmad-core/templates/market-research-tmpl.yaml ====================
+==================== START: bmad-core/templates/market-research-tmpl.yaml ====================
 # <!-- Powered by BMAD™ Core -->
 template:
   id: market-research-template-v2
@@ -1821,9 +1821,9 @@ sections:
       - id: additional-analysis
         title: C. Additional Analysis
         instruction: Any supplementary analysis not included in main body
-==================== END: .bmad-core/templates/market-research-tmpl.yaml ====================
+==================== END: bmad-core/templates/market-research-tmpl.yaml ====================
 
-==================== START: .bmad-core/templates/project-brief-tmpl.yaml ====================
+==================== START: bmad-core/templates/project-brief-tmpl.yaml ====================
 # <!-- Powered by BMAD™ Core -->
 template:
   id: project-brief-template-v2
@@ -2046,9 +2046,9 @@ sections:
         title: PM Handoff
         content: |
           This Project Brief provides the full context for {{project_name}}. Please start in 'PRD Generation Mode', review the brief thoroughly to work with the user to create the PRD section by section as the template indicates, asking for any necessary clarification or suggesting improvements.
-==================== END: .bmad-core/templates/project-brief-tmpl.yaml ====================
+==================== END: bmad-core/templates/project-brief-tmpl.yaml ====================
 
-==================== START: .bmad-core/data/bmad-kb.md ====================
+==================== START: bmad-core/data/bmad-kb.md ====================
 <!-- Powered by BMAD™ Core -->
 # BMAD™ Knowledge Base
 
@@ -2157,7 +2157,7 @@ npx bmad-method install
 
 **Verify Installation**:
 
-- `.bmad-core/` folder created with all agents
+- `bmad-core/` folder created with all agents
 - IDE-specific integration files created
 - All agent commands/rules/modes available
 
@@ -2856,9 +2856,9 @@ Use the **expansion-creator** pack to build your own:
 - **Documentation**: Check `docs/` folder for project-specific context
 - **Community**: Discord and GitHub resources available for support
 - **Contributing**: See `CONTRIBUTING.md` for full guidelines
-==================== END: .bmad-core/data/bmad-kb.md ====================
+==================== END: bmad-core/data/bmad-kb.md ====================
 
-==================== START: .bmad-core/data/brainstorming-techniques.md ====================
+==================== START: bmad-core/data/brainstorming-techniques.md ====================
 <!-- Powered by BMAD™ Core -->
 # Brainstorming Techniques Data
 
@@ -2896,4 +2896,4 @@ Use the **expansion-creator** pack to build your own:
 18. **Resource Constraints**: "What if you had only $10 and 1 hour?"
 19. **Metaphor Mapping**: Use extended metaphors to explore solutions
 20. **Question Storming**: Generate questions instead of answers first
-==================== END: .bmad-core/data/brainstorming-techniques.md ====================
+==================== END: bmad-core/data/brainstorming-techniques.md ====================

--- a/dist/agents/architect.txt
+++ b/dist/agents/architect.txt
@@ -8,13 +8,13 @@ You are now operating as a specialized AI agent from the BMad-Method framework. 
 
 2. **Resource Navigation**: This bundle contains all resources you need. Resources are marked with tags like:
 
-- `==================== START: .bmad-core/folder/filename.md ====================`
-- `==================== END: .bmad-core/folder/filename.md ====================`
+- `==================== START: bmad-core/folder/filename.md ====================`
+- `==================== END: bmad-core/folder/filename.md ====================`
 
 When you need to reference a resource mentioned in your instructions:
 
 - Look for the corresponding START/END tags
-- The format is always the full path with dot prefix (e.g., `.bmad-core/personas/analyst.md`, `.bmad-core/tasks/create-story.md`)
+- The format is always the full path with dot prefix (e.g., `bmad-core/personas/analyst.md`, `bmad-core/tasks/create-story.md`)
 - If a section is specified (e.g., `{root}/tasks/create-story.md#section-name`), navigate to that section within the file
 
 **Understanding YAML References**: In the agent configuration, resources are referenced in the dependencies section. For example:
@@ -29,8 +29,8 @@ dependencies:
 
 These references map directly to bundle sections:
 
-- `utils: template-format` → Look for `==================== START: .bmad-core/utils/template-format.md ====================`
-- `tasks: create-story` → Look for `==================== START: .bmad-core/tasks/create-story.md ====================`
+- `utils: template-format` → Look for `==================== START: bmad-core/utils/template-format.md ====================`
+- `tasks: create-story` → Look for `==================== START: bmad-core/tasks/create-story.md ====================`
 
 3. **Execution Context**: You are operating in a web environment. All your capabilities and knowledge are contained within this bundle. Work within these constraints to provide the best possible assistance.
 
@@ -39,7 +39,7 @@ These references map directly to bundle sections:
 ---
 
 
-==================== START: .bmad-core/agents/architect.md ====================
+==================== START: bmad-core/agents/architect.md ====================
 # architect
 
 CRITICAL: Read the full YAML, start activation to alter your state of being, follow startup section instructions, stay in this being until told to exit this mode:
@@ -102,9 +102,9 @@ dependencies:
     - front-end-architecture-tmpl.yaml
     - fullstack-architecture-tmpl.yaml
 ```
-==================== END: .bmad-core/agents/architect.md ====================
+==================== END: bmad-core/agents/architect.md ====================
 
-==================== START: .bmad-core/tasks/create-deep-research-prompt.md ====================
+==================== START: bmad-core/tasks/create-deep-research-prompt.md ====================
 <!-- Powered by BMAD™ Core -->
 # Create Deep Research Prompt Task
 
@@ -384,9 +384,9 @@ CRITICAL: collaborate with the user to develop specific, actionable research que
 - Balance comprehensiveness with focus
 - Document assumptions and limitations clearly
 - Plan for iterative refinement based on initial findings
-==================== END: .bmad-core/tasks/create-deep-research-prompt.md ====================
+==================== END: bmad-core/tasks/create-deep-research-prompt.md ====================
 
-==================== START: .bmad-core/tasks/create-doc.md ====================
+==================== START: bmad-core/tasks/create-doc.md ====================
 <!-- Powered by BMAD™ Core -->
 # Create Document from Template (YAML Driven)
 
@@ -405,7 +405,7 @@ When this task is invoked:
 
 ## Critical: Template Discovery
 
-If a YAML Template has not been provided, list all templates from .bmad-core/templates or ask the user to provide another.
+If a YAML Template has not been provided, list all templates from bmad-core/templates or ask the user to provide another.
 
 ## CRITICAL: Mandatory Elicitation Format
 
@@ -489,9 +489,9 @@ User can type `#yolo` to toggle to YOLO mode (process all sections at once).
 - Select options 2-9 from data/elicitation-methods only
 - Provide detailed rationale explaining decisions
 - End with "Select 1-9 or just type your question/feedback:"
-==================== END: .bmad-core/tasks/create-doc.md ====================
+==================== END: bmad-core/tasks/create-doc.md ====================
 
-==================== START: .bmad-core/tasks/document-project.md ====================
+==================== START: bmad-core/tasks/document-project.md ====================
 <!-- Powered by BMAD™ Core -->
 # Document an Existing Project
 
@@ -836,9 +836,9 @@ Apply the advanced elicitation task after major sections to refine based on user
 - Documents technical debt, workarounds, and constraints honestly
 - For brownfield projects with PRD: Provides clear enhancement impact analysis
 - The goal is PRACTICAL documentation for AI agents doing real work
-==================== END: .bmad-core/tasks/document-project.md ====================
+==================== END: bmad-core/tasks/document-project.md ====================
 
-==================== START: .bmad-core/tasks/execute-checklist.md ====================
+==================== START: bmad-core/tasks/execute-checklist.md ====================
 <!-- Powered by BMAD™ Core -->
 # Checklist Validation Task
 
@@ -846,7 +846,7 @@ This task provides instructions for validating documentation against checklists.
 
 ## Available Checklists
 
-If the user asks or does not specify a specific checklist, list the checklists available to the agent persona. If the task is being run not with a specific agent, tell the user to check the .bmad-core/checklists folder to select the appropriate one to run.
+If the user asks or does not specify a specific checklist, list the checklists available to the agent persona. If the task is being run not with a specific agent, tell the user to check the bmad-core/checklists folder to select the appropriate one to run.
 
 ## Instructions
 
@@ -854,7 +854,7 @@ If the user asks or does not specify a specific checklist, list the checklists a
    - If user or the task being run provides a checklist name:
      - Try fuzzy matching (e.g. "architecture checklist" -> "architect-checklist")
      - If multiple matches found, ask user to clarify
-     - Load the appropriate checklist from .bmad-core/checklists/
+     - Load the appropriate checklist from bmad-core/checklists/
    - If no checklist specified:
      - Ask the user which checklist they want to use
      - Present the available options from the files in the checklists folder
@@ -926,9 +926,9 @@ The LLM will:
 - Execute the complete checklist validation
 - Present a final report with pass/fail rates and key findings
 - Offer to provide detailed analysis of any section, especially those with warnings or failures
-==================== END: .bmad-core/tasks/execute-checklist.md ====================
+==================== END: bmad-core/tasks/execute-checklist.md ====================
 
-==================== START: .bmad-core/templates/architecture-tmpl.yaml ====================
+==================== START: bmad-core/templates/architecture-tmpl.yaml ====================
 # <!-- Powered by BMAD™ Core -->
 template:
   id: architecture-template-v2
@@ -1059,7 +1059,7 @@ sections:
     instruction: |
       This is the DEFINITIVE technology selection section. Work with the user to make specific choices:
 
-      1. Review PRD technical assumptions and any preferences from .bmad-core/data/technical-preferences.yaml or an attached technical-preferences
+      1. Review PRD technical assumptions and any preferences from bmad-core/data/technical-preferences.yaml or an attached technical-preferences
       2. For each category, present 2-3 viable options with pros/cons
       3. Make a clear recommendation based on project needs
       4. Get explicit user approval for each selection
@@ -1580,9 +1580,9 @@ sections:
           - Key UI requirements from PRD
           - Any frontend-specific decisions made here
           - Request for detailed frontend architecture
-==================== END: .bmad-core/templates/architecture-tmpl.yaml ====================
+==================== END: bmad-core/templates/architecture-tmpl.yaml ====================
 
-==================== START: .bmad-core/templates/brownfield-architecture-tmpl.yaml ====================
+==================== START: bmad-core/templates/brownfield-architecture-tmpl.yaml ====================
 # <!-- Powered by BMAD™ Core -->
 template:
   id: brownfield-architecture-template-v2
@@ -2060,9 +2060,9 @@ sections:
           - Key technical decisions based on real project constraints
           - Existing system compatibility requirements with specific verification steps
           - Clear sequencing of implementation to minimize risk to existing functionality
-==================== END: .bmad-core/templates/brownfield-architecture-tmpl.yaml ====================
+==================== END: bmad-core/templates/brownfield-architecture-tmpl.yaml ====================
 
-==================== START: .bmad-core/templates/front-end-architecture-tmpl.yaml ====================
+==================== START: bmad-core/templates/front-end-architecture-tmpl.yaml ====================
 # <!-- Powered by BMAD™ Core -->
 template:
   id: frontend-architecture-template-v2
@@ -2282,9 +2282,9 @@ sections:
           - Key import patterns
           - File naming conventions
           - Project-specific patterns and utilities
-==================== END: .bmad-core/templates/front-end-architecture-tmpl.yaml ====================
+==================== END: bmad-core/templates/front-end-architecture-tmpl.yaml ====================
 
-==================== START: .bmad-core/templates/fullstack-architecture-tmpl.yaml ====================
+==================== START: bmad-core/templates/fullstack-architecture-tmpl.yaml ====================
 # <!-- Powered by BMAD™ Core -->
 template:
   id: fullstack-architecture-template-v2
@@ -3109,9 +3109,9 @@ sections:
   - id: checklist-results
     title: Checklist Results Report
     instruction: Before running the checklist, offer to output the full architecture document. Once user confirms, execute the architect-checklist and populate results here.
-==================== END: .bmad-core/templates/fullstack-architecture-tmpl.yaml ====================
+==================== END: bmad-core/templates/fullstack-architecture-tmpl.yaml ====================
 
-==================== START: .bmad-core/checklists/architect-checklist.md ====================
+==================== START: bmad-core/checklists/architect-checklist.md ====================
 <!-- Powered by BMAD™ Core -->
 # Architect Solution Validation Checklist
 
@@ -3551,11 +3551,11 @@ Now that you've completed the checklist, generate a comprehensive validation rep
    - Component design clarity
 
 After presenting the report, ask the user if they would like detailed analysis of any specific section, especially those with warnings or failures.]]
-==================== END: .bmad-core/checklists/architect-checklist.md ====================
+==================== END: bmad-core/checklists/architect-checklist.md ====================
 
-==================== START: .bmad-core/data/technical-preferences.md ====================
+==================== START: bmad-core/data/technical-preferences.md ====================
 <!-- Powered by BMAD™ Core -->
 # User-Defined Preferred Patterns and Preferences
 
 None Listed
-==================== END: .bmad-core/data/technical-preferences.md ====================
+==================== END: bmad-core/data/technical-preferences.md ====================

--- a/dist/agents/bmad-master.txt
+++ b/dist/agents/bmad-master.txt
@@ -8,13 +8,13 @@ You are now operating as a specialized AI agent from the BMad-Method framework. 
 
 2. **Resource Navigation**: This bundle contains all resources you need. Resources are marked with tags like:
 
-- `==================== START: .bmad-core/folder/filename.md ====================`
-- `==================== END: .bmad-core/folder/filename.md ====================`
+- `==================== START: bmad-core/folder/filename.md ====================`
+- `==================== END: bmad-core/folder/filename.md ====================`
 
 When you need to reference a resource mentioned in your instructions:
 
 - Look for the corresponding START/END tags
-- The format is always the full path with dot prefix (e.g., `.bmad-core/personas/analyst.md`, `.bmad-core/tasks/create-story.md`)
+- The format is always the full path with dot prefix (e.g., `bmad-core/personas/analyst.md`, `bmad-core/tasks/create-story.md`)
 - If a section is specified (e.g., `{root}/tasks/create-story.md#section-name`), navigate to that section within the file
 
 **Understanding YAML References**: In the agent configuration, resources are referenced in the dependencies section. For example:
@@ -29,8 +29,8 @@ dependencies:
 
 These references map directly to bundle sections:
 
-- `utils: template-format` → Look for `==================== START: .bmad-core/utils/template-format.md ====================`
-- `tasks: create-story` → Look for `==================== START: .bmad-core/tasks/create-story.md ====================`
+- `utils: template-format` → Look for `==================== START: bmad-core/utils/template-format.md ====================`
+- `tasks: create-story` → Look for `==================== START: bmad-core/tasks/create-story.md ====================`
 
 3. **Execution Context**: You are operating in a web environment. All your capabilities and knowledge are contained within this bundle. Work within these constraints to provide the best possible assistance.
 
@@ -39,7 +39,7 @@ These references map directly to bundle sections:
 ---
 
 
-==================== START: .bmad-core/agents/bmad-master.md ====================
+==================== START: bmad-core/agents/bmad-master.md ====================
 # bmad-master
 
 CRITICAL: Read the full YAML, start activation to alter your state of being, follow startup section instructions, stay in this being until told to exit this mode:
@@ -72,7 +72,7 @@ commands:
   - doc-out: Output full document to current destination file
   - document-project: execute the task document-project.md
   - execute-checklist {checklist}: Run task execute-checklist (no checklist = ONLY show available checklists listed under dependencies/checklist below)
-  - kb: Toggle KB mode off (default) or on, when on will load and reference the .bmad-core/data/bmad-kb.md and converse with the user answering his questions with this informational resource
+  - kb: Toggle KB mode off (default) or on, when on will load and reference the bmad-core/data/bmad-kb.md and converse with the user answering his questions with this informational resource
   - shard-doc {document} {destination}: run the task shard-doc against the optionally provided document to the specified destination
   - task {task}: Execute task, if not found or none specified, ONLY list available dependencies/tasks listed below
   - yolo: Toggle Yolo Mode
@@ -124,9 +124,9 @@ dependencies:
     - greenfield-service.md
     - greenfield-ui.md
 ```
-==================== END: .bmad-core/agents/bmad-master.md ====================
+==================== END: bmad-core/agents/bmad-master.md ====================
 
-==================== START: .bmad-core/tasks/advanced-elicitation.md ====================
+==================== START: bmad-core/tasks/advanced-elicitation.md ====================
 <!-- Powered by BMAD™ Core -->
 # Advanced Elicitation Task
 
@@ -245,9 +245,9 @@ Choose a number (0-8) or 9 to proceed:
 - **Stay Relevant**: Tie all elicitation back to the specific content being analyzed
 - **Identify Personas**: For multi-persona methods, clearly identify which viewpoint is speaking
 - **Maintain Flow**: Keep the process moving efficiently
-==================== END: .bmad-core/tasks/advanced-elicitation.md ====================
+==================== END: bmad-core/tasks/advanced-elicitation.md ====================
 
-==================== START: .bmad-core/tasks/brownfield-create-epic.md ====================
+==================== START: bmad-core/tasks/brownfield-create-epic.md ====================
 <!-- Powered by BMAD™ Core -->
 # Create Brownfield Epic Task
 
@@ -409,9 +409,9 @@ The epic creation is successful when:
 - If the scope grows beyond 3 stories, consider the full brownfield PRD process
 - Always prioritize existing system integrity over new functionality
 - When in doubt about scope or complexity, escalate to full brownfield planning
-==================== END: .bmad-core/tasks/brownfield-create-epic.md ====================
+==================== END: bmad-core/tasks/brownfield-create-epic.md ====================
 
-==================== START: .bmad-core/tasks/brownfield-create-story.md ====================
+==================== START: bmad-core/tasks/brownfield-create-story.md ====================
 <!-- Powered by BMAD™ Core -->
 # Create Brownfield Story Task
 
@@ -560,15 +560,15 @@ The story creation is successful when:
 - Always prioritize existing system integrity
 - When in doubt about integration complexity, use brownfield-create-epic instead
 - Stories should take no more than 4 hours of focused development work
-==================== END: .bmad-core/tasks/brownfield-create-story.md ====================
+==================== END: bmad-core/tasks/brownfield-create-story.md ====================
 
-==================== START: .bmad-core/tasks/correct-course.md ====================
+==================== START: bmad-core/tasks/correct-course.md ====================
 <!-- Powered by BMAD™ Core -->
 # Correct Course Task
 
 ## Purpose
 
-- Guide a structured response to a change trigger using the `.bmad-core/checklists/change-checklist`.
+- Guide a structured response to a change trigger using the `bmad-core/checklists/change-checklist`.
 - Analyze the impacts of the change on epics, project artifacts, and the MVP, guided by the checklist's structure.
 - Explore potential solutions (e.g., adjust scope, rollback elements, re-scope features) as prompted by the checklist.
 - Draft specific, actionable proposed updates to any affected project artifacts (e.g., epics, user stories, PRD sections, architecture document sections) based on the analysis.
@@ -582,7 +582,7 @@ The story creation is successful when:
 - **Acknowledge Task & Inputs:**
   - Confirm with the user that the "Correct Course Task" (Change Navigation & Integration) is being initiated.
   - Verify the change trigger and ensure you have the user's initial explanation of the issue and its perceived impact.
-  - Confirm access to all relevant project artifacts (e.g., PRD, Epics/Stories, Architecture Documents, UI/UX Specifications) and, critically, the `.bmad-core/checklists/change-checklist`.
+  - Confirm access to all relevant project artifacts (e.g., PRD, Epics/Stories, Architecture Documents, UI/UX Specifications) and, critically, the `bmad-core/checklists/change-checklist`.
 - **Establish Interaction Mode:**
   - Ask the user their preferred interaction mode for this task:
     - **"Incrementally (Default & Recommended):** Shall we work through the change-checklist section by section, discussing findings and collaboratively drafting proposed changes for each relevant part before moving to the next? This allows for detailed, step-by-step refinement."
@@ -634,9 +634,9 @@ The story creation is successful when:
   - A summary of the change-checklist analysis (issue, impact, rationale for the chosen path).
   - Specific, clearly drafted proposed edits for all affected project artifacts.
 - **Implicit:** An annotated change-checklist (or the record of its completion) reflecting the discussions, findings, and decisions made during the process.
-==================== END: .bmad-core/tasks/correct-course.md ====================
+==================== END: bmad-core/tasks/correct-course.md ====================
 
-==================== START: .bmad-core/tasks/create-deep-research-prompt.md ====================
+==================== START: bmad-core/tasks/create-deep-research-prompt.md ====================
 <!-- Powered by BMAD™ Core -->
 # Create Deep Research Prompt Task
 
@@ -916,9 +916,9 @@ CRITICAL: collaborate with the user to develop specific, actionable research que
 - Balance comprehensiveness with focus
 - Document assumptions and limitations clearly
 - Plan for iterative refinement based on initial findings
-==================== END: .bmad-core/tasks/create-deep-research-prompt.md ====================
+==================== END: bmad-core/tasks/create-deep-research-prompt.md ====================
 
-==================== START: .bmad-core/tasks/create-doc.md ====================
+==================== START: bmad-core/tasks/create-doc.md ====================
 <!-- Powered by BMAD™ Core -->
 # Create Document from Template (YAML Driven)
 
@@ -937,7 +937,7 @@ When this task is invoked:
 
 ## Critical: Template Discovery
 
-If a YAML Template has not been provided, list all templates from .bmad-core/templates or ask the user to provide another.
+If a YAML Template has not been provided, list all templates from bmad-core/templates or ask the user to provide another.
 
 ## CRITICAL: Mandatory Elicitation Format
 
@@ -1021,9 +1021,9 @@ User can type `#yolo` to toggle to YOLO mode (process all sections at once).
 - Select options 2-9 from data/elicitation-methods only
 - Provide detailed rationale explaining decisions
 - End with "Select 1-9 or just type your question/feedback:"
-==================== END: .bmad-core/tasks/create-doc.md ====================
+==================== END: bmad-core/tasks/create-doc.md ====================
 
-==================== START: .bmad-core/tasks/create-next-story.md ====================
+==================== START: bmad-core/tasks/create-next-story.md ====================
 <!-- Powered by BMAD™ Core -->
 # Create Next Story Task
 
@@ -1035,7 +1035,7 @@ To identify the next logical story based on project progress and epic definition
 
 ### 0. Load Core Configuration and Check Workflow
 
-- Load `.bmad-core/core-config.yaml` from the project root
+- Load `bmad-core/core-config.yaml` from the project root
 - If the file does not exist, HALT and inform the user: "core-config.yaml not found. This file is required for story creation. You can either: 1) Copy it from GITHUB bmad-core/core-config.yaml and configure it for your project OR 2) Run the BMad installer against your project to upgrade and add the file automatically. Please add and configure core-config.yaml before proceeding."
 - Extract key configurations: `devStoryLocation`, `prd.*`, `architecture.*`, `workflow.*`
 
@@ -1129,17 +1129,17 @@ ALWAYS cite source documents: `[Source: architecture/{filename}.md#{section}]`
 - Verify all source references are included for technical details
 - Ensure tasks align with both epic requirements and architecture constraints
 - Update status to "Draft" and save the story file
-- Execute `.bmad-core/tasks/execute-checklist` `.bmad-core/checklists/story-draft-checklist`
+- Execute `bmad-core/tasks/execute-checklist` `bmad-core/checklists/story-draft-checklist`
 - Provide summary to user including:
   - Story created: `{devStoryLocation}/{epicNum}.{storyNum}.story.md`
   - Status: Draft
   - Key technical components included from architecture docs
   - Any deviations or conflicts noted between epic and architecture
   - Checklist Results
-  - Next steps: For Complex stories, suggest the user carefully review the story draft and also optionally have the PO run the task `.bmad-core/tasks/validate-next-story`
-==================== END: .bmad-core/tasks/create-next-story.md ====================
+  - Next steps: For Complex stories, suggest the user carefully review the story draft and also optionally have the PO run the task `bmad-core/tasks/validate-next-story`
+==================== END: bmad-core/tasks/create-next-story.md ====================
 
-==================== START: .bmad-core/tasks/document-project.md ====================
+==================== START: bmad-core/tasks/document-project.md ====================
 <!-- Powered by BMAD™ Core -->
 # Document an Existing Project
 
@@ -1484,9 +1484,9 @@ Apply the advanced elicitation task after major sections to refine based on user
 - Documents technical debt, workarounds, and constraints honestly
 - For brownfield projects with PRD: Provides clear enhancement impact analysis
 - The goal is PRACTICAL documentation for AI agents doing real work
-==================== END: .bmad-core/tasks/document-project.md ====================
+==================== END: bmad-core/tasks/document-project.md ====================
 
-==================== START: .bmad-core/tasks/execute-checklist.md ====================
+==================== START: bmad-core/tasks/execute-checklist.md ====================
 <!-- Powered by BMAD™ Core -->
 # Checklist Validation Task
 
@@ -1494,7 +1494,7 @@ This task provides instructions for validating documentation against checklists.
 
 ## Available Checklists
 
-If the user asks or does not specify a specific checklist, list the checklists available to the agent persona. If the task is being run not with a specific agent, tell the user to check the .bmad-core/checklists folder to select the appropriate one to run.
+If the user asks or does not specify a specific checklist, list the checklists available to the agent persona. If the task is being run not with a specific agent, tell the user to check the bmad-core/checklists folder to select the appropriate one to run.
 
 ## Instructions
 
@@ -1502,7 +1502,7 @@ If the user asks or does not specify a specific checklist, list the checklists a
    - If user or the task being run provides a checklist name:
      - Try fuzzy matching (e.g. "architecture checklist" -> "architect-checklist")
      - If multiple matches found, ask user to clarify
-     - Load the appropriate checklist from .bmad-core/checklists/
+     - Load the appropriate checklist from bmad-core/checklists/
    - If no checklist specified:
      - Ask the user which checklist they want to use
      - Present the available options from the files in the checklists folder
@@ -1574,13 +1574,13 @@ The LLM will:
 - Execute the complete checklist validation
 - Present a final report with pass/fail rates and key findings
 - Offer to provide detailed analysis of any section, especially those with warnings or failures
-==================== END: .bmad-core/tasks/execute-checklist.md ====================
+==================== END: bmad-core/tasks/execute-checklist.md ====================
 
-==================== START: .bmad-core/tasks/facilitate-brainstorming-session.md ====================
+==================== START: bmad-core/tasks/facilitate-brainstorming-session.md ====================
 <!-- Powered by BMAD™ Core -->
 ---
 docOutputLocation: docs/brainstorming-session-results.md
-template: '.bmad-core/templates/brainstorming-output-tmpl.yaml'
+template: 'bmad-core/templates/brainstorming-output-tmpl.yaml'
 ---
 
 # Facilitate Brainstorming Session Task
@@ -1714,9 +1714,9 @@ Generate structured document with these sections:
 - Always ask before switching techniques: "Ready to try a different approach?"
 - Offer options: "Should we explore this idea deeper or generate more alternatives?"
 - Respect their process and timing
-==================== END: .bmad-core/tasks/facilitate-brainstorming-session.md ====================
+==================== END: bmad-core/tasks/facilitate-brainstorming-session.md ====================
 
-==================== START: .bmad-core/tasks/generate-ai-frontend-prompt.md ====================
+==================== START: bmad-core/tasks/generate-ai-frontend-prompt.md ====================
 <!-- Powered by BMAD™ Core -->
 # Create AI Frontend Prompt Task
 
@@ -1769,9 +1769,9 @@ You will now synthesize the inputs and the above principles into a final, compre
    - Output the complete, generated prompt in a clear, copy-pasteable format (e.g., a large code block).
    - Explain the structure of the prompt and why certain information was included, referencing the principles above.
    - <important_note>Conclude by reminding the user that all AI-generated code will require careful human review, testing, and refinement to be considered production-ready.</important_note>
-==================== END: .bmad-core/tasks/generate-ai-frontend-prompt.md ====================
+==================== END: bmad-core/tasks/generate-ai-frontend-prompt.md ====================
 
-==================== START: .bmad-core/tasks/index-docs.md ====================
+==================== START: bmad-core/tasks/index-docs.md ====================
 <!-- Powered by BMAD™ Core -->
 # Index Documentation Task
 
@@ -1946,9 +1946,9 @@ Please provide:
 5. Whether to include hidden files/folders (starting with `.`)
 
 Would you like to proceed with documentation indexing? Please provide the required input above.
-==================== END: .bmad-core/tasks/index-docs.md ====================
+==================== END: bmad-core/tasks/index-docs.md ====================
 
-==================== START: .bmad-core/tasks/shard-doc.md ====================
+==================== START: bmad-core/tasks/shard-doc.md ====================
 <!-- Powered by BMAD™ Core -->
 # Document Sharding Task
 
@@ -1960,20 +1960,20 @@ Would you like to proceed with documentation indexing? Please provide the requir
 
 ## Primary Method: Automatic with markdown-tree
 
-[[LLM: First, check if markdownExploder is set to true in .bmad-core/core-config.yaml. If it is, attempt to run the command: `md-tree explode {input file} {output path}`.
+[[LLM: First, check if markdownExploder is set to true in bmad-core/core-config.yaml. If it is, attempt to run the command: `md-tree explode {input file} {output path}`.
 
 If the command succeeds, inform the user that the document has been sharded successfully and STOP - do not proceed further.
 
 If the command fails (especially with an error indicating the command is not found or not available), inform the user: "The markdownExploder setting is enabled but the md-tree command is not available. Please either:
 
 1. Install @kayvan/markdown-tree-parser globally with: `npm install -g @kayvan/markdown-tree-parser`
-2. Or set markdownExploder to false in .bmad-core/core-config.yaml
+2. Or set markdownExploder to false in bmad-core/core-config.yaml
 
 **IMPORTANT: STOP HERE - do not proceed with manual sharding until one of the above actions is taken.**"
 
 If markdownExploder is set to false, inform the user: "The markdownExploder setting is currently false. For better performance and reliability, you should:
 
-1. Set markdownExploder to true in .bmad-core/core-config.yaml
+1. Set markdownExploder to true in bmad-core/core-config.yaml
 2. Install @kayvan/markdown-tree-parser globally with: `npm install -g @kayvan/markdown-tree-parser`
 
 I will now proceed with the manual sharding process."
@@ -2135,9 +2135,9 @@ Document sharded successfully:
 - Preserve ALL formatting, including whitespace where significant
 - Handle edge cases like sections with code blocks containing ## symbols
 - Ensure the sharding is reversible (could reconstruct the original from shards)
-==================== END: .bmad-core/tasks/shard-doc.md ====================
+==================== END: bmad-core/tasks/shard-doc.md ====================
 
-==================== START: .bmad-core/templates/architecture-tmpl.yaml ====================
+==================== START: bmad-core/templates/architecture-tmpl.yaml ====================
 # <!-- Powered by BMAD™ Core -->
 template:
   id: architecture-template-v2
@@ -2268,7 +2268,7 @@ sections:
     instruction: |
       This is the DEFINITIVE technology selection section. Work with the user to make specific choices:
 
-      1. Review PRD technical assumptions and any preferences from .bmad-core/data/technical-preferences.yaml or an attached technical-preferences
+      1. Review PRD technical assumptions and any preferences from bmad-core/data/technical-preferences.yaml or an attached technical-preferences
       2. For each category, present 2-3 viable options with pros/cons
       3. Make a clear recommendation based on project needs
       4. Get explicit user approval for each selection
@@ -2789,9 +2789,9 @@ sections:
           - Key UI requirements from PRD
           - Any frontend-specific decisions made here
           - Request for detailed frontend architecture
-==================== END: .bmad-core/templates/architecture-tmpl.yaml ====================
+==================== END: bmad-core/templates/architecture-tmpl.yaml ====================
 
-==================== START: .bmad-core/templates/brownfield-architecture-tmpl.yaml ====================
+==================== START: bmad-core/templates/brownfield-architecture-tmpl.yaml ====================
 # <!-- Powered by BMAD™ Core -->
 template:
   id: brownfield-architecture-template-v2
@@ -3269,9 +3269,9 @@ sections:
           - Key technical decisions based on real project constraints
           - Existing system compatibility requirements with specific verification steps
           - Clear sequencing of implementation to minimize risk to existing functionality
-==================== END: .bmad-core/templates/brownfield-architecture-tmpl.yaml ====================
+==================== END: bmad-core/templates/brownfield-architecture-tmpl.yaml ====================
 
-==================== START: .bmad-core/templates/brownfield-prd-tmpl.yaml ====================
+==================== START: bmad-core/templates/brownfield-prd-tmpl.yaml ====================
 # <!-- Powered by BMAD™ Core -->
 template:
   id: brownfield-prd-template-v2
@@ -3553,9 +3553,9 @@ sections:
               - template: "IV1: {{existing_functionality_verification}}"
               - template: "IV2: {{integration_point_verification}}"
               - template: "IV3: {{performance_impact_verification}}"
-==================== END: .bmad-core/templates/brownfield-prd-tmpl.yaml ====================
+==================== END: bmad-core/templates/brownfield-prd-tmpl.yaml ====================
 
-==================== START: .bmad-core/templates/competitor-analysis-tmpl.yaml ====================
+==================== START: bmad-core/templates/competitor-analysis-tmpl.yaml ====================
 # <!-- Powered by BMAD™ Core -->
 template:
   id: competitor-analysis-template-v2
@@ -3863,9 +3863,9 @@ sections:
           - Weekly: {{weekly_items}}
           - Monthly: {{monthly_items}}
           - Quarterly: {{quarterly_analysis}}
-==================== END: .bmad-core/templates/competitor-analysis-tmpl.yaml ====================
+==================== END: bmad-core/templates/competitor-analysis-tmpl.yaml ====================
 
-==================== START: .bmad-core/templates/front-end-architecture-tmpl.yaml ====================
+==================== START: bmad-core/templates/front-end-architecture-tmpl.yaml ====================
 # <!-- Powered by BMAD™ Core -->
 template:
   id: frontend-architecture-template-v2
@@ -4085,9 +4085,9 @@ sections:
           - Key import patterns
           - File naming conventions
           - Project-specific patterns and utilities
-==================== END: .bmad-core/templates/front-end-architecture-tmpl.yaml ====================
+==================== END: bmad-core/templates/front-end-architecture-tmpl.yaml ====================
 
-==================== START: .bmad-core/templates/front-end-spec-tmpl.yaml ====================
+==================== START: bmad-core/templates/front-end-spec-tmpl.yaml ====================
 # <!-- Powered by BMAD™ Core -->
 template:
   id: frontend-spec-template-v2
@@ -4438,9 +4438,9 @@ sections:
   - id: checklist-results
     title: Checklist Results
     instruction: If a UI/UX checklist exists, run it against this document and report results here.
-==================== END: .bmad-core/templates/front-end-spec-tmpl.yaml ====================
+==================== END: bmad-core/templates/front-end-spec-tmpl.yaml ====================
 
-==================== START: .bmad-core/templates/fullstack-architecture-tmpl.yaml ====================
+==================== START: bmad-core/templates/fullstack-architecture-tmpl.yaml ====================
 # <!-- Powered by BMAD™ Core -->
 template:
   id: fullstack-architecture-template-v2
@@ -5265,9 +5265,9 @@ sections:
   - id: checklist-results
     title: Checklist Results Report
     instruction: Before running the checklist, offer to output the full architecture document. Once user confirms, execute the architect-checklist and populate results here.
-==================== END: .bmad-core/templates/fullstack-architecture-tmpl.yaml ====================
+==================== END: bmad-core/templates/fullstack-architecture-tmpl.yaml ====================
 
-==================== START: .bmad-core/templates/market-research-tmpl.yaml ====================
+==================== START: bmad-core/templates/market-research-tmpl.yaml ====================
 # <!-- Powered by BMAD™ Core -->
 template:
   id: market-research-template-v2
@@ -5521,9 +5521,9 @@ sections:
       - id: additional-analysis
         title: C. Additional Analysis
         instruction: Any supplementary analysis not included in main body
-==================== END: .bmad-core/templates/market-research-tmpl.yaml ====================
+==================== END: bmad-core/templates/market-research-tmpl.yaml ====================
 
-==================== START: .bmad-core/templates/prd-tmpl.yaml ====================
+==================== START: bmad-core/templates/prd-tmpl.yaml ====================
 # <!-- Powered by BMAD™ Core -->
 template:
   id: prd-template-v2
@@ -5626,7 +5626,7 @@ sections:
     instruction: |
       Gather technical decisions that will guide the Architect. Steps:
 
-      1. Check if .bmad-core/data/technical-preferences.yaml or an attached technical-preferences file exists - use it to pre-populate choices
+      1. Check if bmad-core/data/technical-preferences.yaml or an attached technical-preferences file exists - use it to pre-populate choices
       2. Ask user about: languages, frameworks, starter templates, libraries, APIs, deployment targets
       3. For unknowns, offer guidance based on project goals and MVP scope
       4. Document ALL technical choices with rationale (why this choice fits the project)
@@ -5727,9 +5727,9 @@ sections:
       - id: architect-prompt
         title: Architect Prompt
         instruction: This section will contain the prompt for the Architect, keep it short and to the point to initiate create architecture mode using this document as input.
-==================== END: .bmad-core/templates/prd-tmpl.yaml ====================
+==================== END: bmad-core/templates/prd-tmpl.yaml ====================
 
-==================== START: .bmad-core/templates/project-brief-tmpl.yaml ====================
+==================== START: bmad-core/templates/project-brief-tmpl.yaml ====================
 # <!-- Powered by BMAD™ Core -->
 template:
   id: project-brief-template-v2
@@ -5952,9 +5952,9 @@ sections:
         title: PM Handoff
         content: |
           This Project Brief provides the full context for {{project_name}}. Please start in 'PRD Generation Mode', review the brief thoroughly to work with the user to create the PRD section by section as the template indicates, asking for any necessary clarification or suggesting improvements.
-==================== END: .bmad-core/templates/project-brief-tmpl.yaml ====================
+==================== END: bmad-core/templates/project-brief-tmpl.yaml ====================
 
-==================== START: .bmad-core/templates/story-tmpl.yaml ====================
+==================== START: bmad-core/templates/story-tmpl.yaml ====================
 # <!-- Powered by BMAD™ Core -->
 template:
   id: story-template-v2
@@ -6093,9 +6093,9 @@ sections:
     instruction: Results from QA Agent QA review of the completed story implementation
     owner: qa-agent
     editors: [qa-agent]
-==================== END: .bmad-core/templates/story-tmpl.yaml ====================
+==================== END: bmad-core/templates/story-tmpl.yaml ====================
 
-==================== START: .bmad-core/checklists/architect-checklist.md ====================
+==================== START: bmad-core/checklists/architect-checklist.md ====================
 <!-- Powered by BMAD™ Core -->
 # Architect Solution Validation Checklist
 
@@ -6535,9 +6535,9 @@ Now that you've completed the checklist, generate a comprehensive validation rep
    - Component design clarity
 
 After presenting the report, ask the user if they would like detailed analysis of any specific section, especially those with warnings or failures.]]
-==================== END: .bmad-core/checklists/architect-checklist.md ====================
+==================== END: bmad-core/checklists/architect-checklist.md ====================
 
-==================== START: .bmad-core/checklists/change-checklist.md ====================
+==================== START: bmad-core/checklists/change-checklist.md ====================
 <!-- Powered by BMAD™ Core -->
 # Change Navigation Checklist
 
@@ -6721,9 +6721,9 @@ Keep it action-oriented and forward-looking.]]
 - [ ] **Confirm Next Steps:** Reiterate the handoff plan and the next actions to be taken by specific agents.
 
 ---
-==================== END: .bmad-core/checklists/change-checklist.md ====================
+==================== END: bmad-core/checklists/change-checklist.md ====================
 
-==================== START: .bmad-core/checklists/pm-checklist.md ====================
+==================== START: bmad-core/checklists/pm-checklist.md ====================
 <!-- Powered by BMAD™ Core -->
 # Product Manager (PM) Requirements Checklist
 
@@ -7095,9 +7095,9 @@ After presenting the report, ask if the user wants:
 
 - **READY FOR ARCHITECT**: The PRD and epics are comprehensive, properly structured, and ready for architectural design.
 - **NEEDS REFINEMENT**: The requirements documentation requires additional work to address the identified deficiencies.
-==================== END: .bmad-core/checklists/pm-checklist.md ====================
+==================== END: bmad-core/checklists/pm-checklist.md ====================
 
-==================== START: .bmad-core/checklists/po-master-checklist.md ====================
+==================== START: bmad-core/checklists/po-master-checklist.md ====================
 <!-- Powered by BMAD™ Core -->
 # Product Owner (PO) Master Validation Checklist
 
@@ -7531,9 +7531,9 @@ After presenting the report, ask if the user wants:
 - **APPROVED**: The plan is comprehensive, properly sequenced, and ready for implementation.
 - **CONDITIONAL**: The plan requires specific adjustments before proceeding.
 - **REJECTED**: The plan requires significant revision to address critical deficiencies.
-==================== END: .bmad-core/checklists/po-master-checklist.md ====================
+==================== END: bmad-core/checklists/po-master-checklist.md ====================
 
-==================== START: .bmad-core/checklists/story-dod-checklist.md ====================
+==================== START: bmad-core/checklists/story-dod-checklist.md ====================
 <!-- Powered by BMAD™ Core -->
 # Story Definition of Done (DoD) Checklist
 
@@ -7629,9 +7629,9 @@ After completing the checklist:
 Be honest - it's better to flag issues now than have them discovered later.]]
 
 - [ ] I, the Developer Agent, confirm that all applicable items above have been addressed.
-==================== END: .bmad-core/checklists/story-dod-checklist.md ====================
+==================== END: bmad-core/checklists/story-dod-checklist.md ====================
 
-==================== START: .bmad-core/checklists/story-draft-checklist.md ====================
+==================== START: bmad-core/checklists/story-draft-checklist.md ====================
 <!-- Powered by BMAD™ Core -->
 # Story Draft Checklist
 
@@ -7786,9 +7786,9 @@ Be pragmatic - perfect documentation doesn't exist, but it must be enough to pro
 - READY: The story provides sufficient context for implementation
 - NEEDS REVISION: The story requires updates (see issues)
 - BLOCKED: External information required (specify what information)
-==================== END: .bmad-core/checklists/story-draft-checklist.md ====================
+==================== END: bmad-core/checklists/story-draft-checklist.md ====================
 
-==================== START: .bmad-core/data/bmad-kb.md ====================
+==================== START: bmad-core/data/bmad-kb.md ====================
 <!-- Powered by BMAD™ Core -->
 # BMAD™ Knowledge Base
 
@@ -7897,7 +7897,7 @@ npx bmad-method install
 
 **Verify Installation**:
 
-- `.bmad-core/` folder created with all agents
+- `bmad-core/` folder created with all agents
 - IDE-specific integration files created
 - All agent commands/rules/modes available
 
@@ -8596,9 +8596,9 @@ Use the **expansion-creator** pack to build your own:
 - **Documentation**: Check `docs/` folder for project-specific context
 - **Community**: Discord and GitHub resources available for support
 - **Contributing**: See `CONTRIBUTING.md` for full guidelines
-==================== END: .bmad-core/data/bmad-kb.md ====================
+==================== END: bmad-core/data/bmad-kb.md ====================
 
-==================== START: .bmad-core/data/brainstorming-techniques.md ====================
+==================== START: bmad-core/data/brainstorming-techniques.md ====================
 <!-- Powered by BMAD™ Core -->
 # Brainstorming Techniques Data
 
@@ -8636,9 +8636,9 @@ Use the **expansion-creator** pack to build your own:
 18. **Resource Constraints**: "What if you had only $10 and 1 hour?"
 19. **Metaphor Mapping**: Use extended metaphors to explore solutions
 20. **Question Storming**: Generate questions instead of answers first
-==================== END: .bmad-core/data/brainstorming-techniques.md ====================
+==================== END: bmad-core/data/brainstorming-techniques.md ====================
 
-==================== START: .bmad-core/data/elicitation-methods.md ====================
+==================== START: bmad-core/data/elicitation-methods.md ====================
 <!-- Powered by BMAD™ Core -->
 # Elicitation Methods Data
 
@@ -8794,11 +8794,11 @@ Use the **expansion-creator** pack to build your own:
 - Acknowledge choice to finalize current work
 - Accept output as-is or move to next step
 - Prepare to continue without additional elicitation
-==================== END: .bmad-core/data/elicitation-methods.md ====================
+==================== END: bmad-core/data/elicitation-methods.md ====================
 
-==================== START: .bmad-core/data/technical-preferences.md ====================
+==================== START: bmad-core/data/technical-preferences.md ====================
 <!-- Powered by BMAD™ Core -->
 # User-Defined Preferred Patterns and Preferences
 
 None Listed
-==================== END: .bmad-core/data/technical-preferences.md ====================
+==================== END: bmad-core/data/technical-preferences.md ====================

--- a/dist/agents/bmad-orchestrator.txt
+++ b/dist/agents/bmad-orchestrator.txt
@@ -8,13 +8,13 @@ You are now operating as a specialized AI agent from the BMad-Method framework. 
 
 2. **Resource Navigation**: This bundle contains all resources you need. Resources are marked with tags like:
 
-- `==================== START: .bmad-core/folder/filename.md ====================`
-- `==================== END: .bmad-core/folder/filename.md ====================`
+- `==================== START: bmad-core/folder/filename.md ====================`
+- `==================== END: bmad-core/folder/filename.md ====================`
 
 When you need to reference a resource mentioned in your instructions:
 
 - Look for the corresponding START/END tags
-- The format is always the full path with dot prefix (e.g., `.bmad-core/personas/analyst.md`, `.bmad-core/tasks/create-story.md`)
+- The format is always the full path with dot prefix (e.g., `bmad-core/personas/analyst.md`, `bmad-core/tasks/create-story.md`)
 - If a section is specified (e.g., `{root}/tasks/create-story.md#section-name`), navigate to that section within the file
 
 **Understanding YAML References**: In the agent configuration, resources are referenced in the dependencies section. For example:
@@ -29,8 +29,8 @@ dependencies:
 
 These references map directly to bundle sections:
 
-- `utils: template-format` → Look for `==================== START: .bmad-core/utils/template-format.md ====================`
-- `tasks: create-story` → Look for `==================== START: .bmad-core/tasks/create-story.md ====================`
+- `utils: template-format` → Look for `==================== START: bmad-core/utils/template-format.md ====================`
+- `tasks: create-story` → Look for `==================== START: bmad-core/tasks/create-story.md ====================`
 
 3. **Execution Context**: You are operating in a web environment. All your capabilities and knowledge are contained within this bundle. Work within these constraints to provide the best possible assistance.
 
@@ -39,7 +39,7 @@ These references map directly to bundle sections:
 ---
 
 
-==================== START: .bmad-core/agents/bmad-orchestrator.md ====================
+==================== START: bmad-core/agents/bmad-orchestrator.md ====================
 # bmad-orchestrator
 
 CRITICAL: Read the full YAML, start activation to alter your state of being, follow startup section instructions, stay in this being until told to exit this mode:
@@ -164,9 +164,9 @@ dependencies:
   utils:
     - workflow-management.md
 ```
-==================== END: .bmad-core/agents/bmad-orchestrator.md ====================
+==================== END: bmad-core/agents/bmad-orchestrator.md ====================
 
-==================== START: .bmad-core/tasks/advanced-elicitation.md ====================
+==================== START: bmad-core/tasks/advanced-elicitation.md ====================
 <!-- Powered by BMAD™ Core -->
 # Advanced Elicitation Task
 
@@ -285,9 +285,9 @@ Choose a number (0-8) or 9 to proceed:
 - **Stay Relevant**: Tie all elicitation back to the specific content being analyzed
 - **Identify Personas**: For multi-persona methods, clearly identify which viewpoint is speaking
 - **Maintain Flow**: Keep the process moving efficiently
-==================== END: .bmad-core/tasks/advanced-elicitation.md ====================
+==================== END: bmad-core/tasks/advanced-elicitation.md ====================
 
-==================== START: .bmad-core/tasks/create-doc.md ====================
+==================== START: bmad-core/tasks/create-doc.md ====================
 <!-- Powered by BMAD™ Core -->
 # Create Document from Template (YAML Driven)
 
@@ -306,7 +306,7 @@ When this task is invoked:
 
 ## Critical: Template Discovery
 
-If a YAML Template has not been provided, list all templates from .bmad-core/templates or ask the user to provide another.
+If a YAML Template has not been provided, list all templates from bmad-core/templates or ask the user to provide another.
 
 ## CRITICAL: Mandatory Elicitation Format
 
@@ -390,9 +390,9 @@ User can type `#yolo` to toggle to YOLO mode (process all sections at once).
 - Select options 2-9 from data/elicitation-methods only
 - Provide detailed rationale explaining decisions
 - End with "Select 1-9 or just type your question/feedback:"
-==================== END: .bmad-core/tasks/create-doc.md ====================
+==================== END: bmad-core/tasks/create-doc.md ====================
 
-==================== START: .bmad-core/tasks/kb-mode-interaction.md ====================
+==================== START: bmad-core/tasks/kb-mode-interaction.md ====================
 <!-- Powered by BMAD™ Core -->
 # KB Mode Interaction Task
 
@@ -469,9 +469,9 @@ Or ask me about anything else related to BMad-Method!
 **User**: Tell me about workflows
 
 **Assistant**: [Provides focused information about workflows from the KB, then offers to explore specific workflow types or related topics]
-==================== END: .bmad-core/tasks/kb-mode-interaction.md ====================
+==================== END: bmad-core/tasks/kb-mode-interaction.md ====================
 
-==================== START: .bmad-core/data/bmad-kb.md ====================
+==================== START: bmad-core/data/bmad-kb.md ====================
 <!-- Powered by BMAD™ Core -->
 # BMAD™ Knowledge Base
 
@@ -580,7 +580,7 @@ npx bmad-method install
 
 **Verify Installation**:
 
-- `.bmad-core/` folder created with all agents
+- `bmad-core/` folder created with all agents
 - IDE-specific integration files created
 - All agent commands/rules/modes available
 
@@ -1279,9 +1279,9 @@ Use the **expansion-creator** pack to build your own:
 - **Documentation**: Check `docs/` folder for project-specific context
 - **Community**: Discord and GitHub resources available for support
 - **Contributing**: See `CONTRIBUTING.md` for full guidelines
-==================== END: .bmad-core/data/bmad-kb.md ====================
+==================== END: bmad-core/data/bmad-kb.md ====================
 
-==================== START: .bmad-core/data/elicitation-methods.md ====================
+==================== START: bmad-core/data/elicitation-methods.md ====================
 <!-- Powered by BMAD™ Core -->
 # Elicitation Methods Data
 
@@ -1437,9 +1437,9 @@ Use the **expansion-creator** pack to build your own:
 - Acknowledge choice to finalize current work
 - Accept output as-is or move to next step
 - Prepare to continue without additional elicitation
-==================== END: .bmad-core/data/elicitation-methods.md ====================
+==================== END: bmad-core/data/elicitation-methods.md ====================
 
-==================== START: .bmad-core/utils/workflow-management.md ====================
+==================== START: bmad-core/utils/workflow-management.md ====================
 <!-- Powered by BMAD™ Core -->
 # Workflow Management
 
@@ -1510,4 +1510,4 @@ Handle conditional paths by asking clarifying questions when needed.
 ## Agent Integration
 
 Agents should be workflow-aware: know active workflow, their role, access artifacts, understand expected outputs.
-==================== END: .bmad-core/utils/workflow-management.md ====================
+==================== END: bmad-core/utils/workflow-management.md ====================

--- a/dist/agents/dev.txt
+++ b/dist/agents/dev.txt
@@ -8,13 +8,13 @@ You are now operating as a specialized AI agent from the BMad-Method framework. 
 
 2. **Resource Navigation**: This bundle contains all resources you need. Resources are marked with tags like:
 
-- `==================== START: .bmad-core/folder/filename.md ====================`
-- `==================== END: .bmad-core/folder/filename.md ====================`
+- `==================== START: bmad-core/folder/filename.md ====================`
+- `==================== END: bmad-core/folder/filename.md ====================`
 
 When you need to reference a resource mentioned in your instructions:
 
 - Look for the corresponding START/END tags
-- The format is always the full path with dot prefix (e.g., `.bmad-core/personas/analyst.md`, `.bmad-core/tasks/create-story.md`)
+- The format is always the full path with dot prefix (e.g., `bmad-core/personas/analyst.md`, `bmad-core/tasks/create-story.md`)
 - If a section is specified (e.g., `{root}/tasks/create-story.md#section-name`), navigate to that section within the file
 
 **Understanding YAML References**: In the agent configuration, resources are referenced in the dependencies section. For example:
@@ -29,8 +29,8 @@ dependencies:
 
 These references map directly to bundle sections:
 
-- `utils: template-format` → Look for `==================== START: .bmad-core/utils/template-format.md ====================`
-- `tasks: create-story` → Look for `==================== START: .bmad-core/tasks/create-story.md ====================`
+- `utils: template-format` → Look for `==================== START: bmad-core/utils/template-format.md ====================`
+- `tasks: create-story` → Look for `==================== START: bmad-core/tasks/create-story.md ====================`
 
 3. **Execution Context**: You are operating in a web environment. All your capabilities and knowledge are contained within this bundle. Work within these constraints to provide the best possible assistance.
 
@@ -39,7 +39,7 @@ These references map directly to bundle sections:
 ---
 
 
-==================== START: .bmad-core/agents/dev.md ====================
+==================== START: bmad-core/agents/dev.md ====================
 # dev
 
 CRITICAL: Read the full YAML, start activation to alter your state of being, follow startup section instructions, stay in this being until told to exit this mode:
@@ -90,9 +90,9 @@ dependencies:
     - execute-checklist.md
     - validate-next-story.md
 ```
-==================== END: .bmad-core/agents/dev.md ====================
+==================== END: bmad-core/agents/dev.md ====================
 
-==================== START: .bmad-core/tasks/apply-qa-fixes.md ====================
+==================== START: bmad-core/tasks/apply-qa-fixes.md ====================
 <!-- Powered by BMAD™ Core -->
 # apply-qa-fixes
 
@@ -242,9 +242,9 @@ Fix plan:
 - Tests validate behavior and close gaps
 - Strict adherence to allowed story update areas
 - Gate ownership remains with QA; Dev signals readiness via Status
-==================== END: .bmad-core/tasks/apply-qa-fixes.md ====================
+==================== END: bmad-core/tasks/apply-qa-fixes.md ====================
 
-==================== START: .bmad-core/tasks/execute-checklist.md ====================
+==================== START: bmad-core/tasks/execute-checklist.md ====================
 <!-- Powered by BMAD™ Core -->
 # Checklist Validation Task
 
@@ -252,7 +252,7 @@ This task provides instructions for validating documentation against checklists.
 
 ## Available Checklists
 
-If the user asks or does not specify a specific checklist, list the checklists available to the agent persona. If the task is being run not with a specific agent, tell the user to check the .bmad-core/checklists folder to select the appropriate one to run.
+If the user asks or does not specify a specific checklist, list the checklists available to the agent persona. If the task is being run not with a specific agent, tell the user to check the bmad-core/checklists folder to select the appropriate one to run.
 
 ## Instructions
 
@@ -260,7 +260,7 @@ If the user asks or does not specify a specific checklist, list the checklists a
    - If user or the task being run provides a checklist name:
      - Try fuzzy matching (e.g. "architecture checklist" -> "architect-checklist")
      - If multiple matches found, ask user to clarify
-     - Load the appropriate checklist from .bmad-core/checklists/
+     - Load the appropriate checklist from bmad-core/checklists/
    - If no checklist specified:
      - Ask the user which checklist they want to use
      - Present the available options from the files in the checklists folder
@@ -332,9 +332,9 @@ The LLM will:
 - Execute the complete checklist validation
 - Present a final report with pass/fail rates and key findings
 - Offer to provide detailed analysis of any section, especially those with warnings or failures
-==================== END: .bmad-core/tasks/execute-checklist.md ====================
+==================== END: bmad-core/tasks/execute-checklist.md ====================
 
-==================== START: .bmad-core/tasks/validate-next-story.md ====================
+==================== START: bmad-core/tasks/validate-next-story.md ====================
 <!-- Powered by BMAD™ Core -->
 # Validate Next Story Task
 
@@ -346,7 +346,7 @@ To comprehensively validate a story draft before implementation begins, ensuring
 
 ### 0. Load Core Configuration and Inputs
 
-- Load `.bmad-core/core-config.yaml`
+- Load `bmad-core/core-config.yaml`
 - If the file does not exist, HALT and inform the user: "core-config.yaml not found. This file is required for story validation."
 - Extract key configurations: `devStoryLocation`, `prd.*`, `architecture.*`
 - Identify and load the following inputs:
@@ -470,9 +470,9 @@ Provide a structured validation report including:
 - **NO-GO**: Story requires fixes before implementation
 - **Implementation Readiness Score**: 1-10 scale
 - **Confidence Level**: High/Medium/Low for successful implementation
-==================== END: .bmad-core/tasks/validate-next-story.md ====================
+==================== END: bmad-core/tasks/validate-next-story.md ====================
 
-==================== START: .bmad-core/checklists/story-dod-checklist.md ====================
+==================== START: bmad-core/checklists/story-dod-checklist.md ====================
 <!-- Powered by BMAD™ Core -->
 # Story Definition of Done (DoD) Checklist
 
@@ -568,4 +568,4 @@ After completing the checklist:
 Be honest - it's better to flag issues now than have them discovered later.]]
 
 - [ ] I, the Developer Agent, confirm that all applicable items above have been addressed.
-==================== END: .bmad-core/checklists/story-dod-checklist.md ====================
+==================== END: bmad-core/checklists/story-dod-checklist.md ====================

--- a/dist/agents/pm.txt
+++ b/dist/agents/pm.txt
@@ -8,13 +8,13 @@ You are now operating as a specialized AI agent from the BMad-Method framework. 
 
 2. **Resource Navigation**: This bundle contains all resources you need. Resources are marked with tags like:
 
-- `==================== START: .bmad-core/folder/filename.md ====================`
-- `==================== END: .bmad-core/folder/filename.md ====================`
+- `==================== START: bmad-core/folder/filename.md ====================`
+- `==================== END: bmad-core/folder/filename.md ====================`
 
 When you need to reference a resource mentioned in your instructions:
 
 - Look for the corresponding START/END tags
-- The format is always the full path with dot prefix (e.g., `.bmad-core/personas/analyst.md`, `.bmad-core/tasks/create-story.md`)
+- The format is always the full path with dot prefix (e.g., `bmad-core/personas/analyst.md`, `bmad-core/tasks/create-story.md`)
 - If a section is specified (e.g., `{root}/tasks/create-story.md#section-name`), navigate to that section within the file
 
 **Understanding YAML References**: In the agent configuration, resources are referenced in the dependencies section. For example:
@@ -29,8 +29,8 @@ dependencies:
 
 These references map directly to bundle sections:
 
-- `utils: template-format` → Look for `==================== START: .bmad-core/utils/template-format.md ====================`
-- `tasks: create-story` → Look for `==================== START: .bmad-core/tasks/create-story.md ====================`
+- `utils: template-format` → Look for `==================== START: bmad-core/utils/template-format.md ====================`
+- `tasks: create-story` → Look for `==================== START: bmad-core/tasks/create-story.md ====================`
 
 3. **Execution Context**: You are operating in a web environment. All your capabilities and knowledge are contained within this bundle. Work within these constraints to provide the best possible assistance.
 
@@ -39,7 +39,7 @@ These references map directly to bundle sections:
 ---
 
 
-==================== START: .bmad-core/agents/pm.md ====================
+==================== START: bmad-core/agents/pm.md ====================
 # pm
 
 CRITICAL: Read the full YAML, start activation to alter your state of being, follow startup section instructions, stay in this being until told to exit this mode:
@@ -101,9 +101,9 @@ dependencies:
     - brownfield-prd-tmpl.yaml
     - prd-tmpl.yaml
 ```
-==================== END: .bmad-core/agents/pm.md ====================
+==================== END: bmad-core/agents/pm.md ====================
 
-==================== START: .bmad-core/tasks/brownfield-create-epic.md ====================
+==================== START: bmad-core/tasks/brownfield-create-epic.md ====================
 <!-- Powered by BMAD™ Core -->
 # Create Brownfield Epic Task
 
@@ -265,9 +265,9 @@ The epic creation is successful when:
 - If the scope grows beyond 3 stories, consider the full brownfield PRD process
 - Always prioritize existing system integrity over new functionality
 - When in doubt about scope or complexity, escalate to full brownfield planning
-==================== END: .bmad-core/tasks/brownfield-create-epic.md ====================
+==================== END: bmad-core/tasks/brownfield-create-epic.md ====================
 
-==================== START: .bmad-core/tasks/brownfield-create-story.md ====================
+==================== START: bmad-core/tasks/brownfield-create-story.md ====================
 <!-- Powered by BMAD™ Core -->
 # Create Brownfield Story Task
 
@@ -416,15 +416,15 @@ The story creation is successful when:
 - Always prioritize existing system integrity
 - When in doubt about integration complexity, use brownfield-create-epic instead
 - Stories should take no more than 4 hours of focused development work
-==================== END: .bmad-core/tasks/brownfield-create-story.md ====================
+==================== END: bmad-core/tasks/brownfield-create-story.md ====================
 
-==================== START: .bmad-core/tasks/correct-course.md ====================
+==================== START: bmad-core/tasks/correct-course.md ====================
 <!-- Powered by BMAD™ Core -->
 # Correct Course Task
 
 ## Purpose
 
-- Guide a structured response to a change trigger using the `.bmad-core/checklists/change-checklist`.
+- Guide a structured response to a change trigger using the `bmad-core/checklists/change-checklist`.
 - Analyze the impacts of the change on epics, project artifacts, and the MVP, guided by the checklist's structure.
 - Explore potential solutions (e.g., adjust scope, rollback elements, re-scope features) as prompted by the checklist.
 - Draft specific, actionable proposed updates to any affected project artifacts (e.g., epics, user stories, PRD sections, architecture document sections) based on the analysis.
@@ -438,7 +438,7 @@ The story creation is successful when:
 - **Acknowledge Task & Inputs:**
   - Confirm with the user that the "Correct Course Task" (Change Navigation & Integration) is being initiated.
   - Verify the change trigger and ensure you have the user's initial explanation of the issue and its perceived impact.
-  - Confirm access to all relevant project artifacts (e.g., PRD, Epics/Stories, Architecture Documents, UI/UX Specifications) and, critically, the `.bmad-core/checklists/change-checklist`.
+  - Confirm access to all relevant project artifacts (e.g., PRD, Epics/Stories, Architecture Documents, UI/UX Specifications) and, critically, the `bmad-core/checklists/change-checklist`.
 - **Establish Interaction Mode:**
   - Ask the user their preferred interaction mode for this task:
     - **"Incrementally (Default & Recommended):** Shall we work through the change-checklist section by section, discussing findings and collaboratively drafting proposed changes for each relevant part before moving to the next? This allows for detailed, step-by-step refinement."
@@ -490,9 +490,9 @@ The story creation is successful when:
   - A summary of the change-checklist analysis (issue, impact, rationale for the chosen path).
   - Specific, clearly drafted proposed edits for all affected project artifacts.
 - **Implicit:** An annotated change-checklist (or the record of its completion) reflecting the discussions, findings, and decisions made during the process.
-==================== END: .bmad-core/tasks/correct-course.md ====================
+==================== END: bmad-core/tasks/correct-course.md ====================
 
-==================== START: .bmad-core/tasks/create-deep-research-prompt.md ====================
+==================== START: bmad-core/tasks/create-deep-research-prompt.md ====================
 <!-- Powered by BMAD™ Core -->
 # Create Deep Research Prompt Task
 
@@ -772,9 +772,9 @@ CRITICAL: collaborate with the user to develop specific, actionable research que
 - Balance comprehensiveness with focus
 - Document assumptions and limitations clearly
 - Plan for iterative refinement based on initial findings
-==================== END: .bmad-core/tasks/create-deep-research-prompt.md ====================
+==================== END: bmad-core/tasks/create-deep-research-prompt.md ====================
 
-==================== START: .bmad-core/tasks/create-doc.md ====================
+==================== START: bmad-core/tasks/create-doc.md ====================
 <!-- Powered by BMAD™ Core -->
 # Create Document from Template (YAML Driven)
 
@@ -793,7 +793,7 @@ When this task is invoked:
 
 ## Critical: Template Discovery
 
-If a YAML Template has not been provided, list all templates from .bmad-core/templates or ask the user to provide another.
+If a YAML Template has not been provided, list all templates from bmad-core/templates or ask the user to provide another.
 
 ## CRITICAL: Mandatory Elicitation Format
 
@@ -877,9 +877,9 @@ User can type `#yolo` to toggle to YOLO mode (process all sections at once).
 - Select options 2-9 from data/elicitation-methods only
 - Provide detailed rationale explaining decisions
 - End with "Select 1-9 or just type your question/feedback:"
-==================== END: .bmad-core/tasks/create-doc.md ====================
+==================== END: bmad-core/tasks/create-doc.md ====================
 
-==================== START: .bmad-core/tasks/execute-checklist.md ====================
+==================== START: bmad-core/tasks/execute-checklist.md ====================
 <!-- Powered by BMAD™ Core -->
 # Checklist Validation Task
 
@@ -887,7 +887,7 @@ This task provides instructions for validating documentation against checklists.
 
 ## Available Checklists
 
-If the user asks or does not specify a specific checklist, list the checklists available to the agent persona. If the task is being run not with a specific agent, tell the user to check the .bmad-core/checklists folder to select the appropriate one to run.
+If the user asks or does not specify a specific checklist, list the checklists available to the agent persona. If the task is being run not with a specific agent, tell the user to check the bmad-core/checklists folder to select the appropriate one to run.
 
 ## Instructions
 
@@ -895,7 +895,7 @@ If the user asks or does not specify a specific checklist, list the checklists a
    - If user or the task being run provides a checklist name:
      - Try fuzzy matching (e.g. "architecture checklist" -> "architect-checklist")
      - If multiple matches found, ask user to clarify
-     - Load the appropriate checklist from .bmad-core/checklists/
+     - Load the appropriate checklist from bmad-core/checklists/
    - If no checklist specified:
      - Ask the user which checklist they want to use
      - Present the available options from the files in the checklists folder
@@ -967,9 +967,9 @@ The LLM will:
 - Execute the complete checklist validation
 - Present a final report with pass/fail rates and key findings
 - Offer to provide detailed analysis of any section, especially those with warnings or failures
-==================== END: .bmad-core/tasks/execute-checklist.md ====================
+==================== END: bmad-core/tasks/execute-checklist.md ====================
 
-==================== START: .bmad-core/tasks/shard-doc.md ====================
+==================== START: bmad-core/tasks/shard-doc.md ====================
 <!-- Powered by BMAD™ Core -->
 # Document Sharding Task
 
@@ -981,20 +981,20 @@ The LLM will:
 
 ## Primary Method: Automatic with markdown-tree
 
-[[LLM: First, check if markdownExploder is set to true in .bmad-core/core-config.yaml. If it is, attempt to run the command: `md-tree explode {input file} {output path}`.
+[[LLM: First, check if markdownExploder is set to true in bmad-core/core-config.yaml. If it is, attempt to run the command: `md-tree explode {input file} {output path}`.
 
 If the command succeeds, inform the user that the document has been sharded successfully and STOP - do not proceed further.
 
 If the command fails (especially with an error indicating the command is not found or not available), inform the user: "The markdownExploder setting is enabled but the md-tree command is not available. Please either:
 
 1. Install @kayvan/markdown-tree-parser globally with: `npm install -g @kayvan/markdown-tree-parser`
-2. Or set markdownExploder to false in .bmad-core/core-config.yaml
+2. Or set markdownExploder to false in bmad-core/core-config.yaml
 
 **IMPORTANT: STOP HERE - do not proceed with manual sharding until one of the above actions is taken.**"
 
 If markdownExploder is set to false, inform the user: "The markdownExploder setting is currently false. For better performance and reliability, you should:
 
-1. Set markdownExploder to true in .bmad-core/core-config.yaml
+1. Set markdownExploder to true in bmad-core/core-config.yaml
 2. Install @kayvan/markdown-tree-parser globally with: `npm install -g @kayvan/markdown-tree-parser`
 
 I will now proceed with the manual sharding process."
@@ -1156,9 +1156,9 @@ Document sharded successfully:
 - Preserve ALL formatting, including whitespace where significant
 - Handle edge cases like sections with code blocks containing ## symbols
 - Ensure the sharding is reversible (could reconstruct the original from shards)
-==================== END: .bmad-core/tasks/shard-doc.md ====================
+==================== END: bmad-core/tasks/shard-doc.md ====================
 
-==================== START: .bmad-core/templates/brownfield-prd-tmpl.yaml ====================
+==================== START: bmad-core/templates/brownfield-prd-tmpl.yaml ====================
 # <!-- Powered by BMAD™ Core -->
 template:
   id: brownfield-prd-template-v2
@@ -1440,9 +1440,9 @@ sections:
               - template: "IV1: {{existing_functionality_verification}}"
               - template: "IV2: {{integration_point_verification}}"
               - template: "IV3: {{performance_impact_verification}}"
-==================== END: .bmad-core/templates/brownfield-prd-tmpl.yaml ====================
+==================== END: bmad-core/templates/brownfield-prd-tmpl.yaml ====================
 
-==================== START: .bmad-core/templates/prd-tmpl.yaml ====================
+==================== START: bmad-core/templates/prd-tmpl.yaml ====================
 # <!-- Powered by BMAD™ Core -->
 template:
   id: prd-template-v2
@@ -1545,7 +1545,7 @@ sections:
     instruction: |
       Gather technical decisions that will guide the Architect. Steps:
 
-      1. Check if .bmad-core/data/technical-preferences.yaml or an attached technical-preferences file exists - use it to pre-populate choices
+      1. Check if bmad-core/data/technical-preferences.yaml or an attached technical-preferences file exists - use it to pre-populate choices
       2. Ask user about: languages, frameworks, starter templates, libraries, APIs, deployment targets
       3. For unknowns, offer guidance based on project goals and MVP scope
       4. Document ALL technical choices with rationale (why this choice fits the project)
@@ -1646,9 +1646,9 @@ sections:
       - id: architect-prompt
         title: Architect Prompt
         instruction: This section will contain the prompt for the Architect, keep it short and to the point to initiate create architecture mode using this document as input.
-==================== END: .bmad-core/templates/prd-tmpl.yaml ====================
+==================== END: bmad-core/templates/prd-tmpl.yaml ====================
 
-==================== START: .bmad-core/checklists/change-checklist.md ====================
+==================== START: bmad-core/checklists/change-checklist.md ====================
 <!-- Powered by BMAD™ Core -->
 # Change Navigation Checklist
 
@@ -1832,9 +1832,9 @@ Keep it action-oriented and forward-looking.]]
 - [ ] **Confirm Next Steps:** Reiterate the handoff plan and the next actions to be taken by specific agents.
 
 ---
-==================== END: .bmad-core/checklists/change-checklist.md ====================
+==================== END: bmad-core/checklists/change-checklist.md ====================
 
-==================== START: .bmad-core/checklists/pm-checklist.md ====================
+==================== START: bmad-core/checklists/pm-checklist.md ====================
 <!-- Powered by BMAD™ Core -->
 # Product Manager (PM) Requirements Checklist
 
@@ -2206,11 +2206,11 @@ After presenting the report, ask if the user wants:
 
 - **READY FOR ARCHITECT**: The PRD and epics are comprehensive, properly structured, and ready for architectural design.
 - **NEEDS REFINEMENT**: The requirements documentation requires additional work to address the identified deficiencies.
-==================== END: .bmad-core/checklists/pm-checklist.md ====================
+==================== END: bmad-core/checklists/pm-checklist.md ====================
 
-==================== START: .bmad-core/data/technical-preferences.md ====================
+==================== START: bmad-core/data/technical-preferences.md ====================
 <!-- Powered by BMAD™ Core -->
 # User-Defined Preferred Patterns and Preferences
 
 None Listed
-==================== END: .bmad-core/data/technical-preferences.md ====================
+==================== END: bmad-core/data/technical-preferences.md ====================

--- a/dist/agents/po.txt
+++ b/dist/agents/po.txt
@@ -8,13 +8,13 @@ You are now operating as a specialized AI agent from the BMad-Method framework. 
 
 2. **Resource Navigation**: This bundle contains all resources you need. Resources are marked with tags like:
 
-- `==================== START: .bmad-core/folder/filename.md ====================`
-- `==================== END: .bmad-core/folder/filename.md ====================`
+- `==================== START: bmad-core/folder/filename.md ====================`
+- `==================== END: bmad-core/folder/filename.md ====================`
 
 When you need to reference a resource mentioned in your instructions:
 
 - Look for the corresponding START/END tags
-- The format is always the full path with dot prefix (e.g., `.bmad-core/personas/analyst.md`, `.bmad-core/tasks/create-story.md`)
+- The format is always the full path with dot prefix (e.g., `bmad-core/personas/analyst.md`, `bmad-core/tasks/create-story.md`)
 - If a section is specified (e.g., `{root}/tasks/create-story.md#section-name`), navigate to that section within the file
 
 **Understanding YAML References**: In the agent configuration, resources are referenced in the dependencies section. For example:
@@ -29,8 +29,8 @@ dependencies:
 
 These references map directly to bundle sections:
 
-- `utils: template-format` → Look for `==================== START: .bmad-core/utils/template-format.md ====================`
-- `tasks: create-story` → Look for `==================== START: .bmad-core/tasks/create-story.md ====================`
+- `utils: template-format` → Look for `==================== START: bmad-core/utils/template-format.md ====================`
+- `tasks: create-story` → Look for `==================== START: bmad-core/tasks/create-story.md ====================`
 
 3. **Execution Context**: You are operating in a web environment. All your capabilities and knowledge are contained within this bundle. Work within these constraints to provide the best possible assistance.
 
@@ -39,7 +39,7 @@ These references map directly to bundle sections:
 ---
 
 
-==================== START: .bmad-core/agents/po.md ====================
+==================== START: bmad-core/agents/po.md ====================
 # po
 
 CRITICAL: Read the full YAML, start activation to alter your state of being, follow startup section instructions, stay in this being until told to exit this mode:
@@ -96,15 +96,15 @@ dependencies:
   templates:
     - story-tmpl.yaml
 ```
-==================== END: .bmad-core/agents/po.md ====================
+==================== END: bmad-core/agents/po.md ====================
 
-==================== START: .bmad-core/tasks/correct-course.md ====================
+==================== START: bmad-core/tasks/correct-course.md ====================
 <!-- Powered by BMAD™ Core -->
 # Correct Course Task
 
 ## Purpose
 
-- Guide a structured response to a change trigger using the `.bmad-core/checklists/change-checklist`.
+- Guide a structured response to a change trigger using the `bmad-core/checklists/change-checklist`.
 - Analyze the impacts of the change on epics, project artifacts, and the MVP, guided by the checklist's structure.
 - Explore potential solutions (e.g., adjust scope, rollback elements, re-scope features) as prompted by the checklist.
 - Draft specific, actionable proposed updates to any affected project artifacts (e.g., epics, user stories, PRD sections, architecture document sections) based on the analysis.
@@ -118,7 +118,7 @@ dependencies:
 - **Acknowledge Task & Inputs:**
   - Confirm with the user that the "Correct Course Task" (Change Navigation & Integration) is being initiated.
   - Verify the change trigger and ensure you have the user's initial explanation of the issue and its perceived impact.
-  - Confirm access to all relevant project artifacts (e.g., PRD, Epics/Stories, Architecture Documents, UI/UX Specifications) and, critically, the `.bmad-core/checklists/change-checklist`.
+  - Confirm access to all relevant project artifacts (e.g., PRD, Epics/Stories, Architecture Documents, UI/UX Specifications) and, critically, the `bmad-core/checklists/change-checklist`.
 - **Establish Interaction Mode:**
   - Ask the user their preferred interaction mode for this task:
     - **"Incrementally (Default & Recommended):** Shall we work through the change-checklist section by section, discussing findings and collaboratively drafting proposed changes for each relevant part before moving to the next? This allows for detailed, step-by-step refinement."
@@ -170,9 +170,9 @@ dependencies:
   - A summary of the change-checklist analysis (issue, impact, rationale for the chosen path).
   - Specific, clearly drafted proposed edits for all affected project artifacts.
 - **Implicit:** An annotated change-checklist (or the record of its completion) reflecting the discussions, findings, and decisions made during the process.
-==================== END: .bmad-core/tasks/correct-course.md ====================
+==================== END: bmad-core/tasks/correct-course.md ====================
 
-==================== START: .bmad-core/tasks/execute-checklist.md ====================
+==================== START: bmad-core/tasks/execute-checklist.md ====================
 <!-- Powered by BMAD™ Core -->
 # Checklist Validation Task
 
@@ -180,7 +180,7 @@ This task provides instructions for validating documentation against checklists.
 
 ## Available Checklists
 
-If the user asks or does not specify a specific checklist, list the checklists available to the agent persona. If the task is being run not with a specific agent, tell the user to check the .bmad-core/checklists folder to select the appropriate one to run.
+If the user asks or does not specify a specific checklist, list the checklists available to the agent persona. If the task is being run not with a specific agent, tell the user to check the bmad-core/checklists folder to select the appropriate one to run.
 
 ## Instructions
 
@@ -188,7 +188,7 @@ If the user asks or does not specify a specific checklist, list the checklists a
    - If user or the task being run provides a checklist name:
      - Try fuzzy matching (e.g. "architecture checklist" -> "architect-checklist")
      - If multiple matches found, ask user to clarify
-     - Load the appropriate checklist from .bmad-core/checklists/
+     - Load the appropriate checklist from bmad-core/checklists/
    - If no checklist specified:
      - Ask the user which checklist they want to use
      - Present the available options from the files in the checklists folder
@@ -260,9 +260,9 @@ The LLM will:
 - Execute the complete checklist validation
 - Present a final report with pass/fail rates and key findings
 - Offer to provide detailed analysis of any section, especially those with warnings or failures
-==================== END: .bmad-core/tasks/execute-checklist.md ====================
+==================== END: bmad-core/tasks/execute-checklist.md ====================
 
-==================== START: .bmad-core/tasks/shard-doc.md ====================
+==================== START: bmad-core/tasks/shard-doc.md ====================
 <!-- Powered by BMAD™ Core -->
 # Document Sharding Task
 
@@ -274,20 +274,20 @@ The LLM will:
 
 ## Primary Method: Automatic with markdown-tree
 
-[[LLM: First, check if markdownExploder is set to true in .bmad-core/core-config.yaml. If it is, attempt to run the command: `md-tree explode {input file} {output path}`.
+[[LLM: First, check if markdownExploder is set to true in bmad-core/core-config.yaml. If it is, attempt to run the command: `md-tree explode {input file} {output path}`.
 
 If the command succeeds, inform the user that the document has been sharded successfully and STOP - do not proceed further.
 
 If the command fails (especially with an error indicating the command is not found or not available), inform the user: "The markdownExploder setting is enabled but the md-tree command is not available. Please either:
 
 1. Install @kayvan/markdown-tree-parser globally with: `npm install -g @kayvan/markdown-tree-parser`
-2. Or set markdownExploder to false in .bmad-core/core-config.yaml
+2. Or set markdownExploder to false in bmad-core/core-config.yaml
 
 **IMPORTANT: STOP HERE - do not proceed with manual sharding until one of the above actions is taken.**"
 
 If markdownExploder is set to false, inform the user: "The markdownExploder setting is currently false. For better performance and reliability, you should:
 
-1. Set markdownExploder to true in .bmad-core/core-config.yaml
+1. Set markdownExploder to true in bmad-core/core-config.yaml
 2. Install @kayvan/markdown-tree-parser globally with: `npm install -g @kayvan/markdown-tree-parser`
 
 I will now proceed with the manual sharding process."
@@ -449,9 +449,9 @@ Document sharded successfully:
 - Preserve ALL formatting, including whitespace where significant
 - Handle edge cases like sections with code blocks containing ## symbols
 - Ensure the sharding is reversible (could reconstruct the original from shards)
-==================== END: .bmad-core/tasks/shard-doc.md ====================
+==================== END: bmad-core/tasks/shard-doc.md ====================
 
-==================== START: .bmad-core/tasks/validate-next-story.md ====================
+==================== START: bmad-core/tasks/validate-next-story.md ====================
 <!-- Powered by BMAD™ Core -->
 # Validate Next Story Task
 
@@ -463,7 +463,7 @@ To comprehensively validate a story draft before implementation begins, ensuring
 
 ### 0. Load Core Configuration and Inputs
 
-- Load `.bmad-core/core-config.yaml`
+- Load `bmad-core/core-config.yaml`
 - If the file does not exist, HALT and inform the user: "core-config.yaml not found. This file is required for story validation."
 - Extract key configurations: `devStoryLocation`, `prd.*`, `architecture.*`
 - Identify and load the following inputs:
@@ -587,9 +587,9 @@ Provide a structured validation report including:
 - **NO-GO**: Story requires fixes before implementation
 - **Implementation Readiness Score**: 1-10 scale
 - **Confidence Level**: High/Medium/Low for successful implementation
-==================== END: .bmad-core/tasks/validate-next-story.md ====================
+==================== END: bmad-core/tasks/validate-next-story.md ====================
 
-==================== START: .bmad-core/templates/story-tmpl.yaml ====================
+==================== START: bmad-core/templates/story-tmpl.yaml ====================
 # <!-- Powered by BMAD™ Core -->
 template:
   id: story-template-v2
@@ -728,9 +728,9 @@ sections:
     instruction: Results from QA Agent QA review of the completed story implementation
     owner: qa-agent
     editors: [qa-agent]
-==================== END: .bmad-core/templates/story-tmpl.yaml ====================
+==================== END: bmad-core/templates/story-tmpl.yaml ====================
 
-==================== START: .bmad-core/checklists/change-checklist.md ====================
+==================== START: bmad-core/checklists/change-checklist.md ====================
 <!-- Powered by BMAD™ Core -->
 # Change Navigation Checklist
 
@@ -914,9 +914,9 @@ Keep it action-oriented and forward-looking.]]
 - [ ] **Confirm Next Steps:** Reiterate the handoff plan and the next actions to be taken by specific agents.
 
 ---
-==================== END: .bmad-core/checklists/change-checklist.md ====================
+==================== END: bmad-core/checklists/change-checklist.md ====================
 
-==================== START: .bmad-core/checklists/po-master-checklist.md ====================
+==================== START: bmad-core/checklists/po-master-checklist.md ====================
 <!-- Powered by BMAD™ Core -->
 # Product Owner (PO) Master Validation Checklist
 
@@ -1350,4 +1350,4 @@ After presenting the report, ask if the user wants:
 - **APPROVED**: The plan is comprehensive, properly sequenced, and ready for implementation.
 - **CONDITIONAL**: The plan requires specific adjustments before proceeding.
 - **REJECTED**: The plan requires significant revision to address critical deficiencies.
-==================== END: .bmad-core/checklists/po-master-checklist.md ====================
+==================== END: bmad-core/checklists/po-master-checklist.md ====================

--- a/dist/agents/qa.txt
+++ b/dist/agents/qa.txt
@@ -8,13 +8,13 @@ You are now operating as a specialized AI agent from the BMad-Method framework. 
 
 2. **Resource Navigation**: This bundle contains all resources you need. Resources are marked with tags like:
 
-- `==================== START: .bmad-core/folder/filename.md ====================`
-- `==================== END: .bmad-core/folder/filename.md ====================`
+- `==================== START: bmad-core/folder/filename.md ====================`
+- `==================== END: bmad-core/folder/filename.md ====================`
 
 When you need to reference a resource mentioned in your instructions:
 
 - Look for the corresponding START/END tags
-- The format is always the full path with dot prefix (e.g., `.bmad-core/personas/analyst.md`, `.bmad-core/tasks/create-story.md`)
+- The format is always the full path with dot prefix (e.g., `bmad-core/personas/analyst.md`, `bmad-core/tasks/create-story.md`)
 - If a section is specified (e.g., `{root}/tasks/create-story.md#section-name`), navigate to that section within the file
 
 **Understanding YAML References**: In the agent configuration, resources are referenced in the dependencies section. For example:
@@ -29,8 +29,8 @@ dependencies:
 
 These references map directly to bundle sections:
 
-- `utils: template-format` → Look for `==================== START: .bmad-core/utils/template-format.md ====================`
-- `tasks: create-story` → Look for `==================== START: .bmad-core/tasks/create-story.md ====================`
+- `utils: template-format` → Look for `==================== START: bmad-core/utils/template-format.md ====================`
+- `tasks: create-story` → Look for `==================== START: bmad-core/tasks/create-story.md ====================`
 
 3. **Execution Context**: You are operating in a web environment. All your capabilities and knowledge are contained within this bundle. Work within these constraints to provide the best possible assistance.
 
@@ -39,7 +39,7 @@ These references map directly to bundle sections:
 ---
 
 
-==================== START: .bmad-core/agents/qa.md ====================
+==================== START: bmad-core/agents/qa.md ====================
 # qa
 
 CRITICAL: Read the full YAML, start activation to alter your state of being, follow startup section instructions, stay in this being until told to exit this mode:
@@ -108,9 +108,9 @@ dependencies:
     - qa-gate-tmpl.yaml
     - story-tmpl.yaml
 ```
-==================== END: .bmad-core/agents/qa.md ====================
+==================== END: bmad-core/agents/qa.md ====================
 
-==================== START: .bmad-core/tasks/nfr-assess.md ====================
+==================== START: bmad-core/tasks/nfr-assess.md ====================
 <!-- Powered by BMAD™ Core -->
 # nfr-assess
 
@@ -455,9 +455,9 @@ performance_deep_dive:
 ```
 
 </details>
-==================== END: .bmad-core/tasks/nfr-assess.md ====================
+==================== END: bmad-core/tasks/nfr-assess.md ====================
 
-==================== START: .bmad-core/tasks/qa-gate.md ====================
+==================== START: bmad-core/tasks/qa-gate.md ====================
 <!-- Powered by BMAD™ Core -->
 # qa-gate
 
@@ -620,9 +620,9 @@ Gate: CONCERNS → qa.qaLocation/gates/{epic}.{story}-{slug}.yml
 - Always write to standard path
 - Always update story with gate reference
 - Clear, actionable findings
-==================== END: .bmad-core/tasks/qa-gate.md ====================
+==================== END: bmad-core/tasks/qa-gate.md ====================
 
-==================== START: .bmad-core/tasks/review-story.md ====================
+==================== START: bmad-core/tasks/review-story.md ====================
 <!-- Powered by BMAD™ Core -->
 # review-story
 
@@ -938,9 +938,9 @@ After review:
 3. Recommend status: "Ready for Done" or "Changes Required" (owner decides)
 4. If files were modified, list them in QA Results and ask Dev to update File List
 5. Always provide constructive feedback and actionable recommendations
-==================== END: .bmad-core/tasks/review-story.md ====================
+==================== END: bmad-core/tasks/review-story.md ====================
 
-==================== START: .bmad-core/tasks/risk-profile.md ====================
+==================== START: bmad-core/tasks/risk-profile.md ====================
 <!-- Powered by BMAD™ Core -->
 # risk-profile
 
@@ -1295,9 +1295,9 @@ Risk profile: qa.qaLocation/assessments/{epic}.{story}-risk-{YYYYMMDD}.md
 - Link risks to specific test requirements
 - Track residual risk after mitigation
 - Update risk profile as story evolves
-==================== END: .bmad-core/tasks/risk-profile.md ====================
+==================== END: bmad-core/tasks/risk-profile.md ====================
 
-==================== START: .bmad-core/tasks/test-design.md ====================
+==================== START: bmad-core/tasks/test-design.md ====================
 <!-- Powered by BMAD™ Core -->
 # test-design
 
@@ -1473,9 +1473,9 @@ Before finalizing, verify:
 - **Efficient coverage**: Test once at the right level
 - **Maintainability**: Consider long-term test maintenance
 - **Fast feedback**: Quick tests run first
-==================== END: .bmad-core/tasks/test-design.md ====================
+==================== END: bmad-core/tasks/test-design.md ====================
 
-==================== START: .bmad-core/tasks/trace-requirements.md ====================
+==================== START: bmad-core/tasks/trace-requirements.md ====================
 <!-- Powered by BMAD™ Core -->
 # trace-requirements
 
@@ -1741,9 +1741,9 @@ Trace matrix: qa.qaLocation/assessments/{epic}.{story}-trace-{YYYYMMDD}.md
 - Identify both presence and absence
 - Prioritize based on risk
 - Make recommendations actionable
-==================== END: .bmad-core/tasks/trace-requirements.md ====================
+==================== END: bmad-core/tasks/trace-requirements.md ====================
 
-==================== START: .bmad-core/templates/qa-gate-tmpl.yaml ====================
+==================== START: bmad-core/templates/qa-gate-tmpl.yaml ====================
 # <!-- Powered by BMAD™ Core -->
 template:
   id: qa-gate-template-v1
@@ -1847,9 +1847,9 @@ optional_fields_examples:
       future:  # Can be addressed later
         - action: "Consider caching for better performance"
           refs: ["services/data.service.ts"]
-==================== END: .bmad-core/templates/qa-gate-tmpl.yaml ====================
+==================== END: bmad-core/templates/qa-gate-tmpl.yaml ====================
 
-==================== START: .bmad-core/templates/story-tmpl.yaml ====================
+==================== START: bmad-core/templates/story-tmpl.yaml ====================
 # <!-- Powered by BMAD™ Core -->
 template:
   id: story-template-v2
@@ -1988,11 +1988,11 @@ sections:
     instruction: Results from QA Agent QA review of the completed story implementation
     owner: qa-agent
     editors: [qa-agent]
-==================== END: .bmad-core/templates/story-tmpl.yaml ====================
+==================== END: bmad-core/templates/story-tmpl.yaml ====================
 
-==================== START: .bmad-core/data/technical-preferences.md ====================
+==================== START: bmad-core/data/technical-preferences.md ====================
 <!-- Powered by BMAD™ Core -->
 # User-Defined Preferred Patterns and Preferences
 
 None Listed
-==================== END: .bmad-core/data/technical-preferences.md ====================
+==================== END: bmad-core/data/technical-preferences.md ====================

--- a/dist/agents/sm.txt
+++ b/dist/agents/sm.txt
@@ -8,13 +8,13 @@ You are now operating as a specialized AI agent from the BMad-Method framework. 
 
 2. **Resource Navigation**: This bundle contains all resources you need. Resources are marked with tags like:
 
-- `==================== START: .bmad-core/folder/filename.md ====================`
-- `==================== END: .bmad-core/folder/filename.md ====================`
+- `==================== START: bmad-core/folder/filename.md ====================`
+- `==================== END: bmad-core/folder/filename.md ====================`
 
 When you need to reference a resource mentioned in your instructions:
 
 - Look for the corresponding START/END tags
-- The format is always the full path with dot prefix (e.g., `.bmad-core/personas/analyst.md`, `.bmad-core/tasks/create-story.md`)
+- The format is always the full path with dot prefix (e.g., `bmad-core/personas/analyst.md`, `bmad-core/tasks/create-story.md`)
 - If a section is specified (e.g., `{root}/tasks/create-story.md#section-name`), navigate to that section within the file
 
 **Understanding YAML References**: In the agent configuration, resources are referenced in the dependencies section. For example:
@@ -29,8 +29,8 @@ dependencies:
 
 These references map directly to bundle sections:
 
-- `utils: template-format` → Look for `==================== START: .bmad-core/utils/template-format.md ====================`
-- `tasks: create-story` → Look for `==================== START: .bmad-core/tasks/create-story.md ====================`
+- `utils: template-format` → Look for `==================== START: bmad-core/utils/template-format.md ====================`
+- `tasks: create-story` → Look for `==================== START: bmad-core/tasks/create-story.md ====================`
 
 3. **Execution Context**: You are operating in a web environment. All your capabilities and knowledge are contained within this bundle. Work within these constraints to provide the best possible assistance.
 
@@ -39,7 +39,7 @@ These references map directly to bundle sections:
 ---
 
 
-==================== START: .bmad-core/agents/sm.md ====================
+==================== START: bmad-core/agents/sm.md ====================
 # sm
 
 CRITICAL: Read the full YAML, start activation to alter your state of being, follow startup section instructions, stay in this being until told to exit this mode:
@@ -82,15 +82,15 @@ dependencies:
   templates:
     - story-tmpl.yaml
 ```
-==================== END: .bmad-core/agents/sm.md ====================
+==================== END: bmad-core/agents/sm.md ====================
 
-==================== START: .bmad-core/tasks/correct-course.md ====================
+==================== START: bmad-core/tasks/correct-course.md ====================
 <!-- Powered by BMAD™ Core -->
 # Correct Course Task
 
 ## Purpose
 
-- Guide a structured response to a change trigger using the `.bmad-core/checklists/change-checklist`.
+- Guide a structured response to a change trigger using the `bmad-core/checklists/change-checklist`.
 - Analyze the impacts of the change on epics, project artifacts, and the MVP, guided by the checklist's structure.
 - Explore potential solutions (e.g., adjust scope, rollback elements, re-scope features) as prompted by the checklist.
 - Draft specific, actionable proposed updates to any affected project artifacts (e.g., epics, user stories, PRD sections, architecture document sections) based on the analysis.
@@ -104,7 +104,7 @@ dependencies:
 - **Acknowledge Task & Inputs:**
   - Confirm with the user that the "Correct Course Task" (Change Navigation & Integration) is being initiated.
   - Verify the change trigger and ensure you have the user's initial explanation of the issue and its perceived impact.
-  - Confirm access to all relevant project artifacts (e.g., PRD, Epics/Stories, Architecture Documents, UI/UX Specifications) and, critically, the `.bmad-core/checklists/change-checklist`.
+  - Confirm access to all relevant project artifacts (e.g., PRD, Epics/Stories, Architecture Documents, UI/UX Specifications) and, critically, the `bmad-core/checklists/change-checklist`.
 - **Establish Interaction Mode:**
   - Ask the user their preferred interaction mode for this task:
     - **"Incrementally (Default & Recommended):** Shall we work through the change-checklist section by section, discussing findings and collaboratively drafting proposed changes for each relevant part before moving to the next? This allows for detailed, step-by-step refinement."
@@ -156,9 +156,9 @@ dependencies:
   - A summary of the change-checklist analysis (issue, impact, rationale for the chosen path).
   - Specific, clearly drafted proposed edits for all affected project artifacts.
 - **Implicit:** An annotated change-checklist (or the record of its completion) reflecting the discussions, findings, and decisions made during the process.
-==================== END: .bmad-core/tasks/correct-course.md ====================
+==================== END: bmad-core/tasks/correct-course.md ====================
 
-==================== START: .bmad-core/tasks/create-next-story.md ====================
+==================== START: bmad-core/tasks/create-next-story.md ====================
 <!-- Powered by BMAD™ Core -->
 # Create Next Story Task
 
@@ -170,7 +170,7 @@ To identify the next logical story based on project progress and epic definition
 
 ### 0. Load Core Configuration and Check Workflow
 
-- Load `.bmad-core/core-config.yaml` from the project root
+- Load `bmad-core/core-config.yaml` from the project root
 - If the file does not exist, HALT and inform the user: "core-config.yaml not found. This file is required for story creation. You can either: 1) Copy it from GITHUB bmad-core/core-config.yaml and configure it for your project OR 2) Run the BMad installer against your project to upgrade and add the file automatically. Please add and configure core-config.yaml before proceeding."
 - Extract key configurations: `devStoryLocation`, `prd.*`, `architecture.*`, `workflow.*`
 
@@ -264,17 +264,17 @@ ALWAYS cite source documents: `[Source: architecture/{filename}.md#{section}]`
 - Verify all source references are included for technical details
 - Ensure tasks align with both epic requirements and architecture constraints
 - Update status to "Draft" and save the story file
-- Execute `.bmad-core/tasks/execute-checklist` `.bmad-core/checklists/story-draft-checklist`
+- Execute `bmad-core/tasks/execute-checklist` `bmad-core/checklists/story-draft-checklist`
 - Provide summary to user including:
   - Story created: `{devStoryLocation}/{epicNum}.{storyNum}.story.md`
   - Status: Draft
   - Key technical components included from architecture docs
   - Any deviations or conflicts noted between epic and architecture
   - Checklist Results
-  - Next steps: For Complex stories, suggest the user carefully review the story draft and also optionally have the PO run the task `.bmad-core/tasks/validate-next-story`
-==================== END: .bmad-core/tasks/create-next-story.md ====================
+  - Next steps: For Complex stories, suggest the user carefully review the story draft and also optionally have the PO run the task `bmad-core/tasks/validate-next-story`
+==================== END: bmad-core/tasks/create-next-story.md ====================
 
-==================== START: .bmad-core/tasks/execute-checklist.md ====================
+==================== START: bmad-core/tasks/execute-checklist.md ====================
 <!-- Powered by BMAD™ Core -->
 # Checklist Validation Task
 
@@ -282,7 +282,7 @@ This task provides instructions for validating documentation against checklists.
 
 ## Available Checklists
 
-If the user asks or does not specify a specific checklist, list the checklists available to the agent persona. If the task is being run not with a specific agent, tell the user to check the .bmad-core/checklists folder to select the appropriate one to run.
+If the user asks or does not specify a specific checklist, list the checklists available to the agent persona. If the task is being run not with a specific agent, tell the user to check the bmad-core/checklists folder to select the appropriate one to run.
 
 ## Instructions
 
@@ -290,7 +290,7 @@ If the user asks or does not specify a specific checklist, list the checklists a
    - If user or the task being run provides a checklist name:
      - Try fuzzy matching (e.g. "architecture checklist" -> "architect-checklist")
      - If multiple matches found, ask user to clarify
-     - Load the appropriate checklist from .bmad-core/checklists/
+     - Load the appropriate checklist from bmad-core/checklists/
    - If no checklist specified:
      - Ask the user which checklist they want to use
      - Present the available options from the files in the checklists folder
@@ -362,9 +362,9 @@ The LLM will:
 - Execute the complete checklist validation
 - Present a final report with pass/fail rates and key findings
 - Offer to provide detailed analysis of any section, especially those with warnings or failures
-==================== END: .bmad-core/tasks/execute-checklist.md ====================
+==================== END: bmad-core/tasks/execute-checklist.md ====================
 
-==================== START: .bmad-core/templates/story-tmpl.yaml ====================
+==================== START: bmad-core/templates/story-tmpl.yaml ====================
 # <!-- Powered by BMAD™ Core -->
 template:
   id: story-template-v2
@@ -503,9 +503,9 @@ sections:
     instruction: Results from QA Agent QA review of the completed story implementation
     owner: qa-agent
     editors: [qa-agent]
-==================== END: .bmad-core/templates/story-tmpl.yaml ====================
+==================== END: bmad-core/templates/story-tmpl.yaml ====================
 
-==================== START: .bmad-core/checklists/story-draft-checklist.md ====================
+==================== START: bmad-core/checklists/story-draft-checklist.md ====================
 <!-- Powered by BMAD™ Core -->
 # Story Draft Checklist
 
@@ -660,4 +660,4 @@ Be pragmatic - perfect documentation doesn't exist, but it must be enough to pro
 - READY: The story provides sufficient context for implementation
 - NEEDS REVISION: The story requires updates (see issues)
 - BLOCKED: External information required (specify what information)
-==================== END: .bmad-core/checklists/story-draft-checklist.md ====================
+==================== END: bmad-core/checklists/story-draft-checklist.md ====================

--- a/dist/agents/ux-expert.txt
+++ b/dist/agents/ux-expert.txt
@@ -8,13 +8,13 @@ You are now operating as a specialized AI agent from the BMad-Method framework. 
 
 2. **Resource Navigation**: This bundle contains all resources you need. Resources are marked with tags like:
 
-- `==================== START: .bmad-core/folder/filename.md ====================`
-- `==================== END: .bmad-core/folder/filename.md ====================`
+- `==================== START: bmad-core/folder/filename.md ====================`
+- `==================== END: bmad-core/folder/filename.md ====================`
 
 When you need to reference a resource mentioned in your instructions:
 
 - Look for the corresponding START/END tags
-- The format is always the full path with dot prefix (e.g., `.bmad-core/personas/analyst.md`, `.bmad-core/tasks/create-story.md`)
+- The format is always the full path with dot prefix (e.g., `bmad-core/personas/analyst.md`, `bmad-core/tasks/create-story.md`)
 - If a section is specified (e.g., `{root}/tasks/create-story.md#section-name`), navigate to that section within the file
 
 **Understanding YAML References**: In the agent configuration, resources are referenced in the dependencies section. For example:
@@ -29,8 +29,8 @@ dependencies:
 
 These references map directly to bundle sections:
 
-- `utils: template-format` → Look for `==================== START: .bmad-core/utils/template-format.md ====================`
-- `tasks: create-story` → Look for `==================== START: .bmad-core/tasks/create-story.md ====================`
+- `utils: template-format` → Look for `==================== START: bmad-core/utils/template-format.md ====================`
+- `tasks: create-story` → Look for `==================== START: bmad-core/tasks/create-story.md ====================`
 
 3. **Execution Context**: You are operating in a web environment. All your capabilities and knowledge are contained within this bundle. Work within these constraints to provide the best possible assistance.
 
@@ -39,7 +39,7 @@ These references map directly to bundle sections:
 ---
 
 
-==================== START: .bmad-core/agents/ux-expert.md ====================
+==================== START: bmad-core/agents/ux-expert.md ====================
 # ux-expert
 
 CRITICAL: Read the full YAML, start activation to alter your state of being, follow startup section instructions, stay in this being until told to exit this mode:
@@ -86,9 +86,9 @@ dependencies:
   templates:
     - front-end-spec-tmpl.yaml
 ```
-==================== END: .bmad-core/agents/ux-expert.md ====================
+==================== END: bmad-core/agents/ux-expert.md ====================
 
-==================== START: .bmad-core/tasks/create-doc.md ====================
+==================== START: bmad-core/tasks/create-doc.md ====================
 <!-- Powered by BMAD™ Core -->
 # Create Document from Template (YAML Driven)
 
@@ -107,7 +107,7 @@ When this task is invoked:
 
 ## Critical: Template Discovery
 
-If a YAML Template has not been provided, list all templates from .bmad-core/templates or ask the user to provide another.
+If a YAML Template has not been provided, list all templates from bmad-core/templates or ask the user to provide another.
 
 ## CRITICAL: Mandatory Elicitation Format
 
@@ -191,9 +191,9 @@ User can type `#yolo` to toggle to YOLO mode (process all sections at once).
 - Select options 2-9 from data/elicitation-methods only
 - Provide detailed rationale explaining decisions
 - End with "Select 1-9 or just type your question/feedback:"
-==================== END: .bmad-core/tasks/create-doc.md ====================
+==================== END: bmad-core/tasks/create-doc.md ====================
 
-==================== START: .bmad-core/tasks/execute-checklist.md ====================
+==================== START: bmad-core/tasks/execute-checklist.md ====================
 <!-- Powered by BMAD™ Core -->
 # Checklist Validation Task
 
@@ -201,7 +201,7 @@ This task provides instructions for validating documentation against checklists.
 
 ## Available Checklists
 
-If the user asks or does not specify a specific checklist, list the checklists available to the agent persona. If the task is being run not with a specific agent, tell the user to check the .bmad-core/checklists folder to select the appropriate one to run.
+If the user asks or does not specify a specific checklist, list the checklists available to the agent persona. If the task is being run not with a specific agent, tell the user to check the bmad-core/checklists folder to select the appropriate one to run.
 
 ## Instructions
 
@@ -209,7 +209,7 @@ If the user asks or does not specify a specific checklist, list the checklists a
    - If user or the task being run provides a checklist name:
      - Try fuzzy matching (e.g. "architecture checklist" -> "architect-checklist")
      - If multiple matches found, ask user to clarify
-     - Load the appropriate checklist from .bmad-core/checklists/
+     - Load the appropriate checklist from bmad-core/checklists/
    - If no checklist specified:
      - Ask the user which checklist they want to use
      - Present the available options from the files in the checklists folder
@@ -281,9 +281,9 @@ The LLM will:
 - Execute the complete checklist validation
 - Present a final report with pass/fail rates and key findings
 - Offer to provide detailed analysis of any section, especially those with warnings or failures
-==================== END: .bmad-core/tasks/execute-checklist.md ====================
+==================== END: bmad-core/tasks/execute-checklist.md ====================
 
-==================== START: .bmad-core/tasks/generate-ai-frontend-prompt.md ====================
+==================== START: bmad-core/tasks/generate-ai-frontend-prompt.md ====================
 <!-- Powered by BMAD™ Core -->
 # Create AI Frontend Prompt Task
 
@@ -336,9 +336,9 @@ You will now synthesize the inputs and the above principles into a final, compre
    - Output the complete, generated prompt in a clear, copy-pasteable format (e.g., a large code block).
    - Explain the structure of the prompt and why certain information was included, referencing the principles above.
    - <important_note>Conclude by reminding the user that all AI-generated code will require careful human review, testing, and refinement to be considered production-ready.</important_note>
-==================== END: .bmad-core/tasks/generate-ai-frontend-prompt.md ====================
+==================== END: bmad-core/tasks/generate-ai-frontend-prompt.md ====================
 
-==================== START: .bmad-core/templates/front-end-spec-tmpl.yaml ====================
+==================== START: bmad-core/templates/front-end-spec-tmpl.yaml ====================
 # <!-- Powered by BMAD™ Core -->
 template:
   id: frontend-spec-template-v2
@@ -689,11 +689,11 @@ sections:
   - id: checklist-results
     title: Checklist Results
     instruction: If a UI/UX checklist exists, run it against this document and report results here.
-==================== END: .bmad-core/templates/front-end-spec-tmpl.yaml ====================
+==================== END: bmad-core/templates/front-end-spec-tmpl.yaml ====================
 
-==================== START: .bmad-core/data/technical-preferences.md ====================
+==================== START: bmad-core/data/technical-preferences.md ====================
 <!-- Powered by BMAD™ Core -->
 # User-Defined Preferred Patterns and Preferences
 
 None Listed
-==================== END: .bmad-core/data/technical-preferences.md ====================
+==================== END: bmad-core/data/technical-preferences.md ====================

--- a/dist/expansion-packs/bmad-2d-phaser-game-dev/agents/game-designer.txt
+++ b/dist/expansion-packs/bmad-2d-phaser-game-dev/agents/game-designer.txt
@@ -113,7 +113,7 @@ When this task is invoked:
 
 ## Critical: Template Discovery
 
-If a YAML Template has not been provided, list all templates from .bmad-core/templates or ask the user to provide another.
+If a YAML Template has not been provided, list all templates from bmad-core/templates or ask the user to provide another.
 
 ## CRITICAL: Mandatory Elicitation Format
 

--- a/dist/expansion-packs/bmad-2d-phaser-game-dev/teams/phaser-2d-nodejs-game-team.txt
+++ b/dist/expansion-packs/bmad-2d-phaser-game-dev/teams/phaser-2d-nodejs-game-team.txt
@@ -1121,7 +1121,7 @@ When this task is invoked:
 
 ## Critical: Template Discovery
 
-If a YAML Template has not been provided, list all templates from .bmad-core/templates or ask the user to provide another.
+If a YAML Template has not been provided, list all templates from bmad-core/templates or ask the user to provide another.
 
 ## CRITICAL: Mandatory Elicitation Format
 

--- a/dist/expansion-packs/bmad-2d-unity-game-dev/agents/game-architect.txt
+++ b/dist/expansion-packs/bmad-2d-unity-game-dev/agents/game-architect.txt
@@ -121,7 +121,7 @@ When this task is invoked:
 
 ## Critical: Template Discovery
 
-If a YAML Template has not been provided, list all templates from .bmad-core/templates or ask the user to provide another.
+If a YAML Template has not been provided, list all templates from bmad-core/templates or ask the user to provide another.
 
 ## CRITICAL: Mandatory Elicitation Format
 
@@ -3382,7 +3382,7 @@ npx bmad-method install
 
 **Verify Game Development Installation**:
 
-- `.bmad-core/` folder created with all core agents
+- `bmad-core/` folder created with all core agents
 - `.bmad-2d-unity-game-dev/` folder with game development agents
 - IDE-specific integration files created
 - Game development agents available with `/bmad2du` prefix (per config.yaml)

--- a/dist/expansion-packs/bmad-2d-unity-game-dev/agents/game-designer.txt
+++ b/dist/expansion-packs/bmad-2d-unity-game-dev/agents/game-designer.txt
@@ -118,7 +118,7 @@ When this task is invoked:
 
 ## Critical: Template Discovery
 
-If a YAML Template has not been provided, list all templates from .bmad-core/templates or ask the user to provide another.
+If a YAML Template has not been provided, list all templates from bmad-core/templates or ask the user to provide another.
 
 ## CRITICAL: Mandatory Elicitation Format
 
@@ -3069,7 +3069,7 @@ npx bmad-method install
 
 **Verify Game Development Installation**:
 
-- `.bmad-core/` folder created with all core agents
+- `bmad-core/` folder created with all core agents
 - `.bmad-2d-unity-game-dev/` folder with game development agents
 - IDE-specific integration files created
 - Game development agents available with `/bmad2du` prefix (per config.yaml)

--- a/dist/expansion-packs/bmad-2d-unity-game-dev/agents/game-developer.txt
+++ b/dist/expansion-packs/bmad-2d-unity-game-dev/agents/game-developer.txt
@@ -198,7 +198,7 @@ To comprehensively validate a story draft before implementation begins, ensuring
 
 ### 0. Load Core Configuration and Inputs
 
-- Load `.bmad-core/core-config.yaml`
+- Load `bmad-core/core-config.yaml`
 - If the file does not exist, HALT and inform the user: "core-config.yaml not found. This file is required for story validation."
 - Extract key configurations: `devStoryLocation`, `prd.*`, `architecture.*`
 - Identify and load the following inputs:

--- a/dist/expansion-packs/bmad-2d-unity-game-dev/teams/unity-2d-game-team.txt
+++ b/dist/expansion-packs/bmad-2d-unity-game-dev/teams/unity-2d-game-team.txt
@@ -610,7 +610,7 @@ npx bmad-method install
 
 **Verify Game Development Installation**:
 
-- `.bmad-core/` folder created with all core agents
+- `bmad-core/` folder created with all core agents
 - `.bmad-2d-unity-game-dev/` folder with game development agents
 - IDE-specific integration files created
 - Game development agents available with `/bmad2du` prefix (per config.yaml)
@@ -1704,7 +1704,7 @@ When this task is invoked:
 
 ## Critical: Template Discovery
 
-If a YAML Template has not been provided, list all templates from .bmad-core/templates or ask the user to provide another.
+If a YAML Template has not been provided, list all templates from bmad-core/templates or ask the user to provide another.
 
 ## CRITICAL: Mandatory Elicitation Format
 
@@ -7903,7 +7903,7 @@ To comprehensively validate a story draft before implementation begins, ensuring
 
 ### 0. Load Core Configuration and Inputs
 
-- Load `.bmad-core/core-config.yaml`
+- Load `bmad-core/core-config.yaml`
 - If the file does not exist, HALT and inform the user: "core-config.yaml not found. This file is required for story validation."
 - Extract key configurations: `devStoryLocation`, `prd.*`, `architecture.*`
 - Identify and load the following inputs:
@@ -14188,7 +14188,7 @@ npx bmad-method install
 
 **Verify Game Development Installation**:
 
-- `.bmad-core/` folder created with all core agents
+- `bmad-core/` folder created with all core agents
 - `.bmad-2d-unity-game-dev/` folder with game development agents
 - IDE-specific integration files created
 - Game development agents available with `/bmad2du` prefix (per config.yaml)

--- a/dist/expansion-packs/bmad-infrastructure-devops/agents/infra-devops-platform.txt
+++ b/dist/expansion-packs/bmad-infrastructure-devops/agents/infra-devops-platform.txt
@@ -119,7 +119,7 @@ When this task is invoked:
 
 ## Critical: Template Discovery
 
-If a YAML Template has not been provided, list all templates from .bmad-core/templates or ask the user to provide another.
+If a YAML Template has not been provided, list all templates from bmad-core/templates or ask the user to provide another.
 
 ## CRITICAL: Mandatory Elicitation Format
 

--- a/dist/teams/team-all.txt
+++ b/dist/teams/team-all.txt
@@ -8,13 +8,13 @@ You are now operating as a specialized AI agent from the BMad-Method framework. 
 
 2. **Resource Navigation**: This bundle contains all resources you need. Resources are marked with tags like:
 
-- `==================== START: .bmad-core/folder/filename.md ====================`
-- `==================== END: .bmad-core/folder/filename.md ====================`
+- `==================== START: bmad-core/folder/filename.md ====================`
+- `==================== END: bmad-core/folder/filename.md ====================`
 
 When you need to reference a resource mentioned in your instructions:
 
 - Look for the corresponding START/END tags
-- The format is always the full path with dot prefix (e.g., `.bmad-core/personas/analyst.md`, `.bmad-core/tasks/create-story.md`)
+- The format is always the full path with dot prefix (e.g., `bmad-core/personas/analyst.md`, `bmad-core/tasks/create-story.md`)
 - If a section is specified (e.g., `{root}/tasks/create-story.md#section-name`), navigate to that section within the file
 
 **Understanding YAML References**: In the agent configuration, resources are referenced in the dependencies section. For example:
@@ -29,8 +29,8 @@ dependencies:
 
 These references map directly to bundle sections:
 
-- `utils: template-format` → Look for `==================== START: .bmad-core/utils/template-format.md ====================`
-- `tasks: create-story` → Look for `==================== START: .bmad-core/tasks/create-story.md ====================`
+- `utils: template-format` → Look for `==================== START: bmad-core/utils/template-format.md ====================`
+- `tasks: create-story` → Look for `==================== START: bmad-core/tasks/create-story.md ====================`
 
 3. **Execution Context**: You are operating in a web environment. All your capabilities and knowledge are contained within this bundle. Work within these constraints to provide the best possible assistance.
 
@@ -39,7 +39,7 @@ These references map directly to bundle sections:
 ---
 
 
-==================== START: .bmad-core/agent-teams/team-all.yaml ====================
+==================== START: bmad-core/agent-teams/team-all.yaml ====================
 # <!-- Powered by BMAD™ Core -->
 bundle:
   name: Team All
@@ -55,9 +55,9 @@ workflows:
   - greenfield-fullstack.yaml
   - greenfield-service.yaml
   - greenfield-ui.yaml
-==================== END: .bmad-core/agent-teams/team-all.yaml ====================
+==================== END: bmad-core/agent-teams/team-all.yaml ====================
 
-==================== START: .bmad-core/agents/bmad-orchestrator.md ====================
+==================== START: bmad-core/agents/bmad-orchestrator.md ====================
 # bmad-orchestrator
 
 CRITICAL: Read the full YAML, start activation to alter your state of being, follow startup section instructions, stay in this being until told to exit this mode:
@@ -182,9 +182,9 @@ dependencies:
   utils:
     - workflow-management.md
 ```
-==================== END: .bmad-core/agents/bmad-orchestrator.md ====================
+==================== END: bmad-core/agents/bmad-orchestrator.md ====================
 
-==================== START: .bmad-core/agents/analyst.md ====================
+==================== START: bmad-core/agents/analyst.md ====================
 # analyst
 
 CRITICAL: Read the full YAML, start activation to alter your state of being, follow startup section instructions, stay in this being until told to exit this mode:
@@ -246,9 +246,9 @@ dependencies:
     - market-research-tmpl.yaml
     - project-brief-tmpl.yaml
 ```
-==================== END: .bmad-core/agents/analyst.md ====================
+==================== END: bmad-core/agents/analyst.md ====================
 
-==================== START: .bmad-core/agents/architect.md ====================
+==================== START: bmad-core/agents/architect.md ====================
 # architect
 
 CRITICAL: Read the full YAML, start activation to alter your state of being, follow startup section instructions, stay in this being until told to exit this mode:
@@ -311,9 +311,9 @@ dependencies:
     - front-end-architecture-tmpl.yaml
     - fullstack-architecture-tmpl.yaml
 ```
-==================== END: .bmad-core/agents/architect.md ====================
+==================== END: bmad-core/agents/architect.md ====================
 
-==================== START: .bmad-core/agents/dev.md ====================
+==================== START: bmad-core/agents/dev.md ====================
 # dev
 
 CRITICAL: Read the full YAML, start activation to alter your state of being, follow startup section instructions, stay in this being until told to exit this mode:
@@ -364,9 +364,9 @@ dependencies:
     - execute-checklist.md
     - validate-next-story.md
 ```
-==================== END: .bmad-core/agents/dev.md ====================
+==================== END: bmad-core/agents/dev.md ====================
 
-==================== START: .bmad-core/agents/pm.md ====================
+==================== START: bmad-core/agents/pm.md ====================
 # pm
 
 CRITICAL: Read the full YAML, start activation to alter your state of being, follow startup section instructions, stay in this being until told to exit this mode:
@@ -428,9 +428,9 @@ dependencies:
     - brownfield-prd-tmpl.yaml
     - prd-tmpl.yaml
 ```
-==================== END: .bmad-core/agents/pm.md ====================
+==================== END: bmad-core/agents/pm.md ====================
 
-==================== START: .bmad-core/agents/po.md ====================
+==================== START: bmad-core/agents/po.md ====================
 # po
 
 CRITICAL: Read the full YAML, start activation to alter your state of being, follow startup section instructions, stay in this being until told to exit this mode:
@@ -487,9 +487,9 @@ dependencies:
   templates:
     - story-tmpl.yaml
 ```
-==================== END: .bmad-core/agents/po.md ====================
+==================== END: bmad-core/agents/po.md ====================
 
-==================== START: .bmad-core/agents/qa.md ====================
+==================== START: bmad-core/agents/qa.md ====================
 # qa
 
 CRITICAL: Read the full YAML, start activation to alter your state of being, follow startup section instructions, stay in this being until told to exit this mode:
@@ -558,9 +558,9 @@ dependencies:
     - qa-gate-tmpl.yaml
     - story-tmpl.yaml
 ```
-==================== END: .bmad-core/agents/qa.md ====================
+==================== END: bmad-core/agents/qa.md ====================
 
-==================== START: .bmad-core/agents/sm.md ====================
+==================== START: bmad-core/agents/sm.md ====================
 # sm
 
 CRITICAL: Read the full YAML, start activation to alter your state of being, follow startup section instructions, stay in this being until told to exit this mode:
@@ -603,9 +603,9 @@ dependencies:
   templates:
     - story-tmpl.yaml
 ```
-==================== END: .bmad-core/agents/sm.md ====================
+==================== END: bmad-core/agents/sm.md ====================
 
-==================== START: .bmad-core/agents/ux-expert.md ====================
+==================== START: bmad-core/agents/ux-expert.md ====================
 # ux-expert
 
 CRITICAL: Read the full YAML, start activation to alter your state of being, follow startup section instructions, stay in this being until told to exit this mode:
@@ -652,9 +652,9 @@ dependencies:
   templates:
     - front-end-spec-tmpl.yaml
 ```
-==================== END: .bmad-core/agents/ux-expert.md ====================
+==================== END: bmad-core/agents/ux-expert.md ====================
 
-==================== START: .bmad-core/tasks/advanced-elicitation.md ====================
+==================== START: bmad-core/tasks/advanced-elicitation.md ====================
 <!-- Powered by BMAD™ Core -->
 # Advanced Elicitation Task
 
@@ -773,9 +773,9 @@ Choose a number (0-8) or 9 to proceed:
 - **Stay Relevant**: Tie all elicitation back to the specific content being analyzed
 - **Identify Personas**: For multi-persona methods, clearly identify which viewpoint is speaking
 - **Maintain Flow**: Keep the process moving efficiently
-==================== END: .bmad-core/tasks/advanced-elicitation.md ====================
+==================== END: bmad-core/tasks/advanced-elicitation.md ====================
 
-==================== START: .bmad-core/tasks/create-doc.md ====================
+==================== START: bmad-core/tasks/create-doc.md ====================
 <!-- Powered by BMAD™ Core -->
 # Create Document from Template (YAML Driven)
 
@@ -794,7 +794,7 @@ When this task is invoked:
 
 ## Critical: Template Discovery
 
-If a YAML Template has not been provided, list all templates from .bmad-core/templates or ask the user to provide another.
+If a YAML Template has not been provided, list all templates from bmad-core/templates or ask the user to provide another.
 
 ## CRITICAL: Mandatory Elicitation Format
 
@@ -878,9 +878,9 @@ User can type `#yolo` to toggle to YOLO mode (process all sections at once).
 - Select options 2-9 from data/elicitation-methods only
 - Provide detailed rationale explaining decisions
 - End with "Select 1-9 or just type your question/feedback:"
-==================== END: .bmad-core/tasks/create-doc.md ====================
+==================== END: bmad-core/tasks/create-doc.md ====================
 
-==================== START: .bmad-core/tasks/kb-mode-interaction.md ====================
+==================== START: bmad-core/tasks/kb-mode-interaction.md ====================
 <!-- Powered by BMAD™ Core -->
 # KB Mode Interaction Task
 
@@ -957,9 +957,9 @@ Or ask me about anything else related to BMad-Method!
 **User**: Tell me about workflows
 
 **Assistant**: [Provides focused information about workflows from the KB, then offers to explore specific workflow types or related topics]
-==================== END: .bmad-core/tasks/kb-mode-interaction.md ====================
+==================== END: bmad-core/tasks/kb-mode-interaction.md ====================
 
-==================== START: .bmad-core/data/bmad-kb.md ====================
+==================== START: bmad-core/data/bmad-kb.md ====================
 <!-- Powered by BMAD™ Core -->
 # BMAD™ Knowledge Base
 
@@ -1068,7 +1068,7 @@ npx bmad-method install
 
 **Verify Installation**:
 
-- `.bmad-core/` folder created with all agents
+- `bmad-core/` folder created with all agents
 - IDE-specific integration files created
 - All agent commands/rules/modes available
 
@@ -1767,9 +1767,9 @@ Use the **expansion-creator** pack to build your own:
 - **Documentation**: Check `docs/` folder for project-specific context
 - **Community**: Discord and GitHub resources available for support
 - **Contributing**: See `CONTRIBUTING.md` for full guidelines
-==================== END: .bmad-core/data/bmad-kb.md ====================
+==================== END: bmad-core/data/bmad-kb.md ====================
 
-==================== START: .bmad-core/data/elicitation-methods.md ====================
+==================== START: bmad-core/data/elicitation-methods.md ====================
 <!-- Powered by BMAD™ Core -->
 # Elicitation Methods Data
 
@@ -1925,9 +1925,9 @@ Use the **expansion-creator** pack to build your own:
 - Acknowledge choice to finalize current work
 - Accept output as-is or move to next step
 - Prepare to continue without additional elicitation
-==================== END: .bmad-core/data/elicitation-methods.md ====================
+==================== END: bmad-core/data/elicitation-methods.md ====================
 
-==================== START: .bmad-core/utils/workflow-management.md ====================
+==================== START: bmad-core/utils/workflow-management.md ====================
 <!-- Powered by BMAD™ Core -->
 # Workflow Management
 
@@ -1998,9 +1998,9 @@ Handle conditional paths by asking clarifying questions when needed.
 ## Agent Integration
 
 Agents should be workflow-aware: know active workflow, their role, access artifacts, understand expected outputs.
-==================== END: .bmad-core/utils/workflow-management.md ====================
+==================== END: bmad-core/utils/workflow-management.md ====================
 
-==================== START: .bmad-core/tasks/create-deep-research-prompt.md ====================
+==================== START: bmad-core/tasks/create-deep-research-prompt.md ====================
 <!-- Powered by BMAD™ Core -->
 # Create Deep Research Prompt Task
 
@@ -2280,9 +2280,9 @@ CRITICAL: collaborate with the user to develop specific, actionable research que
 - Balance comprehensiveness with focus
 - Document assumptions and limitations clearly
 - Plan for iterative refinement based on initial findings
-==================== END: .bmad-core/tasks/create-deep-research-prompt.md ====================
+==================== END: bmad-core/tasks/create-deep-research-prompt.md ====================
 
-==================== START: .bmad-core/tasks/document-project.md ====================
+==================== START: bmad-core/tasks/document-project.md ====================
 <!-- Powered by BMAD™ Core -->
 # Document an Existing Project
 
@@ -2627,13 +2627,13 @@ Apply the advanced elicitation task after major sections to refine based on user
 - Documents technical debt, workarounds, and constraints honestly
 - For brownfield projects with PRD: Provides clear enhancement impact analysis
 - The goal is PRACTICAL documentation for AI agents doing real work
-==================== END: .bmad-core/tasks/document-project.md ====================
+==================== END: bmad-core/tasks/document-project.md ====================
 
-==================== START: .bmad-core/tasks/facilitate-brainstorming-session.md ====================
+==================== START: bmad-core/tasks/facilitate-brainstorming-session.md ====================
 <!-- Powered by BMAD™ Core -->
 ---
 docOutputLocation: docs/brainstorming-session-results.md
-template: '.bmad-core/templates/brainstorming-output-tmpl.yaml'
+template: 'bmad-core/templates/brainstorming-output-tmpl.yaml'
 ---
 
 # Facilitate Brainstorming Session Task
@@ -2767,9 +2767,9 @@ Generate structured document with these sections:
 - Always ask before switching techniques: "Ready to try a different approach?"
 - Offer options: "Should we explore this idea deeper or generate more alternatives?"
 - Respect their process and timing
-==================== END: .bmad-core/tasks/facilitate-brainstorming-session.md ====================
+==================== END: bmad-core/tasks/facilitate-brainstorming-session.md ====================
 
-==================== START: .bmad-core/templates/brainstorming-output-tmpl.yaml ====================
+==================== START: bmad-core/templates/brainstorming-output-tmpl.yaml ====================
 template:
   id: brainstorming-output-template-v2
   name: Brainstorming Session Results
@@ -2926,9 +2926,9 @@ sections:
       ---
 
       *Session facilitated using the BMAD-METHOD™ brainstorming framework*
-==================== END: .bmad-core/templates/brainstorming-output-tmpl.yaml ====================
+==================== END: bmad-core/templates/brainstorming-output-tmpl.yaml ====================
 
-==================== START: .bmad-core/templates/competitor-analysis-tmpl.yaml ====================
+==================== START: bmad-core/templates/competitor-analysis-tmpl.yaml ====================
 # <!-- Powered by BMAD™ Core -->
 template:
   id: competitor-analysis-template-v2
@@ -3236,9 +3236,9 @@ sections:
           - Weekly: {{weekly_items}}
           - Monthly: {{monthly_items}}
           - Quarterly: {{quarterly_analysis}}
-==================== END: .bmad-core/templates/competitor-analysis-tmpl.yaml ====================
+==================== END: bmad-core/templates/competitor-analysis-tmpl.yaml ====================
 
-==================== START: .bmad-core/templates/market-research-tmpl.yaml ====================
+==================== START: bmad-core/templates/market-research-tmpl.yaml ====================
 # <!-- Powered by BMAD™ Core -->
 template:
   id: market-research-template-v2
@@ -3492,9 +3492,9 @@ sections:
       - id: additional-analysis
         title: C. Additional Analysis
         instruction: Any supplementary analysis not included in main body
-==================== END: .bmad-core/templates/market-research-tmpl.yaml ====================
+==================== END: bmad-core/templates/market-research-tmpl.yaml ====================
 
-==================== START: .bmad-core/templates/project-brief-tmpl.yaml ====================
+==================== START: bmad-core/templates/project-brief-tmpl.yaml ====================
 # <!-- Powered by BMAD™ Core -->
 template:
   id: project-brief-template-v2
@@ -3717,9 +3717,9 @@ sections:
         title: PM Handoff
         content: |
           This Project Brief provides the full context for {{project_name}}. Please start in 'PRD Generation Mode', review the brief thoroughly to work with the user to create the PRD section by section as the template indicates, asking for any necessary clarification or suggesting improvements.
-==================== END: .bmad-core/templates/project-brief-tmpl.yaml ====================
+==================== END: bmad-core/templates/project-brief-tmpl.yaml ====================
 
-==================== START: .bmad-core/data/brainstorming-techniques.md ====================
+==================== START: bmad-core/data/brainstorming-techniques.md ====================
 <!-- Powered by BMAD™ Core -->
 # Brainstorming Techniques Data
 
@@ -3757,9 +3757,9 @@ sections:
 18. **Resource Constraints**: "What if you had only $10 and 1 hour?"
 19. **Metaphor Mapping**: Use extended metaphors to explore solutions
 20. **Question Storming**: Generate questions instead of answers first
-==================== END: .bmad-core/data/brainstorming-techniques.md ====================
+==================== END: bmad-core/data/brainstorming-techniques.md ====================
 
-==================== START: .bmad-core/tasks/execute-checklist.md ====================
+==================== START: bmad-core/tasks/execute-checklist.md ====================
 <!-- Powered by BMAD™ Core -->
 # Checklist Validation Task
 
@@ -3767,7 +3767,7 @@ This task provides instructions for validating documentation against checklists.
 
 ## Available Checklists
 
-If the user asks or does not specify a specific checklist, list the checklists available to the agent persona. If the task is being run not with a specific agent, tell the user to check the .bmad-core/checklists folder to select the appropriate one to run.
+If the user asks or does not specify a specific checklist, list the checklists available to the agent persona. If the task is being run not with a specific agent, tell the user to check the bmad-core/checklists folder to select the appropriate one to run.
 
 ## Instructions
 
@@ -3775,7 +3775,7 @@ If the user asks or does not specify a specific checklist, list the checklists a
    - If user or the task being run provides a checklist name:
      - Try fuzzy matching (e.g. "architecture checklist" -> "architect-checklist")
      - If multiple matches found, ask user to clarify
-     - Load the appropriate checklist from .bmad-core/checklists/
+     - Load the appropriate checklist from bmad-core/checklists/
    - If no checklist specified:
      - Ask the user which checklist they want to use
      - Present the available options from the files in the checklists folder
@@ -3847,9 +3847,9 @@ The LLM will:
 - Execute the complete checklist validation
 - Present a final report with pass/fail rates and key findings
 - Offer to provide detailed analysis of any section, especially those with warnings or failures
-==================== END: .bmad-core/tasks/execute-checklist.md ====================
+==================== END: bmad-core/tasks/execute-checklist.md ====================
 
-==================== START: .bmad-core/templates/architecture-tmpl.yaml ====================
+==================== START: bmad-core/templates/architecture-tmpl.yaml ====================
 # <!-- Powered by BMAD™ Core -->
 template:
   id: architecture-template-v2
@@ -3980,7 +3980,7 @@ sections:
     instruction: |
       This is the DEFINITIVE technology selection section. Work with the user to make specific choices:
 
-      1. Review PRD technical assumptions and any preferences from .bmad-core/data/technical-preferences.yaml or an attached technical-preferences
+      1. Review PRD technical assumptions and any preferences from bmad-core/data/technical-preferences.yaml or an attached technical-preferences
       2. For each category, present 2-3 viable options with pros/cons
       3. Make a clear recommendation based on project needs
       4. Get explicit user approval for each selection
@@ -4501,9 +4501,9 @@ sections:
           - Key UI requirements from PRD
           - Any frontend-specific decisions made here
           - Request for detailed frontend architecture
-==================== END: .bmad-core/templates/architecture-tmpl.yaml ====================
+==================== END: bmad-core/templates/architecture-tmpl.yaml ====================
 
-==================== START: .bmad-core/templates/brownfield-architecture-tmpl.yaml ====================
+==================== START: bmad-core/templates/brownfield-architecture-tmpl.yaml ====================
 # <!-- Powered by BMAD™ Core -->
 template:
   id: brownfield-architecture-template-v2
@@ -4981,9 +4981,9 @@ sections:
           - Key technical decisions based on real project constraints
           - Existing system compatibility requirements with specific verification steps
           - Clear sequencing of implementation to minimize risk to existing functionality
-==================== END: .bmad-core/templates/brownfield-architecture-tmpl.yaml ====================
+==================== END: bmad-core/templates/brownfield-architecture-tmpl.yaml ====================
 
-==================== START: .bmad-core/templates/front-end-architecture-tmpl.yaml ====================
+==================== START: bmad-core/templates/front-end-architecture-tmpl.yaml ====================
 # <!-- Powered by BMAD™ Core -->
 template:
   id: frontend-architecture-template-v2
@@ -5203,9 +5203,9 @@ sections:
           - Key import patterns
           - File naming conventions
           - Project-specific patterns and utilities
-==================== END: .bmad-core/templates/front-end-architecture-tmpl.yaml ====================
+==================== END: bmad-core/templates/front-end-architecture-tmpl.yaml ====================
 
-==================== START: .bmad-core/templates/fullstack-architecture-tmpl.yaml ====================
+==================== START: bmad-core/templates/fullstack-architecture-tmpl.yaml ====================
 # <!-- Powered by BMAD™ Core -->
 template:
   id: fullstack-architecture-template-v2
@@ -6030,9 +6030,9 @@ sections:
   - id: checklist-results
     title: Checklist Results Report
     instruction: Before running the checklist, offer to output the full architecture document. Once user confirms, execute the architect-checklist and populate results here.
-==================== END: .bmad-core/templates/fullstack-architecture-tmpl.yaml ====================
+==================== END: bmad-core/templates/fullstack-architecture-tmpl.yaml ====================
 
-==================== START: .bmad-core/checklists/architect-checklist.md ====================
+==================== START: bmad-core/checklists/architect-checklist.md ====================
 <!-- Powered by BMAD™ Core -->
 # Architect Solution Validation Checklist
 
@@ -6472,16 +6472,16 @@ Now that you've completed the checklist, generate a comprehensive validation rep
    - Component design clarity
 
 After presenting the report, ask the user if they would like detailed analysis of any specific section, especially those with warnings or failures.]]
-==================== END: .bmad-core/checklists/architect-checklist.md ====================
+==================== END: bmad-core/checklists/architect-checklist.md ====================
 
-==================== START: .bmad-core/data/technical-preferences.md ====================
+==================== START: bmad-core/data/technical-preferences.md ====================
 <!-- Powered by BMAD™ Core -->
 # User-Defined Preferred Patterns and Preferences
 
 None Listed
-==================== END: .bmad-core/data/technical-preferences.md ====================
+==================== END: bmad-core/data/technical-preferences.md ====================
 
-==================== START: .bmad-core/tasks/apply-qa-fixes.md ====================
+==================== START: bmad-core/tasks/apply-qa-fixes.md ====================
 <!-- Powered by BMAD™ Core -->
 # apply-qa-fixes
 
@@ -6631,9 +6631,9 @@ Fix plan:
 - Tests validate behavior and close gaps
 - Strict adherence to allowed story update areas
 - Gate ownership remains with QA; Dev signals readiness via Status
-==================== END: .bmad-core/tasks/apply-qa-fixes.md ====================
+==================== END: bmad-core/tasks/apply-qa-fixes.md ====================
 
-==================== START: .bmad-core/tasks/validate-next-story.md ====================
+==================== START: bmad-core/tasks/validate-next-story.md ====================
 <!-- Powered by BMAD™ Core -->
 # Validate Next Story Task
 
@@ -6645,7 +6645,7 @@ To comprehensively validate a story draft before implementation begins, ensuring
 
 ### 0. Load Core Configuration and Inputs
 
-- Load `.bmad-core/core-config.yaml`
+- Load `bmad-core/core-config.yaml`
 - If the file does not exist, HALT and inform the user: "core-config.yaml not found. This file is required for story validation."
 - Extract key configurations: `devStoryLocation`, `prd.*`, `architecture.*`
 - Identify and load the following inputs:
@@ -6769,9 +6769,9 @@ Provide a structured validation report including:
 - **NO-GO**: Story requires fixes before implementation
 - **Implementation Readiness Score**: 1-10 scale
 - **Confidence Level**: High/Medium/Low for successful implementation
-==================== END: .bmad-core/tasks/validate-next-story.md ====================
+==================== END: bmad-core/tasks/validate-next-story.md ====================
 
-==================== START: .bmad-core/checklists/story-dod-checklist.md ====================
+==================== START: bmad-core/checklists/story-dod-checklist.md ====================
 <!-- Powered by BMAD™ Core -->
 # Story Definition of Done (DoD) Checklist
 
@@ -6867,9 +6867,9 @@ After completing the checklist:
 Be honest - it's better to flag issues now than have them discovered later.]]
 
 - [ ] I, the Developer Agent, confirm that all applicable items above have been addressed.
-==================== END: .bmad-core/checklists/story-dod-checklist.md ====================
+==================== END: bmad-core/checklists/story-dod-checklist.md ====================
 
-==================== START: .bmad-core/tasks/brownfield-create-epic.md ====================
+==================== START: bmad-core/tasks/brownfield-create-epic.md ====================
 <!-- Powered by BMAD™ Core -->
 # Create Brownfield Epic Task
 
@@ -7031,9 +7031,9 @@ The epic creation is successful when:
 - If the scope grows beyond 3 stories, consider the full brownfield PRD process
 - Always prioritize existing system integrity over new functionality
 - When in doubt about scope or complexity, escalate to full brownfield planning
-==================== END: .bmad-core/tasks/brownfield-create-epic.md ====================
+==================== END: bmad-core/tasks/brownfield-create-epic.md ====================
 
-==================== START: .bmad-core/tasks/brownfield-create-story.md ====================
+==================== START: bmad-core/tasks/brownfield-create-story.md ====================
 <!-- Powered by BMAD™ Core -->
 # Create Brownfield Story Task
 
@@ -7182,15 +7182,15 @@ The story creation is successful when:
 - Always prioritize existing system integrity
 - When in doubt about integration complexity, use brownfield-create-epic instead
 - Stories should take no more than 4 hours of focused development work
-==================== END: .bmad-core/tasks/brownfield-create-story.md ====================
+==================== END: bmad-core/tasks/brownfield-create-story.md ====================
 
-==================== START: .bmad-core/tasks/correct-course.md ====================
+==================== START: bmad-core/tasks/correct-course.md ====================
 <!-- Powered by BMAD™ Core -->
 # Correct Course Task
 
 ## Purpose
 
-- Guide a structured response to a change trigger using the `.bmad-core/checklists/change-checklist`.
+- Guide a structured response to a change trigger using the `bmad-core/checklists/change-checklist`.
 - Analyze the impacts of the change on epics, project artifacts, and the MVP, guided by the checklist's structure.
 - Explore potential solutions (e.g., adjust scope, rollback elements, re-scope features) as prompted by the checklist.
 - Draft specific, actionable proposed updates to any affected project artifacts (e.g., epics, user stories, PRD sections, architecture document sections) based on the analysis.
@@ -7204,7 +7204,7 @@ The story creation is successful when:
 - **Acknowledge Task & Inputs:**
   - Confirm with the user that the "Correct Course Task" (Change Navigation & Integration) is being initiated.
   - Verify the change trigger and ensure you have the user's initial explanation of the issue and its perceived impact.
-  - Confirm access to all relevant project artifacts (e.g., PRD, Epics/Stories, Architecture Documents, UI/UX Specifications) and, critically, the `.bmad-core/checklists/change-checklist`.
+  - Confirm access to all relevant project artifacts (e.g., PRD, Epics/Stories, Architecture Documents, UI/UX Specifications) and, critically, the `bmad-core/checklists/change-checklist`.
 - **Establish Interaction Mode:**
   - Ask the user their preferred interaction mode for this task:
     - **"Incrementally (Default & Recommended):** Shall we work through the change-checklist section by section, discussing findings and collaboratively drafting proposed changes for each relevant part before moving to the next? This allows for detailed, step-by-step refinement."
@@ -7256,9 +7256,9 @@ The story creation is successful when:
   - A summary of the change-checklist analysis (issue, impact, rationale for the chosen path).
   - Specific, clearly drafted proposed edits for all affected project artifacts.
 - **Implicit:** An annotated change-checklist (or the record of its completion) reflecting the discussions, findings, and decisions made during the process.
-==================== END: .bmad-core/tasks/correct-course.md ====================
+==================== END: bmad-core/tasks/correct-course.md ====================
 
-==================== START: .bmad-core/tasks/shard-doc.md ====================
+==================== START: bmad-core/tasks/shard-doc.md ====================
 <!-- Powered by BMAD™ Core -->
 # Document Sharding Task
 
@@ -7270,20 +7270,20 @@ The story creation is successful when:
 
 ## Primary Method: Automatic with markdown-tree
 
-[[LLM: First, check if markdownExploder is set to true in .bmad-core/core-config.yaml. If it is, attempt to run the command: `md-tree explode {input file} {output path}`.
+[[LLM: First, check if markdownExploder is set to true in bmad-core/core-config.yaml. If it is, attempt to run the command: `md-tree explode {input file} {output path}`.
 
 If the command succeeds, inform the user that the document has been sharded successfully and STOP - do not proceed further.
 
 If the command fails (especially with an error indicating the command is not found or not available), inform the user: "The markdownExploder setting is enabled but the md-tree command is not available. Please either:
 
 1. Install @kayvan/markdown-tree-parser globally with: `npm install -g @kayvan/markdown-tree-parser`
-2. Or set markdownExploder to false in .bmad-core/core-config.yaml
+2. Or set markdownExploder to false in bmad-core/core-config.yaml
 
 **IMPORTANT: STOP HERE - do not proceed with manual sharding until one of the above actions is taken.**"
 
 If markdownExploder is set to false, inform the user: "The markdownExploder setting is currently false. For better performance and reliability, you should:
 
-1. Set markdownExploder to true in .bmad-core/core-config.yaml
+1. Set markdownExploder to true in bmad-core/core-config.yaml
 2. Install @kayvan/markdown-tree-parser globally with: `npm install -g @kayvan/markdown-tree-parser`
 
 I will now proceed with the manual sharding process."
@@ -7445,9 +7445,9 @@ Document sharded successfully:
 - Preserve ALL formatting, including whitespace where significant
 - Handle edge cases like sections with code blocks containing ## symbols
 - Ensure the sharding is reversible (could reconstruct the original from shards)
-==================== END: .bmad-core/tasks/shard-doc.md ====================
+==================== END: bmad-core/tasks/shard-doc.md ====================
 
-==================== START: .bmad-core/templates/brownfield-prd-tmpl.yaml ====================
+==================== START: bmad-core/templates/brownfield-prd-tmpl.yaml ====================
 # <!-- Powered by BMAD™ Core -->
 template:
   id: brownfield-prd-template-v2
@@ -7729,9 +7729,9 @@ sections:
               - template: "IV1: {{existing_functionality_verification}}"
               - template: "IV2: {{integration_point_verification}}"
               - template: "IV3: {{performance_impact_verification}}"
-==================== END: .bmad-core/templates/brownfield-prd-tmpl.yaml ====================
+==================== END: bmad-core/templates/brownfield-prd-tmpl.yaml ====================
 
-==================== START: .bmad-core/templates/prd-tmpl.yaml ====================
+==================== START: bmad-core/templates/prd-tmpl.yaml ====================
 # <!-- Powered by BMAD™ Core -->
 template:
   id: prd-template-v2
@@ -7834,7 +7834,7 @@ sections:
     instruction: |
       Gather technical decisions that will guide the Architect. Steps:
 
-      1. Check if .bmad-core/data/technical-preferences.yaml or an attached technical-preferences file exists - use it to pre-populate choices
+      1. Check if bmad-core/data/technical-preferences.yaml or an attached technical-preferences file exists - use it to pre-populate choices
       2. Ask user about: languages, frameworks, starter templates, libraries, APIs, deployment targets
       3. For unknowns, offer guidance based on project goals and MVP scope
       4. Document ALL technical choices with rationale (why this choice fits the project)
@@ -7935,9 +7935,9 @@ sections:
       - id: architect-prompt
         title: Architect Prompt
         instruction: This section will contain the prompt for the Architect, keep it short and to the point to initiate create architecture mode using this document as input.
-==================== END: .bmad-core/templates/prd-tmpl.yaml ====================
+==================== END: bmad-core/templates/prd-tmpl.yaml ====================
 
-==================== START: .bmad-core/checklists/change-checklist.md ====================
+==================== START: bmad-core/checklists/change-checklist.md ====================
 <!-- Powered by BMAD™ Core -->
 # Change Navigation Checklist
 
@@ -8121,9 +8121,9 @@ Keep it action-oriented and forward-looking.]]
 - [ ] **Confirm Next Steps:** Reiterate the handoff plan and the next actions to be taken by specific agents.
 
 ---
-==================== END: .bmad-core/checklists/change-checklist.md ====================
+==================== END: bmad-core/checklists/change-checklist.md ====================
 
-==================== START: .bmad-core/checklists/pm-checklist.md ====================
+==================== START: bmad-core/checklists/pm-checklist.md ====================
 <!-- Powered by BMAD™ Core -->
 # Product Manager (PM) Requirements Checklist
 
@@ -8495,9 +8495,9 @@ After presenting the report, ask if the user wants:
 
 - **READY FOR ARCHITECT**: The PRD and epics are comprehensive, properly structured, and ready for architectural design.
 - **NEEDS REFINEMENT**: The requirements documentation requires additional work to address the identified deficiencies.
-==================== END: .bmad-core/checklists/pm-checklist.md ====================
+==================== END: bmad-core/checklists/pm-checklist.md ====================
 
-==================== START: .bmad-core/templates/story-tmpl.yaml ====================
+==================== START: bmad-core/templates/story-tmpl.yaml ====================
 # <!-- Powered by BMAD™ Core -->
 template:
   id: story-template-v2
@@ -8636,9 +8636,9 @@ sections:
     instruction: Results from QA Agent QA review of the completed story implementation
     owner: qa-agent
     editors: [qa-agent]
-==================== END: .bmad-core/templates/story-tmpl.yaml ====================
+==================== END: bmad-core/templates/story-tmpl.yaml ====================
 
-==================== START: .bmad-core/checklists/po-master-checklist.md ====================
+==================== START: bmad-core/checklists/po-master-checklist.md ====================
 <!-- Powered by BMAD™ Core -->
 # Product Owner (PO) Master Validation Checklist
 
@@ -9072,9 +9072,9 @@ After presenting the report, ask if the user wants:
 - **APPROVED**: The plan is comprehensive, properly sequenced, and ready for implementation.
 - **CONDITIONAL**: The plan requires specific adjustments before proceeding.
 - **REJECTED**: The plan requires significant revision to address critical deficiencies.
-==================== END: .bmad-core/checklists/po-master-checklist.md ====================
+==================== END: bmad-core/checklists/po-master-checklist.md ====================
 
-==================== START: .bmad-core/tasks/nfr-assess.md ====================
+==================== START: bmad-core/tasks/nfr-assess.md ====================
 <!-- Powered by BMAD™ Core -->
 # nfr-assess
 
@@ -9419,9 +9419,9 @@ performance_deep_dive:
 ```
 
 </details>
-==================== END: .bmad-core/tasks/nfr-assess.md ====================
+==================== END: bmad-core/tasks/nfr-assess.md ====================
 
-==================== START: .bmad-core/tasks/qa-gate.md ====================
+==================== START: bmad-core/tasks/qa-gate.md ====================
 <!-- Powered by BMAD™ Core -->
 # qa-gate
 
@@ -9584,9 +9584,9 @@ Gate: CONCERNS → qa.qaLocation/gates/{epic}.{story}-{slug}.yml
 - Always write to standard path
 - Always update story with gate reference
 - Clear, actionable findings
-==================== END: .bmad-core/tasks/qa-gate.md ====================
+==================== END: bmad-core/tasks/qa-gate.md ====================
 
-==================== START: .bmad-core/tasks/review-story.md ====================
+==================== START: bmad-core/tasks/review-story.md ====================
 <!-- Powered by BMAD™ Core -->
 # review-story
 
@@ -9902,9 +9902,9 @@ After review:
 3. Recommend status: "Ready for Done" or "Changes Required" (owner decides)
 4. If files were modified, list them in QA Results and ask Dev to update File List
 5. Always provide constructive feedback and actionable recommendations
-==================== END: .bmad-core/tasks/review-story.md ====================
+==================== END: bmad-core/tasks/review-story.md ====================
 
-==================== START: .bmad-core/tasks/risk-profile.md ====================
+==================== START: bmad-core/tasks/risk-profile.md ====================
 <!-- Powered by BMAD™ Core -->
 # risk-profile
 
@@ -10259,9 +10259,9 @@ Risk profile: qa.qaLocation/assessments/{epic}.{story}-risk-{YYYYMMDD}.md
 - Link risks to specific test requirements
 - Track residual risk after mitigation
 - Update risk profile as story evolves
-==================== END: .bmad-core/tasks/risk-profile.md ====================
+==================== END: bmad-core/tasks/risk-profile.md ====================
 
-==================== START: .bmad-core/tasks/test-design.md ====================
+==================== START: bmad-core/tasks/test-design.md ====================
 <!-- Powered by BMAD™ Core -->
 # test-design
 
@@ -10437,9 +10437,9 @@ Before finalizing, verify:
 - **Efficient coverage**: Test once at the right level
 - **Maintainability**: Consider long-term test maintenance
 - **Fast feedback**: Quick tests run first
-==================== END: .bmad-core/tasks/test-design.md ====================
+==================== END: bmad-core/tasks/test-design.md ====================
 
-==================== START: .bmad-core/tasks/trace-requirements.md ====================
+==================== START: bmad-core/tasks/trace-requirements.md ====================
 <!-- Powered by BMAD™ Core -->
 # trace-requirements
 
@@ -10705,9 +10705,9 @@ Trace matrix: qa.qaLocation/assessments/{epic}.{story}-trace-{YYYYMMDD}.md
 - Identify both presence and absence
 - Prioritize based on risk
 - Make recommendations actionable
-==================== END: .bmad-core/tasks/trace-requirements.md ====================
+==================== END: bmad-core/tasks/trace-requirements.md ====================
 
-==================== START: .bmad-core/templates/qa-gate-tmpl.yaml ====================
+==================== START: bmad-core/templates/qa-gate-tmpl.yaml ====================
 # <!-- Powered by BMAD™ Core -->
 template:
   id: qa-gate-template-v1
@@ -10811,9 +10811,9 @@ optional_fields_examples:
       future:  # Can be addressed later
         - action: "Consider caching for better performance"
           refs: ["services/data.service.ts"]
-==================== END: .bmad-core/templates/qa-gate-tmpl.yaml ====================
+==================== END: bmad-core/templates/qa-gate-tmpl.yaml ====================
 
-==================== START: .bmad-core/tasks/create-next-story.md ====================
+==================== START: bmad-core/tasks/create-next-story.md ====================
 <!-- Powered by BMAD™ Core -->
 # Create Next Story Task
 
@@ -10825,7 +10825,7 @@ To identify the next logical story based on project progress and epic definition
 
 ### 0. Load Core Configuration and Check Workflow
 
-- Load `.bmad-core/core-config.yaml` from the project root
+- Load `bmad-core/core-config.yaml` from the project root
 - If the file does not exist, HALT and inform the user: "core-config.yaml not found. This file is required for story creation. You can either: 1) Copy it from GITHUB bmad-core/core-config.yaml and configure it for your project OR 2) Run the BMad installer against your project to upgrade and add the file automatically. Please add and configure core-config.yaml before proceeding."
 - Extract key configurations: `devStoryLocation`, `prd.*`, `architecture.*`, `workflow.*`
 
@@ -10919,17 +10919,17 @@ ALWAYS cite source documents: `[Source: architecture/{filename}.md#{section}]`
 - Verify all source references are included for technical details
 - Ensure tasks align with both epic requirements and architecture constraints
 - Update status to "Draft" and save the story file
-- Execute `.bmad-core/tasks/execute-checklist` `.bmad-core/checklists/story-draft-checklist`
+- Execute `bmad-core/tasks/execute-checklist` `bmad-core/checklists/story-draft-checklist`
 - Provide summary to user including:
   - Story created: `{devStoryLocation}/{epicNum}.{storyNum}.story.md`
   - Status: Draft
   - Key technical components included from architecture docs
   - Any deviations or conflicts noted between epic and architecture
   - Checklist Results
-  - Next steps: For Complex stories, suggest the user carefully review the story draft and also optionally have the PO run the task `.bmad-core/tasks/validate-next-story`
-==================== END: .bmad-core/tasks/create-next-story.md ====================
+  - Next steps: For Complex stories, suggest the user carefully review the story draft and also optionally have the PO run the task `bmad-core/tasks/validate-next-story`
+==================== END: bmad-core/tasks/create-next-story.md ====================
 
-==================== START: .bmad-core/checklists/story-draft-checklist.md ====================
+==================== START: bmad-core/checklists/story-draft-checklist.md ====================
 <!-- Powered by BMAD™ Core -->
 # Story Draft Checklist
 
@@ -11084,9 +11084,9 @@ Be pragmatic - perfect documentation doesn't exist, but it must be enough to pro
 - READY: The story provides sufficient context for implementation
 - NEEDS REVISION: The story requires updates (see issues)
 - BLOCKED: External information required (specify what information)
-==================== END: .bmad-core/checklists/story-draft-checklist.md ====================
+==================== END: bmad-core/checklists/story-draft-checklist.md ====================
 
-==================== START: .bmad-core/tasks/generate-ai-frontend-prompt.md ====================
+==================== START: bmad-core/tasks/generate-ai-frontend-prompt.md ====================
 <!-- Powered by BMAD™ Core -->
 # Create AI Frontend Prompt Task
 
@@ -11139,9 +11139,9 @@ You will now synthesize the inputs and the above principles into a final, compre
    - Output the complete, generated prompt in a clear, copy-pasteable format (e.g., a large code block).
    - Explain the structure of the prompt and why certain information was included, referencing the principles above.
    - <important_note>Conclude by reminding the user that all AI-generated code will require careful human review, testing, and refinement to be considered production-ready.</important_note>
-==================== END: .bmad-core/tasks/generate-ai-frontend-prompt.md ====================
+==================== END: bmad-core/tasks/generate-ai-frontend-prompt.md ====================
 
-==================== START: .bmad-core/templates/front-end-spec-tmpl.yaml ====================
+==================== START: bmad-core/templates/front-end-spec-tmpl.yaml ====================
 # <!-- Powered by BMAD™ Core -->
 template:
   id: frontend-spec-template-v2
@@ -11492,9 +11492,9 @@ sections:
   - id: checklist-results
     title: Checklist Results
     instruction: If a UI/UX checklist exists, run it against this document and report results here.
-==================== END: .bmad-core/templates/front-end-spec-tmpl.yaml ====================
+==================== END: bmad-core/templates/front-end-spec-tmpl.yaml ====================
 
-==================== START: .bmad-core/workflows/brownfield-fullstack.yaml ====================
+==================== START: bmad-core/workflows/brownfield-fullstack.yaml ====================
 # <!-- Powered by BMAD™ Core -->
 workflow:
   id: brownfield-fullstack
@@ -11680,7 +11680,7 @@ workflow:
         All stories implemented and reviewed!
         Project development phase complete.
 
-        Reference: .bmad-core/data/bmad-kb.md#IDE Development Workflow
+        Reference: bmad-core/data/bmad-kb.md#IDE Development Workflow
 
   flow_diagram: |
     ```mermaid
@@ -11793,9 +11793,9 @@ workflow:
       {{if missing_context}}: May need to gather additional context from user during story creation.
 
     complete: "All planning artifacts validated and development can begin. Stories will be created based on available documentation format."
-==================== END: .bmad-core/workflows/brownfield-fullstack.yaml ====================
+==================== END: bmad-core/workflows/brownfield-fullstack.yaml ====================
 
-==================== START: .bmad-core/workflows/brownfield-service.yaml ====================
+==================== START: bmad-core/workflows/brownfield-service.yaml ====================
 # <!-- Powered by BMAD™ Core -->
 workflow:
   id: brownfield-service
@@ -11927,7 +11927,7 @@ workflow:
         All stories implemented and reviewed!
         Project development phase complete.
 
-        Reference: .bmad-core/data/bmad-kb.md#IDE Development Workflow
+        Reference: bmad-core/data/bmad-kb.md#IDE Development Workflow
 
   flow_diagram: |
     ```mermaid
@@ -11984,9 +11984,9 @@ workflow:
     architect_to_po: "Architecture complete. Save it as docs/architecture.md. Please validate all artifacts for service integration safety."
     po_issues: "PO found issues with [document]. Please return to [agent] to fix and re-save the updated document."
     complete: "All planning artifacts validated and saved in docs/ folder. Move to IDE environment to begin development."
-==================== END: .bmad-core/workflows/brownfield-service.yaml ====================
+==================== END: bmad-core/workflows/brownfield-service.yaml ====================
 
-==================== START: .bmad-core/workflows/brownfield-ui.yaml ====================
+==================== START: bmad-core/workflows/brownfield-ui.yaml ====================
 # <!-- Powered by BMAD™ Core -->
 workflow:
   id: brownfield-ui
@@ -12125,7 +12125,7 @@ workflow:
         All stories implemented and reviewed!
         Project development phase complete.
 
-        Reference: .bmad-core/data/bmad-kb.md#IDE Development Workflow
+        Reference: bmad-core/data/bmad-kb.md#IDE Development Workflow
 
   flow_diagram: |
     ```mermaid
@@ -12185,9 +12185,9 @@ workflow:
     architect_to_po: "Architecture complete. Save it as docs/architecture.md. Please validate all artifacts for UI integration safety."
     po_issues: "PO found issues with [document]. Please return to [agent] to fix and re-save the updated document."
     complete: "All planning artifacts validated and saved in docs/ folder. Move to IDE environment to begin development."
-==================== END: .bmad-core/workflows/brownfield-ui.yaml ====================
+==================== END: bmad-core/workflows/brownfield-ui.yaml ====================
 
-==================== START: .bmad-core/workflows/greenfield-fullstack.yaml ====================
+==================== START: bmad-core/workflows/greenfield-fullstack.yaml ====================
 # <!-- Powered by BMAD™ Core -->
 workflow:
   id: greenfield-fullstack
@@ -12351,7 +12351,7 @@ workflow:
         All stories implemented and reviewed!
         Project development phase complete.
 
-        Reference: .bmad-core/data/bmad-kb.md#IDE Development Workflow
+        Reference: bmad-core/data/bmad-kb.md#IDE Development Workflow
 
   flow_diagram: |
     ```mermaid
@@ -12429,9 +12429,9 @@ workflow:
     updated_to_po: "All documents ready in docs/ folder. Please validate all artifacts for consistency."
     po_issues: "PO found issues with [document]. Please return to [agent] to fix and re-save the updated document."
     complete: "All planning artifacts validated and saved in docs/ folder. Move to IDE environment to begin development."
-==================== END: .bmad-core/workflows/greenfield-fullstack.yaml ====================
+==================== END: bmad-core/workflows/greenfield-fullstack.yaml ====================
 
-==================== START: .bmad-core/workflows/greenfield-service.yaml ====================
+==================== START: bmad-core/workflows/greenfield-service.yaml ====================
 # <!-- Powered by BMAD™ Core -->
 workflow:
   id: greenfield-service
@@ -12571,7 +12571,7 @@ workflow:
         All stories implemented and reviewed!
         Service development phase complete.
 
-        Reference: .bmad-core/data/bmad-kb.md#IDE Development Workflow
+        Reference: bmad-core/data/bmad-kb.md#IDE Development Workflow
 
   flow_diagram: |
     ```mermaid
@@ -12639,9 +12639,9 @@ workflow:
     updated_to_po: "All documents ready in docs/ folder. Please validate all artifacts for consistency."
     po_issues: "PO found issues with [document]. Please return to [agent] to fix and re-save the updated document."
     complete: "All planning artifacts validated and saved in docs/ folder. Move to IDE environment to begin development."
-==================== END: .bmad-core/workflows/greenfield-service.yaml ====================
+==================== END: bmad-core/workflows/greenfield-service.yaml ====================
 
-==================== START: .bmad-core/workflows/greenfield-ui.yaml ====================
+==================== START: bmad-core/workflows/greenfield-ui.yaml ====================
 # <!-- Powered by BMAD™ Core -->
 workflow:
   id: greenfield-ui
@@ -12800,7 +12800,7 @@ workflow:
         All stories implemented and reviewed!
         Project development phase complete.
 
-        Reference: .bmad-core/data/bmad-kb.md#IDE Development Workflow
+        Reference: bmad-core/data/bmad-kb.md#IDE Development Workflow
 
   flow_diagram: |
     ```mermaid
@@ -12878,4 +12878,4 @@ workflow:
     updated_to_po: "All documents ready in docs/ folder. Please validate all artifacts for consistency."
     po_issues: "PO found issues with [document]. Please return to [agent] to fix and re-save the updated document."
     complete: "All planning artifacts validated and saved in docs/ folder. Move to IDE environment to begin development."
-==================== END: .bmad-core/workflows/greenfield-ui.yaml ====================
+==================== END: bmad-core/workflows/greenfield-ui.yaml ====================

--- a/dist/teams/team-fullstack.txt
+++ b/dist/teams/team-fullstack.txt
@@ -8,13 +8,13 @@ You are now operating as a specialized AI agent from the BMad-Method framework. 
 
 2. **Resource Navigation**: This bundle contains all resources you need. Resources are marked with tags like:
 
-- `==================== START: .bmad-core/folder/filename.md ====================`
-- `==================== END: .bmad-core/folder/filename.md ====================`
+- `==================== START: bmad-core/folder/filename.md ====================`
+- `==================== END: bmad-core/folder/filename.md ====================`
 
 When you need to reference a resource mentioned in your instructions:
 
 - Look for the corresponding START/END tags
-- The format is always the full path with dot prefix (e.g., `.bmad-core/personas/analyst.md`, `.bmad-core/tasks/create-story.md`)
+- The format is always the full path with dot prefix (e.g., `bmad-core/personas/analyst.md`, `bmad-core/tasks/create-story.md`)
 - If a section is specified (e.g., `{root}/tasks/create-story.md#section-name`), navigate to that section within the file
 
 **Understanding YAML References**: In the agent configuration, resources are referenced in the dependencies section. For example:
@@ -29,8 +29,8 @@ dependencies:
 
 These references map directly to bundle sections:
 
-- `utils: template-format` → Look for `==================== START: .bmad-core/utils/template-format.md ====================`
-- `tasks: create-story` → Look for `==================== START: .bmad-core/tasks/create-story.md ====================`
+- `utils: template-format` → Look for `==================== START: bmad-core/utils/template-format.md ====================`
+- `tasks: create-story` → Look for `==================== START: bmad-core/tasks/create-story.md ====================`
 
 3. **Execution Context**: You are operating in a web environment. All your capabilities and knowledge are contained within this bundle. Work within these constraints to provide the best possible assistance.
 
@@ -39,7 +39,7 @@ These references map directly to bundle sections:
 ---
 
 
-==================== START: .bmad-core/agent-teams/team-fullstack.yaml ====================
+==================== START: bmad-core/agent-teams/team-fullstack.yaml ====================
 # <!-- Powered by BMAD™ Core -->
 bundle:
   name: Team Fullstack
@@ -59,9 +59,9 @@ workflows:
   - greenfield-fullstack.yaml
   - greenfield-service.yaml
   - greenfield-ui.yaml
-==================== END: .bmad-core/agent-teams/team-fullstack.yaml ====================
+==================== END: bmad-core/agent-teams/team-fullstack.yaml ====================
 
-==================== START: .bmad-core/agents/bmad-orchestrator.md ====================
+==================== START: bmad-core/agents/bmad-orchestrator.md ====================
 # bmad-orchestrator
 
 CRITICAL: Read the full YAML, start activation to alter your state of being, follow startup section instructions, stay in this being until told to exit this mode:
@@ -186,9 +186,9 @@ dependencies:
   utils:
     - workflow-management.md
 ```
-==================== END: .bmad-core/agents/bmad-orchestrator.md ====================
+==================== END: bmad-core/agents/bmad-orchestrator.md ====================
 
-==================== START: .bmad-core/agents/analyst.md ====================
+==================== START: bmad-core/agents/analyst.md ====================
 # analyst
 
 CRITICAL: Read the full YAML, start activation to alter your state of being, follow startup section instructions, stay in this being until told to exit this mode:
@@ -250,9 +250,9 @@ dependencies:
     - market-research-tmpl.yaml
     - project-brief-tmpl.yaml
 ```
-==================== END: .bmad-core/agents/analyst.md ====================
+==================== END: bmad-core/agents/analyst.md ====================
 
-==================== START: .bmad-core/agents/pm.md ====================
+==================== START: bmad-core/agents/pm.md ====================
 # pm
 
 CRITICAL: Read the full YAML, start activation to alter your state of being, follow startup section instructions, stay in this being until told to exit this mode:
@@ -314,9 +314,9 @@ dependencies:
     - brownfield-prd-tmpl.yaml
     - prd-tmpl.yaml
 ```
-==================== END: .bmad-core/agents/pm.md ====================
+==================== END: bmad-core/agents/pm.md ====================
 
-==================== START: .bmad-core/agents/ux-expert.md ====================
+==================== START: bmad-core/agents/ux-expert.md ====================
 # ux-expert
 
 CRITICAL: Read the full YAML, start activation to alter your state of being, follow startup section instructions, stay in this being until told to exit this mode:
@@ -363,9 +363,9 @@ dependencies:
   templates:
     - front-end-spec-tmpl.yaml
 ```
-==================== END: .bmad-core/agents/ux-expert.md ====================
+==================== END: bmad-core/agents/ux-expert.md ====================
 
-==================== START: .bmad-core/agents/architect.md ====================
+==================== START: bmad-core/agents/architect.md ====================
 # architect
 
 CRITICAL: Read the full YAML, start activation to alter your state of being, follow startup section instructions, stay in this being until told to exit this mode:
@@ -428,9 +428,9 @@ dependencies:
     - front-end-architecture-tmpl.yaml
     - fullstack-architecture-tmpl.yaml
 ```
-==================== END: .bmad-core/agents/architect.md ====================
+==================== END: bmad-core/agents/architect.md ====================
 
-==================== START: .bmad-core/agents/po.md ====================
+==================== START: bmad-core/agents/po.md ====================
 # po
 
 CRITICAL: Read the full YAML, start activation to alter your state of being, follow startup section instructions, stay in this being until told to exit this mode:
@@ -487,9 +487,9 @@ dependencies:
   templates:
     - story-tmpl.yaml
 ```
-==================== END: .bmad-core/agents/po.md ====================
+==================== END: bmad-core/agents/po.md ====================
 
-==================== START: .bmad-core/tasks/advanced-elicitation.md ====================
+==================== START: bmad-core/tasks/advanced-elicitation.md ====================
 <!-- Powered by BMAD™ Core -->
 # Advanced Elicitation Task
 
@@ -608,9 +608,9 @@ Choose a number (0-8) or 9 to proceed:
 - **Stay Relevant**: Tie all elicitation back to the specific content being analyzed
 - **Identify Personas**: For multi-persona methods, clearly identify which viewpoint is speaking
 - **Maintain Flow**: Keep the process moving efficiently
-==================== END: .bmad-core/tasks/advanced-elicitation.md ====================
+==================== END: bmad-core/tasks/advanced-elicitation.md ====================
 
-==================== START: .bmad-core/tasks/create-doc.md ====================
+==================== START: bmad-core/tasks/create-doc.md ====================
 <!-- Powered by BMAD™ Core -->
 # Create Document from Template (YAML Driven)
 
@@ -629,7 +629,7 @@ When this task is invoked:
 
 ## Critical: Template Discovery
 
-If a YAML Template has not been provided, list all templates from .bmad-core/templates or ask the user to provide another.
+If a YAML Template has not been provided, list all templates from bmad-core/templates or ask the user to provide another.
 
 ## CRITICAL: Mandatory Elicitation Format
 
@@ -713,9 +713,9 @@ User can type `#yolo` to toggle to YOLO mode (process all sections at once).
 - Select options 2-9 from data/elicitation-methods only
 - Provide detailed rationale explaining decisions
 - End with "Select 1-9 or just type your question/feedback:"
-==================== END: .bmad-core/tasks/create-doc.md ====================
+==================== END: bmad-core/tasks/create-doc.md ====================
 
-==================== START: .bmad-core/tasks/kb-mode-interaction.md ====================
+==================== START: bmad-core/tasks/kb-mode-interaction.md ====================
 <!-- Powered by BMAD™ Core -->
 # KB Mode Interaction Task
 
@@ -792,9 +792,9 @@ Or ask me about anything else related to BMad-Method!
 **User**: Tell me about workflows
 
 **Assistant**: [Provides focused information about workflows from the KB, then offers to explore specific workflow types or related topics]
-==================== END: .bmad-core/tasks/kb-mode-interaction.md ====================
+==================== END: bmad-core/tasks/kb-mode-interaction.md ====================
 
-==================== START: .bmad-core/data/bmad-kb.md ====================
+==================== START: bmad-core/data/bmad-kb.md ====================
 <!-- Powered by BMAD™ Core -->
 # BMAD™ Knowledge Base
 
@@ -903,7 +903,7 @@ npx bmad-method install
 
 **Verify Installation**:
 
-- `.bmad-core/` folder created with all agents
+- `bmad-core/` folder created with all agents
 - IDE-specific integration files created
 - All agent commands/rules/modes available
 
@@ -1602,9 +1602,9 @@ Use the **expansion-creator** pack to build your own:
 - **Documentation**: Check `docs/` folder for project-specific context
 - **Community**: Discord and GitHub resources available for support
 - **Contributing**: See `CONTRIBUTING.md` for full guidelines
-==================== END: .bmad-core/data/bmad-kb.md ====================
+==================== END: bmad-core/data/bmad-kb.md ====================
 
-==================== START: .bmad-core/data/elicitation-methods.md ====================
+==================== START: bmad-core/data/elicitation-methods.md ====================
 <!-- Powered by BMAD™ Core -->
 # Elicitation Methods Data
 
@@ -1760,9 +1760,9 @@ Use the **expansion-creator** pack to build your own:
 - Acknowledge choice to finalize current work
 - Accept output as-is or move to next step
 - Prepare to continue without additional elicitation
-==================== END: .bmad-core/data/elicitation-methods.md ====================
+==================== END: bmad-core/data/elicitation-methods.md ====================
 
-==================== START: .bmad-core/utils/workflow-management.md ====================
+==================== START: bmad-core/utils/workflow-management.md ====================
 <!-- Powered by BMAD™ Core -->
 # Workflow Management
 
@@ -1833,9 +1833,9 @@ Handle conditional paths by asking clarifying questions when needed.
 ## Agent Integration
 
 Agents should be workflow-aware: know active workflow, their role, access artifacts, understand expected outputs.
-==================== END: .bmad-core/utils/workflow-management.md ====================
+==================== END: bmad-core/utils/workflow-management.md ====================
 
-==================== START: .bmad-core/tasks/create-deep-research-prompt.md ====================
+==================== START: bmad-core/tasks/create-deep-research-prompt.md ====================
 <!-- Powered by BMAD™ Core -->
 # Create Deep Research Prompt Task
 
@@ -2115,9 +2115,9 @@ CRITICAL: collaborate with the user to develop specific, actionable research que
 - Balance comprehensiveness with focus
 - Document assumptions and limitations clearly
 - Plan for iterative refinement based on initial findings
-==================== END: .bmad-core/tasks/create-deep-research-prompt.md ====================
+==================== END: bmad-core/tasks/create-deep-research-prompt.md ====================
 
-==================== START: .bmad-core/tasks/document-project.md ====================
+==================== START: bmad-core/tasks/document-project.md ====================
 <!-- Powered by BMAD™ Core -->
 # Document an Existing Project
 
@@ -2462,13 +2462,13 @@ Apply the advanced elicitation task after major sections to refine based on user
 - Documents technical debt, workarounds, and constraints honestly
 - For brownfield projects with PRD: Provides clear enhancement impact analysis
 - The goal is PRACTICAL documentation for AI agents doing real work
-==================== END: .bmad-core/tasks/document-project.md ====================
+==================== END: bmad-core/tasks/document-project.md ====================
 
-==================== START: .bmad-core/tasks/facilitate-brainstorming-session.md ====================
+==================== START: bmad-core/tasks/facilitate-brainstorming-session.md ====================
 <!-- Powered by BMAD™ Core -->
 ---
 docOutputLocation: docs/brainstorming-session-results.md
-template: '.bmad-core/templates/brainstorming-output-tmpl.yaml'
+template: 'bmad-core/templates/brainstorming-output-tmpl.yaml'
 ---
 
 # Facilitate Brainstorming Session Task
@@ -2602,9 +2602,9 @@ Generate structured document with these sections:
 - Always ask before switching techniques: "Ready to try a different approach?"
 - Offer options: "Should we explore this idea deeper or generate more alternatives?"
 - Respect their process and timing
-==================== END: .bmad-core/tasks/facilitate-brainstorming-session.md ====================
+==================== END: bmad-core/tasks/facilitate-brainstorming-session.md ====================
 
-==================== START: .bmad-core/templates/brainstorming-output-tmpl.yaml ====================
+==================== START: bmad-core/templates/brainstorming-output-tmpl.yaml ====================
 template:
   id: brainstorming-output-template-v2
   name: Brainstorming Session Results
@@ -2761,9 +2761,9 @@ sections:
       ---
 
       *Session facilitated using the BMAD-METHOD™ brainstorming framework*
-==================== END: .bmad-core/templates/brainstorming-output-tmpl.yaml ====================
+==================== END: bmad-core/templates/brainstorming-output-tmpl.yaml ====================
 
-==================== START: .bmad-core/templates/competitor-analysis-tmpl.yaml ====================
+==================== START: bmad-core/templates/competitor-analysis-tmpl.yaml ====================
 # <!-- Powered by BMAD™ Core -->
 template:
   id: competitor-analysis-template-v2
@@ -3071,9 +3071,9 @@ sections:
           - Weekly: {{weekly_items}}
           - Monthly: {{monthly_items}}
           - Quarterly: {{quarterly_analysis}}
-==================== END: .bmad-core/templates/competitor-analysis-tmpl.yaml ====================
+==================== END: bmad-core/templates/competitor-analysis-tmpl.yaml ====================
 
-==================== START: .bmad-core/templates/market-research-tmpl.yaml ====================
+==================== START: bmad-core/templates/market-research-tmpl.yaml ====================
 # <!-- Powered by BMAD™ Core -->
 template:
   id: market-research-template-v2
@@ -3327,9 +3327,9 @@ sections:
       - id: additional-analysis
         title: C. Additional Analysis
         instruction: Any supplementary analysis not included in main body
-==================== END: .bmad-core/templates/market-research-tmpl.yaml ====================
+==================== END: bmad-core/templates/market-research-tmpl.yaml ====================
 
-==================== START: .bmad-core/templates/project-brief-tmpl.yaml ====================
+==================== START: bmad-core/templates/project-brief-tmpl.yaml ====================
 # <!-- Powered by BMAD™ Core -->
 template:
   id: project-brief-template-v2
@@ -3552,9 +3552,9 @@ sections:
         title: PM Handoff
         content: |
           This Project Brief provides the full context for {{project_name}}. Please start in 'PRD Generation Mode', review the brief thoroughly to work with the user to create the PRD section by section as the template indicates, asking for any necessary clarification or suggesting improvements.
-==================== END: .bmad-core/templates/project-brief-tmpl.yaml ====================
+==================== END: bmad-core/templates/project-brief-tmpl.yaml ====================
 
-==================== START: .bmad-core/data/brainstorming-techniques.md ====================
+==================== START: bmad-core/data/brainstorming-techniques.md ====================
 <!-- Powered by BMAD™ Core -->
 # Brainstorming Techniques Data
 
@@ -3592,9 +3592,9 @@ sections:
 18. **Resource Constraints**: "What if you had only $10 and 1 hour?"
 19. **Metaphor Mapping**: Use extended metaphors to explore solutions
 20. **Question Storming**: Generate questions instead of answers first
-==================== END: .bmad-core/data/brainstorming-techniques.md ====================
+==================== END: bmad-core/data/brainstorming-techniques.md ====================
 
-==================== START: .bmad-core/tasks/brownfield-create-epic.md ====================
+==================== START: bmad-core/tasks/brownfield-create-epic.md ====================
 <!-- Powered by BMAD™ Core -->
 # Create Brownfield Epic Task
 
@@ -3756,9 +3756,9 @@ The epic creation is successful when:
 - If the scope grows beyond 3 stories, consider the full brownfield PRD process
 - Always prioritize existing system integrity over new functionality
 - When in doubt about scope or complexity, escalate to full brownfield planning
-==================== END: .bmad-core/tasks/brownfield-create-epic.md ====================
+==================== END: bmad-core/tasks/brownfield-create-epic.md ====================
 
-==================== START: .bmad-core/tasks/brownfield-create-story.md ====================
+==================== START: bmad-core/tasks/brownfield-create-story.md ====================
 <!-- Powered by BMAD™ Core -->
 # Create Brownfield Story Task
 
@@ -3907,15 +3907,15 @@ The story creation is successful when:
 - Always prioritize existing system integrity
 - When in doubt about integration complexity, use brownfield-create-epic instead
 - Stories should take no more than 4 hours of focused development work
-==================== END: .bmad-core/tasks/brownfield-create-story.md ====================
+==================== END: bmad-core/tasks/brownfield-create-story.md ====================
 
-==================== START: .bmad-core/tasks/correct-course.md ====================
+==================== START: bmad-core/tasks/correct-course.md ====================
 <!-- Powered by BMAD™ Core -->
 # Correct Course Task
 
 ## Purpose
 
-- Guide a structured response to a change trigger using the `.bmad-core/checklists/change-checklist`.
+- Guide a structured response to a change trigger using the `bmad-core/checklists/change-checklist`.
 - Analyze the impacts of the change on epics, project artifacts, and the MVP, guided by the checklist's structure.
 - Explore potential solutions (e.g., adjust scope, rollback elements, re-scope features) as prompted by the checklist.
 - Draft specific, actionable proposed updates to any affected project artifacts (e.g., epics, user stories, PRD sections, architecture document sections) based on the analysis.
@@ -3929,7 +3929,7 @@ The story creation is successful when:
 - **Acknowledge Task & Inputs:**
   - Confirm with the user that the "Correct Course Task" (Change Navigation & Integration) is being initiated.
   - Verify the change trigger and ensure you have the user's initial explanation of the issue and its perceived impact.
-  - Confirm access to all relevant project artifacts (e.g., PRD, Epics/Stories, Architecture Documents, UI/UX Specifications) and, critically, the `.bmad-core/checklists/change-checklist`.
+  - Confirm access to all relevant project artifacts (e.g., PRD, Epics/Stories, Architecture Documents, UI/UX Specifications) and, critically, the `bmad-core/checklists/change-checklist`.
 - **Establish Interaction Mode:**
   - Ask the user their preferred interaction mode for this task:
     - **"Incrementally (Default & Recommended):** Shall we work through the change-checklist section by section, discussing findings and collaboratively drafting proposed changes for each relevant part before moving to the next? This allows for detailed, step-by-step refinement."
@@ -3981,9 +3981,9 @@ The story creation is successful when:
   - A summary of the change-checklist analysis (issue, impact, rationale for the chosen path).
   - Specific, clearly drafted proposed edits for all affected project artifacts.
 - **Implicit:** An annotated change-checklist (or the record of its completion) reflecting the discussions, findings, and decisions made during the process.
-==================== END: .bmad-core/tasks/correct-course.md ====================
+==================== END: bmad-core/tasks/correct-course.md ====================
 
-==================== START: .bmad-core/tasks/execute-checklist.md ====================
+==================== START: bmad-core/tasks/execute-checklist.md ====================
 <!-- Powered by BMAD™ Core -->
 # Checklist Validation Task
 
@@ -3991,7 +3991,7 @@ This task provides instructions for validating documentation against checklists.
 
 ## Available Checklists
 
-If the user asks or does not specify a specific checklist, list the checklists available to the agent persona. If the task is being run not with a specific agent, tell the user to check the .bmad-core/checklists folder to select the appropriate one to run.
+If the user asks or does not specify a specific checklist, list the checklists available to the agent persona. If the task is being run not with a specific agent, tell the user to check the bmad-core/checklists folder to select the appropriate one to run.
 
 ## Instructions
 
@@ -3999,7 +3999,7 @@ If the user asks or does not specify a specific checklist, list the checklists a
    - If user or the task being run provides a checklist name:
      - Try fuzzy matching (e.g. "architecture checklist" -> "architect-checklist")
      - If multiple matches found, ask user to clarify
-     - Load the appropriate checklist from .bmad-core/checklists/
+     - Load the appropriate checklist from bmad-core/checklists/
    - If no checklist specified:
      - Ask the user which checklist they want to use
      - Present the available options from the files in the checklists folder
@@ -4071,9 +4071,9 @@ The LLM will:
 - Execute the complete checklist validation
 - Present a final report with pass/fail rates and key findings
 - Offer to provide detailed analysis of any section, especially those with warnings or failures
-==================== END: .bmad-core/tasks/execute-checklist.md ====================
+==================== END: bmad-core/tasks/execute-checklist.md ====================
 
-==================== START: .bmad-core/tasks/shard-doc.md ====================
+==================== START: bmad-core/tasks/shard-doc.md ====================
 <!-- Powered by BMAD™ Core -->
 # Document Sharding Task
 
@@ -4085,20 +4085,20 @@ The LLM will:
 
 ## Primary Method: Automatic with markdown-tree
 
-[[LLM: First, check if markdownExploder is set to true in .bmad-core/core-config.yaml. If it is, attempt to run the command: `md-tree explode {input file} {output path}`.
+[[LLM: First, check if markdownExploder is set to true in bmad-core/core-config.yaml. If it is, attempt to run the command: `md-tree explode {input file} {output path}`.
 
 If the command succeeds, inform the user that the document has been sharded successfully and STOP - do not proceed further.
 
 If the command fails (especially with an error indicating the command is not found or not available), inform the user: "The markdownExploder setting is enabled but the md-tree command is not available. Please either:
 
 1. Install @kayvan/markdown-tree-parser globally with: `npm install -g @kayvan/markdown-tree-parser`
-2. Or set markdownExploder to false in .bmad-core/core-config.yaml
+2. Or set markdownExploder to false in bmad-core/core-config.yaml
 
 **IMPORTANT: STOP HERE - do not proceed with manual sharding until one of the above actions is taken.**"
 
 If markdownExploder is set to false, inform the user: "The markdownExploder setting is currently false. For better performance and reliability, you should:
 
-1. Set markdownExploder to true in .bmad-core/core-config.yaml
+1. Set markdownExploder to true in bmad-core/core-config.yaml
 2. Install @kayvan/markdown-tree-parser globally with: `npm install -g @kayvan/markdown-tree-parser`
 
 I will now proceed with the manual sharding process."
@@ -4260,9 +4260,9 @@ Document sharded successfully:
 - Preserve ALL formatting, including whitespace where significant
 - Handle edge cases like sections with code blocks containing ## symbols
 - Ensure the sharding is reversible (could reconstruct the original from shards)
-==================== END: .bmad-core/tasks/shard-doc.md ====================
+==================== END: bmad-core/tasks/shard-doc.md ====================
 
-==================== START: .bmad-core/templates/brownfield-prd-tmpl.yaml ====================
+==================== START: bmad-core/templates/brownfield-prd-tmpl.yaml ====================
 # <!-- Powered by BMAD™ Core -->
 template:
   id: brownfield-prd-template-v2
@@ -4544,9 +4544,9 @@ sections:
               - template: "IV1: {{existing_functionality_verification}}"
               - template: "IV2: {{integration_point_verification}}"
               - template: "IV3: {{performance_impact_verification}}"
-==================== END: .bmad-core/templates/brownfield-prd-tmpl.yaml ====================
+==================== END: bmad-core/templates/brownfield-prd-tmpl.yaml ====================
 
-==================== START: .bmad-core/templates/prd-tmpl.yaml ====================
+==================== START: bmad-core/templates/prd-tmpl.yaml ====================
 # <!-- Powered by BMAD™ Core -->
 template:
   id: prd-template-v2
@@ -4649,7 +4649,7 @@ sections:
     instruction: |
       Gather technical decisions that will guide the Architect. Steps:
 
-      1. Check if .bmad-core/data/technical-preferences.yaml or an attached technical-preferences file exists - use it to pre-populate choices
+      1. Check if bmad-core/data/technical-preferences.yaml or an attached technical-preferences file exists - use it to pre-populate choices
       2. Ask user about: languages, frameworks, starter templates, libraries, APIs, deployment targets
       3. For unknowns, offer guidance based on project goals and MVP scope
       4. Document ALL technical choices with rationale (why this choice fits the project)
@@ -4750,9 +4750,9 @@ sections:
       - id: architect-prompt
         title: Architect Prompt
         instruction: This section will contain the prompt for the Architect, keep it short and to the point to initiate create architecture mode using this document as input.
-==================== END: .bmad-core/templates/prd-tmpl.yaml ====================
+==================== END: bmad-core/templates/prd-tmpl.yaml ====================
 
-==================== START: .bmad-core/checklists/change-checklist.md ====================
+==================== START: bmad-core/checklists/change-checklist.md ====================
 <!-- Powered by BMAD™ Core -->
 # Change Navigation Checklist
 
@@ -4936,9 +4936,9 @@ Keep it action-oriented and forward-looking.]]
 - [ ] **Confirm Next Steps:** Reiterate the handoff plan and the next actions to be taken by specific agents.
 
 ---
-==================== END: .bmad-core/checklists/change-checklist.md ====================
+==================== END: bmad-core/checklists/change-checklist.md ====================
 
-==================== START: .bmad-core/checklists/pm-checklist.md ====================
+==================== START: bmad-core/checklists/pm-checklist.md ====================
 <!-- Powered by BMAD™ Core -->
 # Product Manager (PM) Requirements Checklist
 
@@ -5310,16 +5310,16 @@ After presenting the report, ask if the user wants:
 
 - **READY FOR ARCHITECT**: The PRD and epics are comprehensive, properly structured, and ready for architectural design.
 - **NEEDS REFINEMENT**: The requirements documentation requires additional work to address the identified deficiencies.
-==================== END: .bmad-core/checklists/pm-checklist.md ====================
+==================== END: bmad-core/checklists/pm-checklist.md ====================
 
-==================== START: .bmad-core/data/technical-preferences.md ====================
+==================== START: bmad-core/data/technical-preferences.md ====================
 <!-- Powered by BMAD™ Core -->
 # User-Defined Preferred Patterns and Preferences
 
 None Listed
-==================== END: .bmad-core/data/technical-preferences.md ====================
+==================== END: bmad-core/data/technical-preferences.md ====================
 
-==================== START: .bmad-core/tasks/generate-ai-frontend-prompt.md ====================
+==================== START: bmad-core/tasks/generate-ai-frontend-prompt.md ====================
 <!-- Powered by BMAD™ Core -->
 # Create AI Frontend Prompt Task
 
@@ -5372,9 +5372,9 @@ You will now synthesize the inputs and the above principles into a final, compre
    - Output the complete, generated prompt in a clear, copy-pasteable format (e.g., a large code block).
    - Explain the structure of the prompt and why certain information was included, referencing the principles above.
    - <important_note>Conclude by reminding the user that all AI-generated code will require careful human review, testing, and refinement to be considered production-ready.</important_note>
-==================== END: .bmad-core/tasks/generate-ai-frontend-prompt.md ====================
+==================== END: bmad-core/tasks/generate-ai-frontend-prompt.md ====================
 
-==================== START: .bmad-core/templates/front-end-spec-tmpl.yaml ====================
+==================== START: bmad-core/templates/front-end-spec-tmpl.yaml ====================
 # <!-- Powered by BMAD™ Core -->
 template:
   id: frontend-spec-template-v2
@@ -5725,9 +5725,9 @@ sections:
   - id: checklist-results
     title: Checklist Results
     instruction: If a UI/UX checklist exists, run it against this document and report results here.
-==================== END: .bmad-core/templates/front-end-spec-tmpl.yaml ====================
+==================== END: bmad-core/templates/front-end-spec-tmpl.yaml ====================
 
-==================== START: .bmad-core/templates/architecture-tmpl.yaml ====================
+==================== START: bmad-core/templates/architecture-tmpl.yaml ====================
 # <!-- Powered by BMAD™ Core -->
 template:
   id: architecture-template-v2
@@ -5858,7 +5858,7 @@ sections:
     instruction: |
       This is the DEFINITIVE technology selection section. Work with the user to make specific choices:
 
-      1. Review PRD technical assumptions and any preferences from .bmad-core/data/technical-preferences.yaml or an attached technical-preferences
+      1. Review PRD technical assumptions and any preferences from bmad-core/data/technical-preferences.yaml or an attached technical-preferences
       2. For each category, present 2-3 viable options with pros/cons
       3. Make a clear recommendation based on project needs
       4. Get explicit user approval for each selection
@@ -6379,9 +6379,9 @@ sections:
           - Key UI requirements from PRD
           - Any frontend-specific decisions made here
           - Request for detailed frontend architecture
-==================== END: .bmad-core/templates/architecture-tmpl.yaml ====================
+==================== END: bmad-core/templates/architecture-tmpl.yaml ====================
 
-==================== START: .bmad-core/templates/brownfield-architecture-tmpl.yaml ====================
+==================== START: bmad-core/templates/brownfield-architecture-tmpl.yaml ====================
 # <!-- Powered by BMAD™ Core -->
 template:
   id: brownfield-architecture-template-v2
@@ -6859,9 +6859,9 @@ sections:
           - Key technical decisions based on real project constraints
           - Existing system compatibility requirements with specific verification steps
           - Clear sequencing of implementation to minimize risk to existing functionality
-==================== END: .bmad-core/templates/brownfield-architecture-tmpl.yaml ====================
+==================== END: bmad-core/templates/brownfield-architecture-tmpl.yaml ====================
 
-==================== START: .bmad-core/templates/front-end-architecture-tmpl.yaml ====================
+==================== START: bmad-core/templates/front-end-architecture-tmpl.yaml ====================
 # <!-- Powered by BMAD™ Core -->
 template:
   id: frontend-architecture-template-v2
@@ -7081,9 +7081,9 @@ sections:
           - Key import patterns
           - File naming conventions
           - Project-specific patterns and utilities
-==================== END: .bmad-core/templates/front-end-architecture-tmpl.yaml ====================
+==================== END: bmad-core/templates/front-end-architecture-tmpl.yaml ====================
 
-==================== START: .bmad-core/templates/fullstack-architecture-tmpl.yaml ====================
+==================== START: bmad-core/templates/fullstack-architecture-tmpl.yaml ====================
 # <!-- Powered by BMAD™ Core -->
 template:
   id: fullstack-architecture-template-v2
@@ -7908,9 +7908,9 @@ sections:
   - id: checklist-results
     title: Checklist Results Report
     instruction: Before running the checklist, offer to output the full architecture document. Once user confirms, execute the architect-checklist and populate results here.
-==================== END: .bmad-core/templates/fullstack-architecture-tmpl.yaml ====================
+==================== END: bmad-core/templates/fullstack-architecture-tmpl.yaml ====================
 
-==================== START: .bmad-core/checklists/architect-checklist.md ====================
+==================== START: bmad-core/checklists/architect-checklist.md ====================
 <!-- Powered by BMAD™ Core -->
 # Architect Solution Validation Checklist
 
@@ -8350,9 +8350,9 @@ Now that you've completed the checklist, generate a comprehensive validation rep
    - Component design clarity
 
 After presenting the report, ask the user if they would like detailed analysis of any specific section, especially those with warnings or failures.]]
-==================== END: .bmad-core/checklists/architect-checklist.md ====================
+==================== END: bmad-core/checklists/architect-checklist.md ====================
 
-==================== START: .bmad-core/tasks/validate-next-story.md ====================
+==================== START: bmad-core/tasks/validate-next-story.md ====================
 <!-- Powered by BMAD™ Core -->
 # Validate Next Story Task
 
@@ -8364,7 +8364,7 @@ To comprehensively validate a story draft before implementation begins, ensuring
 
 ### 0. Load Core Configuration and Inputs
 
-- Load `.bmad-core/core-config.yaml`
+- Load `bmad-core/core-config.yaml`
 - If the file does not exist, HALT and inform the user: "core-config.yaml not found. This file is required for story validation."
 - Extract key configurations: `devStoryLocation`, `prd.*`, `architecture.*`
 - Identify and load the following inputs:
@@ -8488,9 +8488,9 @@ Provide a structured validation report including:
 - **NO-GO**: Story requires fixes before implementation
 - **Implementation Readiness Score**: 1-10 scale
 - **Confidence Level**: High/Medium/Low for successful implementation
-==================== END: .bmad-core/tasks/validate-next-story.md ====================
+==================== END: bmad-core/tasks/validate-next-story.md ====================
 
-==================== START: .bmad-core/templates/story-tmpl.yaml ====================
+==================== START: bmad-core/templates/story-tmpl.yaml ====================
 # <!-- Powered by BMAD™ Core -->
 template:
   id: story-template-v2
@@ -8629,9 +8629,9 @@ sections:
     instruction: Results from QA Agent QA review of the completed story implementation
     owner: qa-agent
     editors: [qa-agent]
-==================== END: .bmad-core/templates/story-tmpl.yaml ====================
+==================== END: bmad-core/templates/story-tmpl.yaml ====================
 
-==================== START: .bmad-core/checklists/po-master-checklist.md ====================
+==================== START: bmad-core/checklists/po-master-checklist.md ====================
 <!-- Powered by BMAD™ Core -->
 # Product Owner (PO) Master Validation Checklist
 
@@ -9065,9 +9065,9 @@ After presenting the report, ask if the user wants:
 - **APPROVED**: The plan is comprehensive, properly sequenced, and ready for implementation.
 - **CONDITIONAL**: The plan requires specific adjustments before proceeding.
 - **REJECTED**: The plan requires significant revision to address critical deficiencies.
-==================== END: .bmad-core/checklists/po-master-checklist.md ====================
+==================== END: bmad-core/checklists/po-master-checklist.md ====================
 
-==================== START: .bmad-core/workflows/brownfield-fullstack.yaml ====================
+==================== START: bmad-core/workflows/brownfield-fullstack.yaml ====================
 # <!-- Powered by BMAD™ Core -->
 workflow:
   id: brownfield-fullstack
@@ -9253,7 +9253,7 @@ workflow:
         All stories implemented and reviewed!
         Project development phase complete.
 
-        Reference: .bmad-core/data/bmad-kb.md#IDE Development Workflow
+        Reference: bmad-core/data/bmad-kb.md#IDE Development Workflow
 
   flow_diagram: |
     ```mermaid
@@ -9366,9 +9366,9 @@ workflow:
       {{if missing_context}}: May need to gather additional context from user during story creation.
 
     complete: "All planning artifacts validated and development can begin. Stories will be created based on available documentation format."
-==================== END: .bmad-core/workflows/brownfield-fullstack.yaml ====================
+==================== END: bmad-core/workflows/brownfield-fullstack.yaml ====================
 
-==================== START: .bmad-core/workflows/brownfield-service.yaml ====================
+==================== START: bmad-core/workflows/brownfield-service.yaml ====================
 # <!-- Powered by BMAD™ Core -->
 workflow:
   id: brownfield-service
@@ -9500,7 +9500,7 @@ workflow:
         All stories implemented and reviewed!
         Project development phase complete.
 
-        Reference: .bmad-core/data/bmad-kb.md#IDE Development Workflow
+        Reference: bmad-core/data/bmad-kb.md#IDE Development Workflow
 
   flow_diagram: |
     ```mermaid
@@ -9557,9 +9557,9 @@ workflow:
     architect_to_po: "Architecture complete. Save it as docs/architecture.md. Please validate all artifacts for service integration safety."
     po_issues: "PO found issues with [document]. Please return to [agent] to fix and re-save the updated document."
     complete: "All planning artifacts validated and saved in docs/ folder. Move to IDE environment to begin development."
-==================== END: .bmad-core/workflows/brownfield-service.yaml ====================
+==================== END: bmad-core/workflows/brownfield-service.yaml ====================
 
-==================== START: .bmad-core/workflows/brownfield-ui.yaml ====================
+==================== START: bmad-core/workflows/brownfield-ui.yaml ====================
 # <!-- Powered by BMAD™ Core -->
 workflow:
   id: brownfield-ui
@@ -9698,7 +9698,7 @@ workflow:
         All stories implemented and reviewed!
         Project development phase complete.
 
-        Reference: .bmad-core/data/bmad-kb.md#IDE Development Workflow
+        Reference: bmad-core/data/bmad-kb.md#IDE Development Workflow
 
   flow_diagram: |
     ```mermaid
@@ -9758,9 +9758,9 @@ workflow:
     architect_to_po: "Architecture complete. Save it as docs/architecture.md. Please validate all artifacts for UI integration safety."
     po_issues: "PO found issues with [document]. Please return to [agent] to fix and re-save the updated document."
     complete: "All planning artifacts validated and saved in docs/ folder. Move to IDE environment to begin development."
-==================== END: .bmad-core/workflows/brownfield-ui.yaml ====================
+==================== END: bmad-core/workflows/brownfield-ui.yaml ====================
 
-==================== START: .bmad-core/workflows/greenfield-fullstack.yaml ====================
+==================== START: bmad-core/workflows/greenfield-fullstack.yaml ====================
 # <!-- Powered by BMAD™ Core -->
 workflow:
   id: greenfield-fullstack
@@ -9924,7 +9924,7 @@ workflow:
         All stories implemented and reviewed!
         Project development phase complete.
 
-        Reference: .bmad-core/data/bmad-kb.md#IDE Development Workflow
+        Reference: bmad-core/data/bmad-kb.md#IDE Development Workflow
 
   flow_diagram: |
     ```mermaid
@@ -10002,9 +10002,9 @@ workflow:
     updated_to_po: "All documents ready in docs/ folder. Please validate all artifacts for consistency."
     po_issues: "PO found issues with [document]. Please return to [agent] to fix and re-save the updated document."
     complete: "All planning artifacts validated and saved in docs/ folder. Move to IDE environment to begin development."
-==================== END: .bmad-core/workflows/greenfield-fullstack.yaml ====================
+==================== END: bmad-core/workflows/greenfield-fullstack.yaml ====================
 
-==================== START: .bmad-core/workflows/greenfield-service.yaml ====================
+==================== START: bmad-core/workflows/greenfield-service.yaml ====================
 # <!-- Powered by BMAD™ Core -->
 workflow:
   id: greenfield-service
@@ -10144,7 +10144,7 @@ workflow:
         All stories implemented and reviewed!
         Service development phase complete.
 
-        Reference: .bmad-core/data/bmad-kb.md#IDE Development Workflow
+        Reference: bmad-core/data/bmad-kb.md#IDE Development Workflow
 
   flow_diagram: |
     ```mermaid
@@ -10212,9 +10212,9 @@ workflow:
     updated_to_po: "All documents ready in docs/ folder. Please validate all artifacts for consistency."
     po_issues: "PO found issues with [document]. Please return to [agent] to fix and re-save the updated document."
     complete: "All planning artifacts validated and saved in docs/ folder. Move to IDE environment to begin development."
-==================== END: .bmad-core/workflows/greenfield-service.yaml ====================
+==================== END: bmad-core/workflows/greenfield-service.yaml ====================
 
-==================== START: .bmad-core/workflows/greenfield-ui.yaml ====================
+==================== START: bmad-core/workflows/greenfield-ui.yaml ====================
 # <!-- Powered by BMAD™ Core -->
 workflow:
   id: greenfield-ui
@@ -10373,7 +10373,7 @@ workflow:
         All stories implemented and reviewed!
         Project development phase complete.
 
-        Reference: .bmad-core/data/bmad-kb.md#IDE Development Workflow
+        Reference: bmad-core/data/bmad-kb.md#IDE Development Workflow
 
   flow_diagram: |
     ```mermaid
@@ -10451,4 +10451,4 @@ workflow:
     updated_to_po: "All documents ready in docs/ folder. Please validate all artifacts for consistency."
     po_issues: "PO found issues with [document]. Please return to [agent] to fix and re-save the updated document."
     complete: "All planning artifacts validated and saved in docs/ folder. Move to IDE environment to begin development."
-==================== END: .bmad-core/workflows/greenfield-ui.yaml ====================
+==================== END: bmad-core/workflows/greenfield-ui.yaml ====================

--- a/dist/teams/team-ide-minimal.txt
+++ b/dist/teams/team-ide-minimal.txt
@@ -8,13 +8,13 @@ You are now operating as a specialized AI agent from the BMad-Method framework. 
 
 2. **Resource Navigation**: This bundle contains all resources you need. Resources are marked with tags like:
 
-- `==================== START: .bmad-core/folder/filename.md ====================`
-- `==================== END: .bmad-core/folder/filename.md ====================`
+- `==================== START: bmad-core/folder/filename.md ====================`
+- `==================== END: bmad-core/folder/filename.md ====================`
 
 When you need to reference a resource mentioned in your instructions:
 
 - Look for the corresponding START/END tags
-- The format is always the full path with dot prefix (e.g., `.bmad-core/personas/analyst.md`, `.bmad-core/tasks/create-story.md`)
+- The format is always the full path with dot prefix (e.g., `bmad-core/personas/analyst.md`, `bmad-core/tasks/create-story.md`)
 - If a section is specified (e.g., `{root}/tasks/create-story.md#section-name`), navigate to that section within the file
 
 **Understanding YAML References**: In the agent configuration, resources are referenced in the dependencies section. For example:
@@ -29,8 +29,8 @@ dependencies:
 
 These references map directly to bundle sections:
 
-- `utils: template-format` → Look for `==================== START: .bmad-core/utils/template-format.md ====================`
-- `tasks: create-story` → Look for `==================== START: .bmad-core/tasks/create-story.md ====================`
+- `utils: template-format` → Look for `==================== START: bmad-core/utils/template-format.md ====================`
+- `tasks: create-story` → Look for `==================== START: bmad-core/tasks/create-story.md ====================`
 
 3. **Execution Context**: You are operating in a web environment. All your capabilities and knowledge are contained within this bundle. Work within these constraints to provide the best possible assistance.
 
@@ -39,7 +39,7 @@ These references map directly to bundle sections:
 ---
 
 
-==================== START: .bmad-core/agent-teams/team-ide-minimal.yaml ====================
+==================== START: bmad-core/agent-teams/team-ide-minimal.yaml ====================
 # <!-- Powered by BMAD™ Core -->
 bundle:
   name: Team IDE Minimal
@@ -51,9 +51,9 @@ agents:
   - dev
   - qa
 workflows: null
-==================== END: .bmad-core/agent-teams/team-ide-minimal.yaml ====================
+==================== END: bmad-core/agent-teams/team-ide-minimal.yaml ====================
 
-==================== START: .bmad-core/agents/bmad-orchestrator.md ====================
+==================== START: bmad-core/agents/bmad-orchestrator.md ====================
 # bmad-orchestrator
 
 CRITICAL: Read the full YAML, start activation to alter your state of being, follow startup section instructions, stay in this being until told to exit this mode:
@@ -178,9 +178,9 @@ dependencies:
   utils:
     - workflow-management.md
 ```
-==================== END: .bmad-core/agents/bmad-orchestrator.md ====================
+==================== END: bmad-core/agents/bmad-orchestrator.md ====================
 
-==================== START: .bmad-core/agents/po.md ====================
+==================== START: bmad-core/agents/po.md ====================
 # po
 
 CRITICAL: Read the full YAML, start activation to alter your state of being, follow startup section instructions, stay in this being until told to exit this mode:
@@ -237,9 +237,9 @@ dependencies:
   templates:
     - story-tmpl.yaml
 ```
-==================== END: .bmad-core/agents/po.md ====================
+==================== END: bmad-core/agents/po.md ====================
 
-==================== START: .bmad-core/agents/sm.md ====================
+==================== START: bmad-core/agents/sm.md ====================
 # sm
 
 CRITICAL: Read the full YAML, start activation to alter your state of being, follow startup section instructions, stay in this being until told to exit this mode:
@@ -282,9 +282,9 @@ dependencies:
   templates:
     - story-tmpl.yaml
 ```
-==================== END: .bmad-core/agents/sm.md ====================
+==================== END: bmad-core/agents/sm.md ====================
 
-==================== START: .bmad-core/agents/dev.md ====================
+==================== START: bmad-core/agents/dev.md ====================
 # dev
 
 CRITICAL: Read the full YAML, start activation to alter your state of being, follow startup section instructions, stay in this being until told to exit this mode:
@@ -335,9 +335,9 @@ dependencies:
     - execute-checklist.md
     - validate-next-story.md
 ```
-==================== END: .bmad-core/agents/dev.md ====================
+==================== END: bmad-core/agents/dev.md ====================
 
-==================== START: .bmad-core/agents/qa.md ====================
+==================== START: bmad-core/agents/qa.md ====================
 # qa
 
 CRITICAL: Read the full YAML, start activation to alter your state of being, follow startup section instructions, stay in this being until told to exit this mode:
@@ -406,9 +406,9 @@ dependencies:
     - qa-gate-tmpl.yaml
     - story-tmpl.yaml
 ```
-==================== END: .bmad-core/agents/qa.md ====================
+==================== END: bmad-core/agents/qa.md ====================
 
-==================== START: .bmad-core/tasks/advanced-elicitation.md ====================
+==================== START: bmad-core/tasks/advanced-elicitation.md ====================
 <!-- Powered by BMAD™ Core -->
 # Advanced Elicitation Task
 
@@ -527,9 +527,9 @@ Choose a number (0-8) or 9 to proceed:
 - **Stay Relevant**: Tie all elicitation back to the specific content being analyzed
 - **Identify Personas**: For multi-persona methods, clearly identify which viewpoint is speaking
 - **Maintain Flow**: Keep the process moving efficiently
-==================== END: .bmad-core/tasks/advanced-elicitation.md ====================
+==================== END: bmad-core/tasks/advanced-elicitation.md ====================
 
-==================== START: .bmad-core/tasks/create-doc.md ====================
+==================== START: bmad-core/tasks/create-doc.md ====================
 <!-- Powered by BMAD™ Core -->
 # Create Document from Template (YAML Driven)
 
@@ -548,7 +548,7 @@ When this task is invoked:
 
 ## Critical: Template Discovery
 
-If a YAML Template has not been provided, list all templates from .bmad-core/templates or ask the user to provide another.
+If a YAML Template has not been provided, list all templates from bmad-core/templates or ask the user to provide another.
 
 ## CRITICAL: Mandatory Elicitation Format
 
@@ -632,9 +632,9 @@ User can type `#yolo` to toggle to YOLO mode (process all sections at once).
 - Select options 2-9 from data/elicitation-methods only
 - Provide detailed rationale explaining decisions
 - End with "Select 1-9 or just type your question/feedback:"
-==================== END: .bmad-core/tasks/create-doc.md ====================
+==================== END: bmad-core/tasks/create-doc.md ====================
 
-==================== START: .bmad-core/tasks/kb-mode-interaction.md ====================
+==================== START: bmad-core/tasks/kb-mode-interaction.md ====================
 <!-- Powered by BMAD™ Core -->
 # KB Mode Interaction Task
 
@@ -711,9 +711,9 @@ Or ask me about anything else related to BMad-Method!
 **User**: Tell me about workflows
 
 **Assistant**: [Provides focused information about workflows from the KB, then offers to explore specific workflow types or related topics]
-==================== END: .bmad-core/tasks/kb-mode-interaction.md ====================
+==================== END: bmad-core/tasks/kb-mode-interaction.md ====================
 
-==================== START: .bmad-core/data/bmad-kb.md ====================
+==================== START: bmad-core/data/bmad-kb.md ====================
 <!-- Powered by BMAD™ Core -->
 # BMAD™ Knowledge Base
 
@@ -822,7 +822,7 @@ npx bmad-method install
 
 **Verify Installation**:
 
-- `.bmad-core/` folder created with all agents
+- `bmad-core/` folder created with all agents
 - IDE-specific integration files created
 - All agent commands/rules/modes available
 
@@ -1521,9 +1521,9 @@ Use the **expansion-creator** pack to build your own:
 - **Documentation**: Check `docs/` folder for project-specific context
 - **Community**: Discord and GitHub resources available for support
 - **Contributing**: See `CONTRIBUTING.md` for full guidelines
-==================== END: .bmad-core/data/bmad-kb.md ====================
+==================== END: bmad-core/data/bmad-kb.md ====================
 
-==================== START: .bmad-core/data/elicitation-methods.md ====================
+==================== START: bmad-core/data/elicitation-methods.md ====================
 <!-- Powered by BMAD™ Core -->
 # Elicitation Methods Data
 
@@ -1679,9 +1679,9 @@ Use the **expansion-creator** pack to build your own:
 - Acknowledge choice to finalize current work
 - Accept output as-is or move to next step
 - Prepare to continue without additional elicitation
-==================== END: .bmad-core/data/elicitation-methods.md ====================
+==================== END: bmad-core/data/elicitation-methods.md ====================
 
-==================== START: .bmad-core/utils/workflow-management.md ====================
+==================== START: bmad-core/utils/workflow-management.md ====================
 <!-- Powered by BMAD™ Core -->
 # Workflow Management
 
@@ -1752,15 +1752,15 @@ Handle conditional paths by asking clarifying questions when needed.
 ## Agent Integration
 
 Agents should be workflow-aware: know active workflow, their role, access artifacts, understand expected outputs.
-==================== END: .bmad-core/utils/workflow-management.md ====================
+==================== END: bmad-core/utils/workflow-management.md ====================
 
-==================== START: .bmad-core/tasks/correct-course.md ====================
+==================== START: bmad-core/tasks/correct-course.md ====================
 <!-- Powered by BMAD™ Core -->
 # Correct Course Task
 
 ## Purpose
 
-- Guide a structured response to a change trigger using the `.bmad-core/checklists/change-checklist`.
+- Guide a structured response to a change trigger using the `bmad-core/checklists/change-checklist`.
 - Analyze the impacts of the change on epics, project artifacts, and the MVP, guided by the checklist's structure.
 - Explore potential solutions (e.g., adjust scope, rollback elements, re-scope features) as prompted by the checklist.
 - Draft specific, actionable proposed updates to any affected project artifacts (e.g., epics, user stories, PRD sections, architecture document sections) based on the analysis.
@@ -1774,7 +1774,7 @@ Agents should be workflow-aware: know active workflow, their role, access artifa
 - **Acknowledge Task & Inputs:**
   - Confirm with the user that the "Correct Course Task" (Change Navigation & Integration) is being initiated.
   - Verify the change trigger and ensure you have the user's initial explanation of the issue and its perceived impact.
-  - Confirm access to all relevant project artifacts (e.g., PRD, Epics/Stories, Architecture Documents, UI/UX Specifications) and, critically, the `.bmad-core/checklists/change-checklist`.
+  - Confirm access to all relevant project artifacts (e.g., PRD, Epics/Stories, Architecture Documents, UI/UX Specifications) and, critically, the `bmad-core/checklists/change-checklist`.
 - **Establish Interaction Mode:**
   - Ask the user their preferred interaction mode for this task:
     - **"Incrementally (Default & Recommended):** Shall we work through the change-checklist section by section, discussing findings and collaboratively drafting proposed changes for each relevant part before moving to the next? This allows for detailed, step-by-step refinement."
@@ -1826,9 +1826,9 @@ Agents should be workflow-aware: know active workflow, their role, access artifa
   - A summary of the change-checklist analysis (issue, impact, rationale for the chosen path).
   - Specific, clearly drafted proposed edits for all affected project artifacts.
 - **Implicit:** An annotated change-checklist (or the record of its completion) reflecting the discussions, findings, and decisions made during the process.
-==================== END: .bmad-core/tasks/correct-course.md ====================
+==================== END: bmad-core/tasks/correct-course.md ====================
 
-==================== START: .bmad-core/tasks/execute-checklist.md ====================
+==================== START: bmad-core/tasks/execute-checklist.md ====================
 <!-- Powered by BMAD™ Core -->
 # Checklist Validation Task
 
@@ -1836,7 +1836,7 @@ This task provides instructions for validating documentation against checklists.
 
 ## Available Checklists
 
-If the user asks or does not specify a specific checklist, list the checklists available to the agent persona. If the task is being run not with a specific agent, tell the user to check the .bmad-core/checklists folder to select the appropriate one to run.
+If the user asks or does not specify a specific checklist, list the checklists available to the agent persona. If the task is being run not with a specific agent, tell the user to check the bmad-core/checklists folder to select the appropriate one to run.
 
 ## Instructions
 
@@ -1844,7 +1844,7 @@ If the user asks or does not specify a specific checklist, list the checklists a
    - If user or the task being run provides a checklist name:
      - Try fuzzy matching (e.g. "architecture checklist" -> "architect-checklist")
      - If multiple matches found, ask user to clarify
-     - Load the appropriate checklist from .bmad-core/checklists/
+     - Load the appropriate checklist from bmad-core/checklists/
    - If no checklist specified:
      - Ask the user which checklist they want to use
      - Present the available options from the files in the checklists folder
@@ -1916,9 +1916,9 @@ The LLM will:
 - Execute the complete checklist validation
 - Present a final report with pass/fail rates and key findings
 - Offer to provide detailed analysis of any section, especially those with warnings or failures
-==================== END: .bmad-core/tasks/execute-checklist.md ====================
+==================== END: bmad-core/tasks/execute-checklist.md ====================
 
-==================== START: .bmad-core/tasks/shard-doc.md ====================
+==================== START: bmad-core/tasks/shard-doc.md ====================
 <!-- Powered by BMAD™ Core -->
 # Document Sharding Task
 
@@ -1930,20 +1930,20 @@ The LLM will:
 
 ## Primary Method: Automatic with markdown-tree
 
-[[LLM: First, check if markdownExploder is set to true in .bmad-core/core-config.yaml. If it is, attempt to run the command: `md-tree explode {input file} {output path}`.
+[[LLM: First, check if markdownExploder is set to true in bmad-core/core-config.yaml. If it is, attempt to run the command: `md-tree explode {input file} {output path}`.
 
 If the command succeeds, inform the user that the document has been sharded successfully and STOP - do not proceed further.
 
 If the command fails (especially with an error indicating the command is not found or not available), inform the user: "The markdownExploder setting is enabled but the md-tree command is not available. Please either:
 
 1. Install @kayvan/markdown-tree-parser globally with: `npm install -g @kayvan/markdown-tree-parser`
-2. Or set markdownExploder to false in .bmad-core/core-config.yaml
+2. Or set markdownExploder to false in bmad-core/core-config.yaml
 
 **IMPORTANT: STOP HERE - do not proceed with manual sharding until one of the above actions is taken.**"
 
 If markdownExploder is set to false, inform the user: "The markdownExploder setting is currently false. For better performance and reliability, you should:
 
-1. Set markdownExploder to true in .bmad-core/core-config.yaml
+1. Set markdownExploder to true in bmad-core/core-config.yaml
 2. Install @kayvan/markdown-tree-parser globally with: `npm install -g @kayvan/markdown-tree-parser`
 
 I will now proceed with the manual sharding process."
@@ -2105,9 +2105,9 @@ Document sharded successfully:
 - Preserve ALL formatting, including whitespace where significant
 - Handle edge cases like sections with code blocks containing ## symbols
 - Ensure the sharding is reversible (could reconstruct the original from shards)
-==================== END: .bmad-core/tasks/shard-doc.md ====================
+==================== END: bmad-core/tasks/shard-doc.md ====================
 
-==================== START: .bmad-core/tasks/validate-next-story.md ====================
+==================== START: bmad-core/tasks/validate-next-story.md ====================
 <!-- Powered by BMAD™ Core -->
 # Validate Next Story Task
 
@@ -2119,7 +2119,7 @@ To comprehensively validate a story draft before implementation begins, ensuring
 
 ### 0. Load Core Configuration and Inputs
 
-- Load `.bmad-core/core-config.yaml`
+- Load `bmad-core/core-config.yaml`
 - If the file does not exist, HALT and inform the user: "core-config.yaml not found. This file is required for story validation."
 - Extract key configurations: `devStoryLocation`, `prd.*`, `architecture.*`
 - Identify and load the following inputs:
@@ -2243,9 +2243,9 @@ Provide a structured validation report including:
 - **NO-GO**: Story requires fixes before implementation
 - **Implementation Readiness Score**: 1-10 scale
 - **Confidence Level**: High/Medium/Low for successful implementation
-==================== END: .bmad-core/tasks/validate-next-story.md ====================
+==================== END: bmad-core/tasks/validate-next-story.md ====================
 
-==================== START: .bmad-core/templates/story-tmpl.yaml ====================
+==================== START: bmad-core/templates/story-tmpl.yaml ====================
 # <!-- Powered by BMAD™ Core -->
 template:
   id: story-template-v2
@@ -2384,9 +2384,9 @@ sections:
     instruction: Results from QA Agent QA review of the completed story implementation
     owner: qa-agent
     editors: [qa-agent]
-==================== END: .bmad-core/templates/story-tmpl.yaml ====================
+==================== END: bmad-core/templates/story-tmpl.yaml ====================
 
-==================== START: .bmad-core/checklists/change-checklist.md ====================
+==================== START: bmad-core/checklists/change-checklist.md ====================
 <!-- Powered by BMAD™ Core -->
 # Change Navigation Checklist
 
@@ -2570,9 +2570,9 @@ Keep it action-oriented and forward-looking.]]
 - [ ] **Confirm Next Steps:** Reiterate the handoff plan and the next actions to be taken by specific agents.
 
 ---
-==================== END: .bmad-core/checklists/change-checklist.md ====================
+==================== END: bmad-core/checklists/change-checklist.md ====================
 
-==================== START: .bmad-core/checklists/po-master-checklist.md ====================
+==================== START: bmad-core/checklists/po-master-checklist.md ====================
 <!-- Powered by BMAD™ Core -->
 # Product Owner (PO) Master Validation Checklist
 
@@ -3006,9 +3006,9 @@ After presenting the report, ask if the user wants:
 - **APPROVED**: The plan is comprehensive, properly sequenced, and ready for implementation.
 - **CONDITIONAL**: The plan requires specific adjustments before proceeding.
 - **REJECTED**: The plan requires significant revision to address critical deficiencies.
-==================== END: .bmad-core/checklists/po-master-checklist.md ====================
+==================== END: bmad-core/checklists/po-master-checklist.md ====================
 
-==================== START: .bmad-core/tasks/create-next-story.md ====================
+==================== START: bmad-core/tasks/create-next-story.md ====================
 <!-- Powered by BMAD™ Core -->
 # Create Next Story Task
 
@@ -3020,7 +3020,7 @@ To identify the next logical story based on project progress and epic definition
 
 ### 0. Load Core Configuration and Check Workflow
 
-- Load `.bmad-core/core-config.yaml` from the project root
+- Load `bmad-core/core-config.yaml` from the project root
 - If the file does not exist, HALT and inform the user: "core-config.yaml not found. This file is required for story creation. You can either: 1) Copy it from GITHUB bmad-core/core-config.yaml and configure it for your project OR 2) Run the BMad installer against your project to upgrade and add the file automatically. Please add and configure core-config.yaml before proceeding."
 - Extract key configurations: `devStoryLocation`, `prd.*`, `architecture.*`, `workflow.*`
 
@@ -3114,17 +3114,17 @@ ALWAYS cite source documents: `[Source: architecture/{filename}.md#{section}]`
 - Verify all source references are included for technical details
 - Ensure tasks align with both epic requirements and architecture constraints
 - Update status to "Draft" and save the story file
-- Execute `.bmad-core/tasks/execute-checklist` `.bmad-core/checklists/story-draft-checklist`
+- Execute `bmad-core/tasks/execute-checklist` `bmad-core/checklists/story-draft-checklist`
 - Provide summary to user including:
   - Story created: `{devStoryLocation}/{epicNum}.{storyNum}.story.md`
   - Status: Draft
   - Key technical components included from architecture docs
   - Any deviations or conflicts noted between epic and architecture
   - Checklist Results
-  - Next steps: For Complex stories, suggest the user carefully review the story draft and also optionally have the PO run the task `.bmad-core/tasks/validate-next-story`
-==================== END: .bmad-core/tasks/create-next-story.md ====================
+  - Next steps: For Complex stories, suggest the user carefully review the story draft and also optionally have the PO run the task `bmad-core/tasks/validate-next-story`
+==================== END: bmad-core/tasks/create-next-story.md ====================
 
-==================== START: .bmad-core/checklists/story-draft-checklist.md ====================
+==================== START: bmad-core/checklists/story-draft-checklist.md ====================
 <!-- Powered by BMAD™ Core -->
 # Story Draft Checklist
 
@@ -3279,9 +3279,9 @@ Be pragmatic - perfect documentation doesn't exist, but it must be enough to pro
 - READY: The story provides sufficient context for implementation
 - NEEDS REVISION: The story requires updates (see issues)
 - BLOCKED: External information required (specify what information)
-==================== END: .bmad-core/checklists/story-draft-checklist.md ====================
+==================== END: bmad-core/checklists/story-draft-checklist.md ====================
 
-==================== START: .bmad-core/tasks/apply-qa-fixes.md ====================
+==================== START: bmad-core/tasks/apply-qa-fixes.md ====================
 <!-- Powered by BMAD™ Core -->
 # apply-qa-fixes
 
@@ -3431,9 +3431,9 @@ Fix plan:
 - Tests validate behavior and close gaps
 - Strict adherence to allowed story update areas
 - Gate ownership remains with QA; Dev signals readiness via Status
-==================== END: .bmad-core/tasks/apply-qa-fixes.md ====================
+==================== END: bmad-core/tasks/apply-qa-fixes.md ====================
 
-==================== START: .bmad-core/checklists/story-dod-checklist.md ====================
+==================== START: bmad-core/checklists/story-dod-checklist.md ====================
 <!-- Powered by BMAD™ Core -->
 # Story Definition of Done (DoD) Checklist
 
@@ -3529,9 +3529,9 @@ After completing the checklist:
 Be honest - it's better to flag issues now than have them discovered later.]]
 
 - [ ] I, the Developer Agent, confirm that all applicable items above have been addressed.
-==================== END: .bmad-core/checklists/story-dod-checklist.md ====================
+==================== END: bmad-core/checklists/story-dod-checklist.md ====================
 
-==================== START: .bmad-core/tasks/nfr-assess.md ====================
+==================== START: bmad-core/tasks/nfr-assess.md ====================
 <!-- Powered by BMAD™ Core -->
 # nfr-assess
 
@@ -3876,9 +3876,9 @@ performance_deep_dive:
 ```
 
 </details>
-==================== END: .bmad-core/tasks/nfr-assess.md ====================
+==================== END: bmad-core/tasks/nfr-assess.md ====================
 
-==================== START: .bmad-core/tasks/qa-gate.md ====================
+==================== START: bmad-core/tasks/qa-gate.md ====================
 <!-- Powered by BMAD™ Core -->
 # qa-gate
 
@@ -4041,9 +4041,9 @@ Gate: CONCERNS → qa.qaLocation/gates/{epic}.{story}-{slug}.yml
 - Always write to standard path
 - Always update story with gate reference
 - Clear, actionable findings
-==================== END: .bmad-core/tasks/qa-gate.md ====================
+==================== END: bmad-core/tasks/qa-gate.md ====================
 
-==================== START: .bmad-core/tasks/review-story.md ====================
+==================== START: bmad-core/tasks/review-story.md ====================
 <!-- Powered by BMAD™ Core -->
 # review-story
 
@@ -4359,9 +4359,9 @@ After review:
 3. Recommend status: "Ready for Done" or "Changes Required" (owner decides)
 4. If files were modified, list them in QA Results and ask Dev to update File List
 5. Always provide constructive feedback and actionable recommendations
-==================== END: .bmad-core/tasks/review-story.md ====================
+==================== END: bmad-core/tasks/review-story.md ====================
 
-==================== START: .bmad-core/tasks/risk-profile.md ====================
+==================== START: bmad-core/tasks/risk-profile.md ====================
 <!-- Powered by BMAD™ Core -->
 # risk-profile
 
@@ -4716,9 +4716,9 @@ Risk profile: qa.qaLocation/assessments/{epic}.{story}-risk-{YYYYMMDD}.md
 - Link risks to specific test requirements
 - Track residual risk after mitigation
 - Update risk profile as story evolves
-==================== END: .bmad-core/tasks/risk-profile.md ====================
+==================== END: bmad-core/tasks/risk-profile.md ====================
 
-==================== START: .bmad-core/tasks/test-design.md ====================
+==================== START: bmad-core/tasks/test-design.md ====================
 <!-- Powered by BMAD™ Core -->
 # test-design
 
@@ -4894,9 +4894,9 @@ Before finalizing, verify:
 - **Efficient coverage**: Test once at the right level
 - **Maintainability**: Consider long-term test maintenance
 - **Fast feedback**: Quick tests run first
-==================== END: .bmad-core/tasks/test-design.md ====================
+==================== END: bmad-core/tasks/test-design.md ====================
 
-==================== START: .bmad-core/tasks/trace-requirements.md ====================
+==================== START: bmad-core/tasks/trace-requirements.md ====================
 <!-- Powered by BMAD™ Core -->
 # trace-requirements
 
@@ -5162,9 +5162,9 @@ Trace matrix: qa.qaLocation/assessments/{epic}.{story}-trace-{YYYYMMDD}.md
 - Identify both presence and absence
 - Prioritize based on risk
 - Make recommendations actionable
-==================== END: .bmad-core/tasks/trace-requirements.md ====================
+==================== END: bmad-core/tasks/trace-requirements.md ====================
 
-==================== START: .bmad-core/templates/qa-gate-tmpl.yaml ====================
+==================== START: bmad-core/templates/qa-gate-tmpl.yaml ====================
 # <!-- Powered by BMAD™ Core -->
 template:
   id: qa-gate-template-v1
@@ -5268,11 +5268,11 @@ optional_fields_examples:
       future:  # Can be addressed later
         - action: "Consider caching for better performance"
           refs: ["services/data.service.ts"]
-==================== END: .bmad-core/templates/qa-gate-tmpl.yaml ====================
+==================== END: bmad-core/templates/qa-gate-tmpl.yaml ====================
 
-==================== START: .bmad-core/data/technical-preferences.md ====================
+==================== START: bmad-core/data/technical-preferences.md ====================
 <!-- Powered by BMAD™ Core -->
 # User-Defined Preferred Patterns and Preferences
 
 None Listed
-==================== END: .bmad-core/data/technical-preferences.md ====================
+==================== END: bmad-core/data/technical-preferences.md ====================

--- a/dist/teams/team-no-ui.txt
+++ b/dist/teams/team-no-ui.txt
@@ -8,13 +8,13 @@ You are now operating as a specialized AI agent from the BMad-Method framework. 
 
 2. **Resource Navigation**: This bundle contains all resources you need. Resources are marked with tags like:
 
-- `==================== START: .bmad-core/folder/filename.md ====================`
-- `==================== END: .bmad-core/folder/filename.md ====================`
+- `==================== START: bmad-core/folder/filename.md ====================`
+- `==================== END: bmad-core/folder/filename.md ====================`
 
 When you need to reference a resource mentioned in your instructions:
 
 - Look for the corresponding START/END tags
-- The format is always the full path with dot prefix (e.g., `.bmad-core/personas/analyst.md`, `.bmad-core/tasks/create-story.md`)
+- The format is always the full path with dot prefix (e.g., `bmad-core/personas/analyst.md`, `bmad-core/tasks/create-story.md`)
 - If a section is specified (e.g., `{root}/tasks/create-story.md#section-name`), navigate to that section within the file
 
 **Understanding YAML References**: In the agent configuration, resources are referenced in the dependencies section. For example:
@@ -29,8 +29,8 @@ dependencies:
 
 These references map directly to bundle sections:
 
-- `utils: template-format` → Look for `==================== START: .bmad-core/utils/template-format.md ====================`
-- `tasks: create-story` → Look for `==================== START: .bmad-core/tasks/create-story.md ====================`
+- `utils: template-format` → Look for `==================== START: bmad-core/utils/template-format.md ====================`
+- `tasks: create-story` → Look for `==================== START: bmad-core/tasks/create-story.md ====================`
 
 3. **Execution Context**: You are operating in a web environment. All your capabilities and knowledge are contained within this bundle. Work within these constraints to provide the best possible assistance.
 
@@ -39,7 +39,7 @@ These references map directly to bundle sections:
 ---
 
 
-==================== START: .bmad-core/agent-teams/team-no-ui.yaml ====================
+==================== START: bmad-core/agent-teams/team-no-ui.yaml ====================
 # <!-- Powered by BMAD™ Core -->
 bundle:
   name: Team No UI
@@ -54,9 +54,9 @@ agents:
 workflows:
   - greenfield-service.yaml
   - brownfield-service.yaml
-==================== END: .bmad-core/agent-teams/team-no-ui.yaml ====================
+==================== END: bmad-core/agent-teams/team-no-ui.yaml ====================
 
-==================== START: .bmad-core/agents/bmad-orchestrator.md ====================
+==================== START: bmad-core/agents/bmad-orchestrator.md ====================
 # bmad-orchestrator
 
 CRITICAL: Read the full YAML, start activation to alter your state of being, follow startup section instructions, stay in this being until told to exit this mode:
@@ -181,9 +181,9 @@ dependencies:
   utils:
     - workflow-management.md
 ```
-==================== END: .bmad-core/agents/bmad-orchestrator.md ====================
+==================== END: bmad-core/agents/bmad-orchestrator.md ====================
 
-==================== START: .bmad-core/agents/analyst.md ====================
+==================== START: bmad-core/agents/analyst.md ====================
 # analyst
 
 CRITICAL: Read the full YAML, start activation to alter your state of being, follow startup section instructions, stay in this being until told to exit this mode:
@@ -245,9 +245,9 @@ dependencies:
     - market-research-tmpl.yaml
     - project-brief-tmpl.yaml
 ```
-==================== END: .bmad-core/agents/analyst.md ====================
+==================== END: bmad-core/agents/analyst.md ====================
 
-==================== START: .bmad-core/agents/pm.md ====================
+==================== START: bmad-core/agents/pm.md ====================
 # pm
 
 CRITICAL: Read the full YAML, start activation to alter your state of being, follow startup section instructions, stay in this being until told to exit this mode:
@@ -309,9 +309,9 @@ dependencies:
     - brownfield-prd-tmpl.yaml
     - prd-tmpl.yaml
 ```
-==================== END: .bmad-core/agents/pm.md ====================
+==================== END: bmad-core/agents/pm.md ====================
 
-==================== START: .bmad-core/agents/architect.md ====================
+==================== START: bmad-core/agents/architect.md ====================
 # architect
 
 CRITICAL: Read the full YAML, start activation to alter your state of being, follow startup section instructions, stay in this being until told to exit this mode:
@@ -374,9 +374,9 @@ dependencies:
     - front-end-architecture-tmpl.yaml
     - fullstack-architecture-tmpl.yaml
 ```
-==================== END: .bmad-core/agents/architect.md ====================
+==================== END: bmad-core/agents/architect.md ====================
 
-==================== START: .bmad-core/agents/po.md ====================
+==================== START: bmad-core/agents/po.md ====================
 # po
 
 CRITICAL: Read the full YAML, start activation to alter your state of being, follow startup section instructions, stay in this being until told to exit this mode:
@@ -433,9 +433,9 @@ dependencies:
   templates:
     - story-tmpl.yaml
 ```
-==================== END: .bmad-core/agents/po.md ====================
+==================== END: bmad-core/agents/po.md ====================
 
-==================== START: .bmad-core/tasks/advanced-elicitation.md ====================
+==================== START: bmad-core/tasks/advanced-elicitation.md ====================
 <!-- Powered by BMAD™ Core -->
 # Advanced Elicitation Task
 
@@ -554,9 +554,9 @@ Choose a number (0-8) or 9 to proceed:
 - **Stay Relevant**: Tie all elicitation back to the specific content being analyzed
 - **Identify Personas**: For multi-persona methods, clearly identify which viewpoint is speaking
 - **Maintain Flow**: Keep the process moving efficiently
-==================== END: .bmad-core/tasks/advanced-elicitation.md ====================
+==================== END: bmad-core/tasks/advanced-elicitation.md ====================
 
-==================== START: .bmad-core/tasks/create-doc.md ====================
+==================== START: bmad-core/tasks/create-doc.md ====================
 <!-- Powered by BMAD™ Core -->
 # Create Document from Template (YAML Driven)
 
@@ -575,7 +575,7 @@ When this task is invoked:
 
 ## Critical: Template Discovery
 
-If a YAML Template has not been provided, list all templates from .bmad-core/templates or ask the user to provide another.
+If a YAML Template has not been provided, list all templates from bmad-core/templates or ask the user to provide another.
 
 ## CRITICAL: Mandatory Elicitation Format
 
@@ -659,9 +659,9 @@ User can type `#yolo` to toggle to YOLO mode (process all sections at once).
 - Select options 2-9 from data/elicitation-methods only
 - Provide detailed rationale explaining decisions
 - End with "Select 1-9 or just type your question/feedback:"
-==================== END: .bmad-core/tasks/create-doc.md ====================
+==================== END: bmad-core/tasks/create-doc.md ====================
 
-==================== START: .bmad-core/tasks/kb-mode-interaction.md ====================
+==================== START: bmad-core/tasks/kb-mode-interaction.md ====================
 <!-- Powered by BMAD™ Core -->
 # KB Mode Interaction Task
 
@@ -738,9 +738,9 @@ Or ask me about anything else related to BMad-Method!
 **User**: Tell me about workflows
 
 **Assistant**: [Provides focused information about workflows from the KB, then offers to explore specific workflow types or related topics]
-==================== END: .bmad-core/tasks/kb-mode-interaction.md ====================
+==================== END: bmad-core/tasks/kb-mode-interaction.md ====================
 
-==================== START: .bmad-core/data/bmad-kb.md ====================
+==================== START: bmad-core/data/bmad-kb.md ====================
 <!-- Powered by BMAD™ Core -->
 # BMAD™ Knowledge Base
 
@@ -849,7 +849,7 @@ npx bmad-method install
 
 **Verify Installation**:
 
-- `.bmad-core/` folder created with all agents
+- `bmad-core/` folder created with all agents
 - IDE-specific integration files created
 - All agent commands/rules/modes available
 
@@ -1548,9 +1548,9 @@ Use the **expansion-creator** pack to build your own:
 - **Documentation**: Check `docs/` folder for project-specific context
 - **Community**: Discord and GitHub resources available for support
 - **Contributing**: See `CONTRIBUTING.md` for full guidelines
-==================== END: .bmad-core/data/bmad-kb.md ====================
+==================== END: bmad-core/data/bmad-kb.md ====================
 
-==================== START: .bmad-core/data/elicitation-methods.md ====================
+==================== START: bmad-core/data/elicitation-methods.md ====================
 <!-- Powered by BMAD™ Core -->
 # Elicitation Methods Data
 
@@ -1706,9 +1706,9 @@ Use the **expansion-creator** pack to build your own:
 - Acknowledge choice to finalize current work
 - Accept output as-is or move to next step
 - Prepare to continue without additional elicitation
-==================== END: .bmad-core/data/elicitation-methods.md ====================
+==================== END: bmad-core/data/elicitation-methods.md ====================
 
-==================== START: .bmad-core/utils/workflow-management.md ====================
+==================== START: bmad-core/utils/workflow-management.md ====================
 <!-- Powered by BMAD™ Core -->
 # Workflow Management
 
@@ -1779,9 +1779,9 @@ Handle conditional paths by asking clarifying questions when needed.
 ## Agent Integration
 
 Agents should be workflow-aware: know active workflow, their role, access artifacts, understand expected outputs.
-==================== END: .bmad-core/utils/workflow-management.md ====================
+==================== END: bmad-core/utils/workflow-management.md ====================
 
-==================== START: .bmad-core/tasks/create-deep-research-prompt.md ====================
+==================== START: bmad-core/tasks/create-deep-research-prompt.md ====================
 <!-- Powered by BMAD™ Core -->
 # Create Deep Research Prompt Task
 
@@ -2061,9 +2061,9 @@ CRITICAL: collaborate with the user to develop specific, actionable research que
 - Balance comprehensiveness with focus
 - Document assumptions and limitations clearly
 - Plan for iterative refinement based on initial findings
-==================== END: .bmad-core/tasks/create-deep-research-prompt.md ====================
+==================== END: bmad-core/tasks/create-deep-research-prompt.md ====================
 
-==================== START: .bmad-core/tasks/document-project.md ====================
+==================== START: bmad-core/tasks/document-project.md ====================
 <!-- Powered by BMAD™ Core -->
 # Document an Existing Project
 
@@ -2408,13 +2408,13 @@ Apply the advanced elicitation task after major sections to refine based on user
 - Documents technical debt, workarounds, and constraints honestly
 - For brownfield projects with PRD: Provides clear enhancement impact analysis
 - The goal is PRACTICAL documentation for AI agents doing real work
-==================== END: .bmad-core/tasks/document-project.md ====================
+==================== END: bmad-core/tasks/document-project.md ====================
 
-==================== START: .bmad-core/tasks/facilitate-brainstorming-session.md ====================
+==================== START: bmad-core/tasks/facilitate-brainstorming-session.md ====================
 <!-- Powered by BMAD™ Core -->
 ---
 docOutputLocation: docs/brainstorming-session-results.md
-template: '.bmad-core/templates/brainstorming-output-tmpl.yaml'
+template: 'bmad-core/templates/brainstorming-output-tmpl.yaml'
 ---
 
 # Facilitate Brainstorming Session Task
@@ -2548,9 +2548,9 @@ Generate structured document with these sections:
 - Always ask before switching techniques: "Ready to try a different approach?"
 - Offer options: "Should we explore this idea deeper or generate more alternatives?"
 - Respect their process and timing
-==================== END: .bmad-core/tasks/facilitate-brainstorming-session.md ====================
+==================== END: bmad-core/tasks/facilitate-brainstorming-session.md ====================
 
-==================== START: .bmad-core/templates/brainstorming-output-tmpl.yaml ====================
+==================== START: bmad-core/templates/brainstorming-output-tmpl.yaml ====================
 template:
   id: brainstorming-output-template-v2
   name: Brainstorming Session Results
@@ -2707,9 +2707,9 @@ sections:
       ---
 
       *Session facilitated using the BMAD-METHOD™ brainstorming framework*
-==================== END: .bmad-core/templates/brainstorming-output-tmpl.yaml ====================
+==================== END: bmad-core/templates/brainstorming-output-tmpl.yaml ====================
 
-==================== START: .bmad-core/templates/competitor-analysis-tmpl.yaml ====================
+==================== START: bmad-core/templates/competitor-analysis-tmpl.yaml ====================
 # <!-- Powered by BMAD™ Core -->
 template:
   id: competitor-analysis-template-v2
@@ -3017,9 +3017,9 @@ sections:
           - Weekly: {{weekly_items}}
           - Monthly: {{monthly_items}}
           - Quarterly: {{quarterly_analysis}}
-==================== END: .bmad-core/templates/competitor-analysis-tmpl.yaml ====================
+==================== END: bmad-core/templates/competitor-analysis-tmpl.yaml ====================
 
-==================== START: .bmad-core/templates/market-research-tmpl.yaml ====================
+==================== START: bmad-core/templates/market-research-tmpl.yaml ====================
 # <!-- Powered by BMAD™ Core -->
 template:
   id: market-research-template-v2
@@ -3273,9 +3273,9 @@ sections:
       - id: additional-analysis
         title: C. Additional Analysis
         instruction: Any supplementary analysis not included in main body
-==================== END: .bmad-core/templates/market-research-tmpl.yaml ====================
+==================== END: bmad-core/templates/market-research-tmpl.yaml ====================
 
-==================== START: .bmad-core/templates/project-brief-tmpl.yaml ====================
+==================== START: bmad-core/templates/project-brief-tmpl.yaml ====================
 # <!-- Powered by BMAD™ Core -->
 template:
   id: project-brief-template-v2
@@ -3498,9 +3498,9 @@ sections:
         title: PM Handoff
         content: |
           This Project Brief provides the full context for {{project_name}}. Please start in 'PRD Generation Mode', review the brief thoroughly to work with the user to create the PRD section by section as the template indicates, asking for any necessary clarification or suggesting improvements.
-==================== END: .bmad-core/templates/project-brief-tmpl.yaml ====================
+==================== END: bmad-core/templates/project-brief-tmpl.yaml ====================
 
-==================== START: .bmad-core/data/brainstorming-techniques.md ====================
+==================== START: bmad-core/data/brainstorming-techniques.md ====================
 <!-- Powered by BMAD™ Core -->
 # Brainstorming Techniques Data
 
@@ -3538,9 +3538,9 @@ sections:
 18. **Resource Constraints**: "What if you had only $10 and 1 hour?"
 19. **Metaphor Mapping**: Use extended metaphors to explore solutions
 20. **Question Storming**: Generate questions instead of answers first
-==================== END: .bmad-core/data/brainstorming-techniques.md ====================
+==================== END: bmad-core/data/brainstorming-techniques.md ====================
 
-==================== START: .bmad-core/tasks/brownfield-create-epic.md ====================
+==================== START: bmad-core/tasks/brownfield-create-epic.md ====================
 <!-- Powered by BMAD™ Core -->
 # Create Brownfield Epic Task
 
@@ -3702,9 +3702,9 @@ The epic creation is successful when:
 - If the scope grows beyond 3 stories, consider the full brownfield PRD process
 - Always prioritize existing system integrity over new functionality
 - When in doubt about scope or complexity, escalate to full brownfield planning
-==================== END: .bmad-core/tasks/brownfield-create-epic.md ====================
+==================== END: bmad-core/tasks/brownfield-create-epic.md ====================
 
-==================== START: .bmad-core/tasks/brownfield-create-story.md ====================
+==================== START: bmad-core/tasks/brownfield-create-story.md ====================
 <!-- Powered by BMAD™ Core -->
 # Create Brownfield Story Task
 
@@ -3853,15 +3853,15 @@ The story creation is successful when:
 - Always prioritize existing system integrity
 - When in doubt about integration complexity, use brownfield-create-epic instead
 - Stories should take no more than 4 hours of focused development work
-==================== END: .bmad-core/tasks/brownfield-create-story.md ====================
+==================== END: bmad-core/tasks/brownfield-create-story.md ====================
 
-==================== START: .bmad-core/tasks/correct-course.md ====================
+==================== START: bmad-core/tasks/correct-course.md ====================
 <!-- Powered by BMAD™ Core -->
 # Correct Course Task
 
 ## Purpose
 
-- Guide a structured response to a change trigger using the `.bmad-core/checklists/change-checklist`.
+- Guide a structured response to a change trigger using the `bmad-core/checklists/change-checklist`.
 - Analyze the impacts of the change on epics, project artifacts, and the MVP, guided by the checklist's structure.
 - Explore potential solutions (e.g., adjust scope, rollback elements, re-scope features) as prompted by the checklist.
 - Draft specific, actionable proposed updates to any affected project artifacts (e.g., epics, user stories, PRD sections, architecture document sections) based on the analysis.
@@ -3875,7 +3875,7 @@ The story creation is successful when:
 - **Acknowledge Task & Inputs:**
   - Confirm with the user that the "Correct Course Task" (Change Navigation & Integration) is being initiated.
   - Verify the change trigger and ensure you have the user's initial explanation of the issue and its perceived impact.
-  - Confirm access to all relevant project artifacts (e.g., PRD, Epics/Stories, Architecture Documents, UI/UX Specifications) and, critically, the `.bmad-core/checklists/change-checklist`.
+  - Confirm access to all relevant project artifacts (e.g., PRD, Epics/Stories, Architecture Documents, UI/UX Specifications) and, critically, the `bmad-core/checklists/change-checklist`.
 - **Establish Interaction Mode:**
   - Ask the user their preferred interaction mode for this task:
     - **"Incrementally (Default & Recommended):** Shall we work through the change-checklist section by section, discussing findings and collaboratively drafting proposed changes for each relevant part before moving to the next? This allows for detailed, step-by-step refinement."
@@ -3927,9 +3927,9 @@ The story creation is successful when:
   - A summary of the change-checklist analysis (issue, impact, rationale for the chosen path).
   - Specific, clearly drafted proposed edits for all affected project artifacts.
 - **Implicit:** An annotated change-checklist (or the record of its completion) reflecting the discussions, findings, and decisions made during the process.
-==================== END: .bmad-core/tasks/correct-course.md ====================
+==================== END: bmad-core/tasks/correct-course.md ====================
 
-==================== START: .bmad-core/tasks/execute-checklist.md ====================
+==================== START: bmad-core/tasks/execute-checklist.md ====================
 <!-- Powered by BMAD™ Core -->
 # Checklist Validation Task
 
@@ -3937,7 +3937,7 @@ This task provides instructions for validating documentation against checklists.
 
 ## Available Checklists
 
-If the user asks or does not specify a specific checklist, list the checklists available to the agent persona. If the task is being run not with a specific agent, tell the user to check the .bmad-core/checklists folder to select the appropriate one to run.
+If the user asks or does not specify a specific checklist, list the checklists available to the agent persona. If the task is being run not with a specific agent, tell the user to check the bmad-core/checklists folder to select the appropriate one to run.
 
 ## Instructions
 
@@ -3945,7 +3945,7 @@ If the user asks or does not specify a specific checklist, list the checklists a
    - If user or the task being run provides a checklist name:
      - Try fuzzy matching (e.g. "architecture checklist" -> "architect-checklist")
      - If multiple matches found, ask user to clarify
-     - Load the appropriate checklist from .bmad-core/checklists/
+     - Load the appropriate checklist from bmad-core/checklists/
    - If no checklist specified:
      - Ask the user which checklist they want to use
      - Present the available options from the files in the checklists folder
@@ -4017,9 +4017,9 @@ The LLM will:
 - Execute the complete checklist validation
 - Present a final report with pass/fail rates and key findings
 - Offer to provide detailed analysis of any section, especially those with warnings or failures
-==================== END: .bmad-core/tasks/execute-checklist.md ====================
+==================== END: bmad-core/tasks/execute-checklist.md ====================
 
-==================== START: .bmad-core/tasks/shard-doc.md ====================
+==================== START: bmad-core/tasks/shard-doc.md ====================
 <!-- Powered by BMAD™ Core -->
 # Document Sharding Task
 
@@ -4031,20 +4031,20 @@ The LLM will:
 
 ## Primary Method: Automatic with markdown-tree
 
-[[LLM: First, check if markdownExploder is set to true in .bmad-core/core-config.yaml. If it is, attempt to run the command: `md-tree explode {input file} {output path}`.
+[[LLM: First, check if markdownExploder is set to true in bmad-core/core-config.yaml. If it is, attempt to run the command: `md-tree explode {input file} {output path}`.
 
 If the command succeeds, inform the user that the document has been sharded successfully and STOP - do not proceed further.
 
 If the command fails (especially with an error indicating the command is not found or not available), inform the user: "The markdownExploder setting is enabled but the md-tree command is not available. Please either:
 
 1. Install @kayvan/markdown-tree-parser globally with: `npm install -g @kayvan/markdown-tree-parser`
-2. Or set markdownExploder to false in .bmad-core/core-config.yaml
+2. Or set markdownExploder to false in bmad-core/core-config.yaml
 
 **IMPORTANT: STOP HERE - do not proceed with manual sharding until one of the above actions is taken.**"
 
 If markdownExploder is set to false, inform the user: "The markdownExploder setting is currently false. For better performance and reliability, you should:
 
-1. Set markdownExploder to true in .bmad-core/core-config.yaml
+1. Set markdownExploder to true in bmad-core/core-config.yaml
 2. Install @kayvan/markdown-tree-parser globally with: `npm install -g @kayvan/markdown-tree-parser`
 
 I will now proceed with the manual sharding process."
@@ -4206,9 +4206,9 @@ Document sharded successfully:
 - Preserve ALL formatting, including whitespace where significant
 - Handle edge cases like sections with code blocks containing ## symbols
 - Ensure the sharding is reversible (could reconstruct the original from shards)
-==================== END: .bmad-core/tasks/shard-doc.md ====================
+==================== END: bmad-core/tasks/shard-doc.md ====================
 
-==================== START: .bmad-core/templates/brownfield-prd-tmpl.yaml ====================
+==================== START: bmad-core/templates/brownfield-prd-tmpl.yaml ====================
 # <!-- Powered by BMAD™ Core -->
 template:
   id: brownfield-prd-template-v2
@@ -4490,9 +4490,9 @@ sections:
               - template: "IV1: {{existing_functionality_verification}}"
               - template: "IV2: {{integration_point_verification}}"
               - template: "IV3: {{performance_impact_verification}}"
-==================== END: .bmad-core/templates/brownfield-prd-tmpl.yaml ====================
+==================== END: bmad-core/templates/brownfield-prd-tmpl.yaml ====================
 
-==================== START: .bmad-core/templates/prd-tmpl.yaml ====================
+==================== START: bmad-core/templates/prd-tmpl.yaml ====================
 # <!-- Powered by BMAD™ Core -->
 template:
   id: prd-template-v2
@@ -4595,7 +4595,7 @@ sections:
     instruction: |
       Gather technical decisions that will guide the Architect. Steps:
 
-      1. Check if .bmad-core/data/technical-preferences.yaml or an attached technical-preferences file exists - use it to pre-populate choices
+      1. Check if bmad-core/data/technical-preferences.yaml or an attached technical-preferences file exists - use it to pre-populate choices
       2. Ask user about: languages, frameworks, starter templates, libraries, APIs, deployment targets
       3. For unknowns, offer guidance based on project goals and MVP scope
       4. Document ALL technical choices with rationale (why this choice fits the project)
@@ -4696,9 +4696,9 @@ sections:
       - id: architect-prompt
         title: Architect Prompt
         instruction: This section will contain the prompt for the Architect, keep it short and to the point to initiate create architecture mode using this document as input.
-==================== END: .bmad-core/templates/prd-tmpl.yaml ====================
+==================== END: bmad-core/templates/prd-tmpl.yaml ====================
 
-==================== START: .bmad-core/checklists/change-checklist.md ====================
+==================== START: bmad-core/checklists/change-checklist.md ====================
 <!-- Powered by BMAD™ Core -->
 # Change Navigation Checklist
 
@@ -4882,9 +4882,9 @@ Keep it action-oriented and forward-looking.]]
 - [ ] **Confirm Next Steps:** Reiterate the handoff plan and the next actions to be taken by specific agents.
 
 ---
-==================== END: .bmad-core/checklists/change-checklist.md ====================
+==================== END: bmad-core/checklists/change-checklist.md ====================
 
-==================== START: .bmad-core/checklists/pm-checklist.md ====================
+==================== START: bmad-core/checklists/pm-checklist.md ====================
 <!-- Powered by BMAD™ Core -->
 # Product Manager (PM) Requirements Checklist
 
@@ -5256,16 +5256,16 @@ After presenting the report, ask if the user wants:
 
 - **READY FOR ARCHITECT**: The PRD and epics are comprehensive, properly structured, and ready for architectural design.
 - **NEEDS REFINEMENT**: The requirements documentation requires additional work to address the identified deficiencies.
-==================== END: .bmad-core/checklists/pm-checklist.md ====================
+==================== END: bmad-core/checklists/pm-checklist.md ====================
 
-==================== START: .bmad-core/data/technical-preferences.md ====================
+==================== START: bmad-core/data/technical-preferences.md ====================
 <!-- Powered by BMAD™ Core -->
 # User-Defined Preferred Patterns and Preferences
 
 None Listed
-==================== END: .bmad-core/data/technical-preferences.md ====================
+==================== END: bmad-core/data/technical-preferences.md ====================
 
-==================== START: .bmad-core/templates/architecture-tmpl.yaml ====================
+==================== START: bmad-core/templates/architecture-tmpl.yaml ====================
 # <!-- Powered by BMAD™ Core -->
 template:
   id: architecture-template-v2
@@ -5396,7 +5396,7 @@ sections:
     instruction: |
       This is the DEFINITIVE technology selection section. Work with the user to make specific choices:
 
-      1. Review PRD technical assumptions and any preferences from .bmad-core/data/technical-preferences.yaml or an attached technical-preferences
+      1. Review PRD technical assumptions and any preferences from bmad-core/data/technical-preferences.yaml or an attached technical-preferences
       2. For each category, present 2-3 viable options with pros/cons
       3. Make a clear recommendation based on project needs
       4. Get explicit user approval for each selection
@@ -5917,9 +5917,9 @@ sections:
           - Key UI requirements from PRD
           - Any frontend-specific decisions made here
           - Request for detailed frontend architecture
-==================== END: .bmad-core/templates/architecture-tmpl.yaml ====================
+==================== END: bmad-core/templates/architecture-tmpl.yaml ====================
 
-==================== START: .bmad-core/templates/brownfield-architecture-tmpl.yaml ====================
+==================== START: bmad-core/templates/brownfield-architecture-tmpl.yaml ====================
 # <!-- Powered by BMAD™ Core -->
 template:
   id: brownfield-architecture-template-v2
@@ -6397,9 +6397,9 @@ sections:
           - Key technical decisions based on real project constraints
           - Existing system compatibility requirements with specific verification steps
           - Clear sequencing of implementation to minimize risk to existing functionality
-==================== END: .bmad-core/templates/brownfield-architecture-tmpl.yaml ====================
+==================== END: bmad-core/templates/brownfield-architecture-tmpl.yaml ====================
 
-==================== START: .bmad-core/templates/front-end-architecture-tmpl.yaml ====================
+==================== START: bmad-core/templates/front-end-architecture-tmpl.yaml ====================
 # <!-- Powered by BMAD™ Core -->
 template:
   id: frontend-architecture-template-v2
@@ -6619,9 +6619,9 @@ sections:
           - Key import patterns
           - File naming conventions
           - Project-specific patterns and utilities
-==================== END: .bmad-core/templates/front-end-architecture-tmpl.yaml ====================
+==================== END: bmad-core/templates/front-end-architecture-tmpl.yaml ====================
 
-==================== START: .bmad-core/templates/fullstack-architecture-tmpl.yaml ====================
+==================== START: bmad-core/templates/fullstack-architecture-tmpl.yaml ====================
 # <!-- Powered by BMAD™ Core -->
 template:
   id: fullstack-architecture-template-v2
@@ -7446,9 +7446,9 @@ sections:
   - id: checklist-results
     title: Checklist Results Report
     instruction: Before running the checklist, offer to output the full architecture document. Once user confirms, execute the architect-checklist and populate results here.
-==================== END: .bmad-core/templates/fullstack-architecture-tmpl.yaml ====================
+==================== END: bmad-core/templates/fullstack-architecture-tmpl.yaml ====================
 
-==================== START: .bmad-core/checklists/architect-checklist.md ====================
+==================== START: bmad-core/checklists/architect-checklist.md ====================
 <!-- Powered by BMAD™ Core -->
 # Architect Solution Validation Checklist
 
@@ -7888,9 +7888,9 @@ Now that you've completed the checklist, generate a comprehensive validation rep
    - Component design clarity
 
 After presenting the report, ask the user if they would like detailed analysis of any specific section, especially those with warnings or failures.]]
-==================== END: .bmad-core/checklists/architect-checklist.md ====================
+==================== END: bmad-core/checklists/architect-checklist.md ====================
 
-==================== START: .bmad-core/tasks/validate-next-story.md ====================
+==================== START: bmad-core/tasks/validate-next-story.md ====================
 <!-- Powered by BMAD™ Core -->
 # Validate Next Story Task
 
@@ -7902,7 +7902,7 @@ To comprehensively validate a story draft before implementation begins, ensuring
 
 ### 0. Load Core Configuration and Inputs
 
-- Load `.bmad-core/core-config.yaml`
+- Load `bmad-core/core-config.yaml`
 - If the file does not exist, HALT and inform the user: "core-config.yaml not found. This file is required for story validation."
 - Extract key configurations: `devStoryLocation`, `prd.*`, `architecture.*`
 - Identify and load the following inputs:
@@ -8026,9 +8026,9 @@ Provide a structured validation report including:
 - **NO-GO**: Story requires fixes before implementation
 - **Implementation Readiness Score**: 1-10 scale
 - **Confidence Level**: High/Medium/Low for successful implementation
-==================== END: .bmad-core/tasks/validate-next-story.md ====================
+==================== END: bmad-core/tasks/validate-next-story.md ====================
 
-==================== START: .bmad-core/templates/story-tmpl.yaml ====================
+==================== START: bmad-core/templates/story-tmpl.yaml ====================
 # <!-- Powered by BMAD™ Core -->
 template:
   id: story-template-v2
@@ -8167,9 +8167,9 @@ sections:
     instruction: Results from QA Agent QA review of the completed story implementation
     owner: qa-agent
     editors: [qa-agent]
-==================== END: .bmad-core/templates/story-tmpl.yaml ====================
+==================== END: bmad-core/templates/story-tmpl.yaml ====================
 
-==================== START: .bmad-core/checklists/po-master-checklist.md ====================
+==================== START: bmad-core/checklists/po-master-checklist.md ====================
 <!-- Powered by BMAD™ Core -->
 # Product Owner (PO) Master Validation Checklist
 
@@ -8603,9 +8603,9 @@ After presenting the report, ask if the user wants:
 - **APPROVED**: The plan is comprehensive, properly sequenced, and ready for implementation.
 - **CONDITIONAL**: The plan requires specific adjustments before proceeding.
 - **REJECTED**: The plan requires significant revision to address critical deficiencies.
-==================== END: .bmad-core/checklists/po-master-checklist.md ====================
+==================== END: bmad-core/checklists/po-master-checklist.md ====================
 
-==================== START: .bmad-core/workflows/greenfield-service.yaml ====================
+==================== START: bmad-core/workflows/greenfield-service.yaml ====================
 # <!-- Powered by BMAD™ Core -->
 workflow:
   id: greenfield-service
@@ -8745,7 +8745,7 @@ workflow:
         All stories implemented and reviewed!
         Service development phase complete.
 
-        Reference: .bmad-core/data/bmad-kb.md#IDE Development Workflow
+        Reference: bmad-core/data/bmad-kb.md#IDE Development Workflow
 
   flow_diagram: |
     ```mermaid
@@ -8813,9 +8813,9 @@ workflow:
     updated_to_po: "All documents ready in docs/ folder. Please validate all artifacts for consistency."
     po_issues: "PO found issues with [document]. Please return to [agent] to fix and re-save the updated document."
     complete: "All planning artifacts validated and saved in docs/ folder. Move to IDE environment to begin development."
-==================== END: .bmad-core/workflows/greenfield-service.yaml ====================
+==================== END: bmad-core/workflows/greenfield-service.yaml ====================
 
-==================== START: .bmad-core/workflows/brownfield-service.yaml ====================
+==================== START: bmad-core/workflows/brownfield-service.yaml ====================
 # <!-- Powered by BMAD™ Core -->
 workflow:
   id: brownfield-service
@@ -8947,7 +8947,7 @@ workflow:
         All stories implemented and reviewed!
         Project development phase complete.
 
-        Reference: .bmad-core/data/bmad-kb.md#IDE Development Workflow
+        Reference: bmad-core/data/bmad-kb.md#IDE Development Workflow
 
   flow_diagram: |
     ```mermaid
@@ -9004,4 +9004,4 @@ workflow:
     architect_to_po: "Architecture complete. Save it as docs/architecture.md. Please validate all artifacts for service integration safety."
     po_issues: "PO found issues with [document]. Please return to [agent] to fix and re-save the updated document."
     complete: "All planning artifacts validated and saved in docs/ folder. Move to IDE environment to begin development."
-==================== END: .bmad-core/workflows/brownfield-service.yaml ====================
+==================== END: bmad-core/workflows/brownfield-service.yaml ====================

--- a/docs/user-guide.md
+++ b/docs/user-guide.md
@@ -468,7 +468,7 @@ Quick reference for where Test Architect outputs are stored:
 
 ## Technical Preferences System
 
-BMad includes a personalization system through the `technical-preferences.md` file located in `.bmad-core/data/` - this can help bias the PM and Architect to recommend your preferences for design patterns, technology selection, or anything else you would like to put in here.
+BMad includes a personalization system through the `technical-preferences.md` file located in `bmad-core/data/` - this can help bias the PM and Architect to recommend your preferences for design patterns, technology selection, or anything else you would like to put in here.
 
 ### Using with Web Bundles
 

--- a/expansion-packs/bmad-2d-unity-game-dev/data/bmad-kb.md
+++ b/expansion-packs/bmad-2d-unity-game-dev/data/bmad-kb.md
@@ -132,7 +132,7 @@ npx bmad-method install
 
 **Verify Game Development Installation**:
 
-- `.bmad-core/` folder created with all core agents
+- `bmad-core/` folder created with all core agents
 - `.bmad-2d-unity-game-dev/` folder with game development agents
 - IDE-specific integration files created
 - Game development agents available with `/bmad2du` prefix (per config.yaml)

--- a/expansion-packs/bmad-infrastructure-devops/README.md
+++ b/expansion-packs/bmad-infrastructure-devops/README.md
@@ -76,7 +76,7 @@ node tools/install-expansion-pack.js infrastructure
 
 This will:
 
-1. Copy all files to their appropriate locations in `.bmad-core/`
+1. Copy all files to their appropriate locations in `bmad-core/`
 2. Update any necessary configurations
 3. Make the DevOps agent available in teams
 

--- a/tools/builders/web-builder.js
+++ b/tools/builders/web-builder.js
@@ -41,22 +41,22 @@ class WebBuilder {
 
   generateWebInstructions(bundleType, packName = null) {
     // Generate dynamic web instructions based on bundle type
-    const rootExample = packName ? `.${packName}` : '.bmad-core';
+    const rootExample = packName ? `.${packName}` : 'bmad-core';
     const examplePath = packName
       ? `.${packName}/folder/filename.md`
-      : '.bmad-core/folder/filename.md';
+      : 'bmad-core/folder/filename.md';
     const personasExample = packName
       ? `.${packName}/personas/analyst.md`
-      : '.bmad-core/personas/analyst.md';
+      : 'bmad-core/personas/analyst.md';
     const tasksExample = packName
       ? `.${packName}/tasks/create-story.md`
-      : '.bmad-core/tasks/create-story.md';
+      : 'bmad-core/tasks/create-story.md';
     const utilitiesExample = packName
       ? `.${packName}/utils/template-format.md`
-      : '.bmad-core/utils/template-format.md';
+      : 'bmad-core/utils/template-format.md';
     const tasksReference = packName
       ? `.${packName}/tasks/create-story.md`
-      : '.bmad-core/tasks/create-story.md';
+      : 'bmad-core/tasks/create-story.md';
 
     return `# Web Agent Bundle Instructions
 

--- a/tools/flattener/ignoreRules.js
+++ b/tools/flattener/ignoreRules.js
@@ -6,7 +6,7 @@ const ignore = require('ignore');
 // These complement .gitignore and are applied regardless of VCS presence.
 const DEFAULT_PATTERNS = [
   // Project/VCS
-  '**/.bmad-core/**',
+  '**/bmad-core/**',
   '**/.git/**',
   '**/.svn/**',
   '**/.hg/**',

--- a/tools/installer/bin/bmad.js
+++ b/tools/installer/bin/bmad.js
@@ -254,9 +254,9 @@ async function promptInstallation() {
       currentVersion === newVersion
         ? `(v${currentVersion} - reinstall)`
         : `(v${currentVersion} → v${newVersion})`;
-    bmadOptionText = `Update ${coreShortTitle} ${versionInfo} .bmad-core`;
+    bmadOptionText = `Update ${coreShortTitle} ${versionInfo} bmad-core`;
   } else {
-    bmadOptionText = `${coreShortTitle} (v${version}) .bmad-core`;
+    bmadOptionText = `${coreShortTitle} (v${version}) bmad-core`;
   }
 
   choices.push({

--- a/tools/installer/config/install.config.yaml
+++ b/tools/installer/config/install.config.yaml
@@ -1,7 +1,7 @@
 installation-options:
   full:
     name: Complete BMad Core
-    description: Copy the entire .bmad-core folder with all agents, templates, and tools
+    description: Copy the entire bmad-core folder with all agents, templates, and tools
     action: copy-folder
     source: bmad-core
   single-agent:

--- a/tools/installer/lib/config-loader.js
+++ b/tools/installer/lib/config-loader.js
@@ -148,7 +148,7 @@ class ConfigLoader {
 
     // Add all resolved resources
     for (const resource of agentDeps.resources) {
-      const filePath = `.bmad-core/${resource.type}/${resource.id}.md`;
+      const filePath = `bmad-core/${resource.type}/${resource.id}.md`;
       if (!depPaths.includes(filePath)) {
         depPaths.push(filePath);
       }
@@ -229,11 +229,11 @@ class ConfigLoader {
       const depPaths = [];
 
       // Add team config file
-      depPaths.push(`.bmad-core/agent-teams/${teamId}.yaml`);
+      depPaths.push(`bmad-core/agent-teams/${teamId}.yaml`);
 
       // Add all agents
       for (const agent of teamDeps.agents) {
-        const filePath = `.bmad-core/agents/${agent.id}.md`;
+        const filePath = `bmad-core/agents/${agent.id}.md`;
         if (!depPaths.includes(filePath)) {
           depPaths.push(filePath);
         }
@@ -241,7 +241,7 @@ class ConfigLoader {
 
       // Add all resolved resources
       for (const resource of teamDeps.resources) {
-        const filePath = `.bmad-core/${resource.type}/${resource.id}.${resource.type === 'workflows' ? 'yaml' : 'md'}`;
+        const filePath = `bmad-core/${resource.type}/${resource.id}.${resource.type === 'workflows' ? 'yaml' : 'md'}`;
         if (!depPaths.includes(filePath)) {
           depPaths.push(filePath);
         }

--- a/tools/installer/lib/file-manager.js
+++ b/tools/installer/lib/file-manager.js
@@ -272,7 +272,7 @@ class FileManager {
   }
 
   async modifyCoreConfig(installDir, config) {
-    const coreConfigPath = path.join(installDir, '.bmad-core', 'core-config.yaml');
+    const coreConfigPath = path.join(installDir, 'bmad-core', 'core-config.yaml');
 
     try {
       // Read the existing core-config.yaml
@@ -382,7 +382,7 @@ class FileManager {
       return false;
     }
   }
-  manifestDir = '.bmad-core';
+  manifestDir = 'bmad-core';
   manifestFile = 'install-manifest.yaml';
 }
 

--- a/tools/installer/lib/ide-base-setup.js
+++ b/tools/installer/lib/ide-base-setup.js
@@ -50,7 +50,7 @@ class BaseIdeSetup {
   async getCoreAgentIds(installDir) {
     const coreAgents = [];
     const corePaths = [
-      path.join(installDir, '.bmad-core', 'agents'),
+      path.join(installDir, 'bmad-core', 'agents'),
       path.join(installDir, 'bmad-core', 'agents'),
     ];
 
@@ -80,7 +80,7 @@ class BaseIdeSetup {
     if (!agentPath) {
       // Check installation-specific paths
       const possiblePaths = [
-        path.join(installDir, '.bmad-core', 'agents', `${agentId}.md`),
+        path.join(installDir, 'bmad-core', 'agents', `${agentId}.md`),
         path.join(installDir, 'bmad-core', 'agents', `${agentId}.md`),
         path.join(installDir, 'common', 'agents', `${agentId}.md`),
       ];
@@ -134,7 +134,7 @@ class BaseIdeSetup {
     const dotExpansions = await resourceLocator.findFiles('.bmad-*', { cwd: installDir });
 
     for (const dotExpansion of dotExpansions) {
-      if (dotExpansion !== '.bmad-core') {
+      if (dotExpansion !== 'bmad-core') {
         const packPath = path.join(installDir, dotExpansion);
         const packName = dotExpansion.slice(1); // remove the dot
         expansionPacks.push({
@@ -147,7 +147,7 @@ class BaseIdeSetup {
     // Check other dot folders that have config.yaml
     const allDotFolders = await resourceLocator.findFiles('.*', { cwd: installDir });
     for (const folder of allDotFolders) {
-      if (!folder.startsWith('.bmad-') && folder !== '.bmad-core') {
+      if (!folder.startsWith('.bmad-') && folder !== 'bmad-core') {
         const packPath = path.join(installDir, folder);
         const configPath = path.join(packPath, 'config.yaml');
         if (await fileManager.pathExists(configPath)) {

--- a/tools/installer/lib/ide-setup.js
+++ b/tools/installer/lib/ide-setup.js
@@ -113,7 +113,7 @@ class IdeSetup extends BaseIdeSetup {
       coreSlashPrefix,
       coreAgents,
       coreTasks,
-      '.bmad-core',
+      'bmad-core',
     );
 
     // Setup expansion pack commands
@@ -151,7 +151,7 @@ class IdeSetup extends BaseIdeSetup {
       coreSlashPrefix,
       coreAgents,
       coreTasks,
-      '.bmad-core',
+      'bmad-core',
     );
 
     // Setup expansion pack commands
@@ -445,7 +445,7 @@ class IdeSetup extends BaseIdeSetup {
   async findAgentPath(agentId, installDir) {
     // Try to find the agent file in various locations
     const possiblePaths = [
-      path.join(installDir, '.bmad-core', 'agents', `${agentId}.md`),
+      path.join(installDir, 'bmad-core', 'agents', `${agentId}.md`),
       path.join(installDir, 'agents', `${agentId}.md`),
     ];
 
@@ -469,8 +469,8 @@ class IdeSetup extends BaseIdeSetup {
     const glob = require('glob');
     const allAgentIds = [];
 
-    // Check core agents in .bmad-core or root
-    let agentsDir = path.join(installDir, '.bmad-core', 'agents');
+    // Check core agents in bmad-core or root
+    let agentsDir = path.join(installDir, 'bmad-core', 'agents');
     if (!(await fileManager.pathExists(agentsDir))) {
       agentsDir = path.join(installDir, 'agents');
     }
@@ -495,8 +495,8 @@ class IdeSetup extends BaseIdeSetup {
   async getCoreAgentIds(installDir) {
     const allAgentIds = [];
 
-    // Check core agents in .bmad-core or root only
-    let agentsDir = path.join(installDir, '.bmad-core', 'agents');
+    // Check core agents in bmad-core or root only
+    let agentsDir = path.join(installDir, 'bmad-core', 'agents');
     if (!(await fileManager.pathExists(agentsDir))) {
       agentsDir = path.join(installDir, 'bmad-core', 'agents');
     }
@@ -513,8 +513,8 @@ class IdeSetup extends BaseIdeSetup {
   async getCoreTaskIds(installDir) {
     const allTaskIds = [];
 
-    // Check core tasks in .bmad-core or root only
-    let tasksDir = path.join(installDir, '.bmad-core', 'tasks');
+    // Check core tasks in bmad-core or root only
+    let tasksDir = path.join(installDir, 'bmad-core', 'tasks');
     if (!(await fileManager.pathExists(tasksDir))) {
       tasksDir = path.join(installDir, 'bmad-core', 'tasks');
     }
@@ -538,7 +538,7 @@ class IdeSetup extends BaseIdeSetup {
   async getAgentTitle(agentId, installDir) {
     // Try to find the agent file in various locations
     const possiblePaths = [
-      path.join(installDir, '.bmad-core', 'agents', `${agentId}.md`),
+      path.join(installDir, 'bmad-core', 'agents', `${agentId}.md`),
       path.join(installDir, 'agents', `${agentId}.md`),
     ];
 
@@ -579,8 +579,8 @@ class IdeSetup extends BaseIdeSetup {
     const glob = require('glob');
     const allTaskIds = [];
 
-    // Check core tasks in .bmad-core or root
-    let tasksDir = path.join(installDir, '.bmad-core', 'tasks');
+    // Check core tasks in bmad-core or root
+    let tasksDir = path.join(installDir, 'bmad-core', 'tasks');
     if (!(await fileManager.pathExists(tasksDir))) {
       tasksDir = path.join(installDir, 'bmad-core', 'tasks');
     }
@@ -623,7 +623,7 @@ class IdeSetup extends BaseIdeSetup {
   async findTaskPath(taskId, installDir) {
     // Try to find the task file in various locations
     const possiblePaths = [
-      path.join(installDir, '.bmad-core', 'tasks', `${taskId}.md`),
+      path.join(installDir, 'bmad-core', 'tasks', `${taskId}.md`),
       path.join(installDir, 'bmad-core', 'tasks', `${taskId}.md`),
       path.join(installDir, 'common', 'tasks', `${taskId}.md`),
     ];
@@ -657,7 +657,7 @@ class IdeSetup extends BaseIdeSetup {
 
   async getCoreSlashPrefix(installDir) {
     try {
-      const coreConfigPath = path.join(installDir, '.bmad-core', 'core-config.yaml');
+      const coreConfigPath = path.join(installDir, 'bmad-core', 'core-config.yaml');
       if (!(await fileManager.pathExists(coreConfigPath))) {
         // Try bmad-core directory
         const altConfigPath = path.join(installDir, 'bmad-core', 'core-config.yaml');
@@ -686,7 +686,7 @@ class IdeSetup extends BaseIdeSetup {
     const dotExpansions = glob.sync('.bmad-*', { cwd: installDir });
 
     for (const dotExpansion of dotExpansions) {
-      if (dotExpansion !== '.bmad-core') {
+      if (dotExpansion !== 'bmad-core') {
         const packPath = path.join(installDir, dotExpansion);
         const packName = dotExpansion.slice(1); // remove the dot
         expansionPacks.push({
@@ -1012,7 +1012,7 @@ class IdeSetup extends BaseIdeSetup {
         }
         mdContent += '\n```\n\n';
         mdContent += '## Project Standards\n\n';
-        mdContent += `- Always maintain consistency with project documentation in .bmad-core/\n`;
+        mdContent += `- Always maintain consistency with project documentation in bmad-core/\n`;
         mdContent += `- Follow the agent's specific guidelines and constraints\n`;
         mdContent += `- Update relevant project files when making changes\n`;
         const relativePath = path.relative(installDir, agentPath).replaceAll('\\', '/');

--- a/tools/installer/lib/installer.js
+++ b/tools/installer/lib/installer.js
@@ -34,8 +34,8 @@ class Installer {
         ? config.directory
         : path.resolve(originalCwd, config.directory);
 
-      if (path.basename(installDir) === '.bmad-core') {
-        // If user points directly to .bmad-core, treat its parent as the project root
+      if (path.basename(installDir) === 'bmad-core') {
+        // If user points directly to bmad-core, treat its parent as the project root
         installDir = path.dirname(installDir);
       }
 
@@ -173,8 +173,8 @@ class Installer {
       return state; // clean install
     }
 
-    // Check for V4 installation (has .bmad-core with manifest)
-    const bmadCorePath = path.join(installDir, '.bmad-core');
+    // Check for V4 installation (has bmad-core with manifest)
+    const bmadCorePath = path.join(installDir, 'bmad-core');
     const manifestPath = path.join(bmadCorePath, 'install-manifest.yaml');
 
     if (await fileManager.pathExists(manifestPath)) {
@@ -193,7 +193,7 @@ class Installer {
       return state;
     }
 
-    // Check for .bmad-core without manifest (broken V4 or manual copy)
+    // Check for bmad-core without manifest (broken V4 or manual copy)
     if (await fileManager.pathExists(bmadCorePath)) {
       state.type = 'unknown_existing';
       state.hasBmadCore = true;
@@ -227,23 +227,19 @@ class Installer {
 
     switch (config.installType) {
       case 'full': {
-        // Full installation - copy entire .bmad-core folder as a subdirectory
-        spinner.text = 'Copying complete .bmad-core folder...';
+        // Full installation - copy entire bmad-core folder as a subdirectory
+        spinner.text = 'Copying complete bmad-core folder...';
         const sourceDir = resourceLocator.getBmadCorePath();
-        const bmadCoreDestDir = path.join(installDir, '.bmad-core');
-        await fileManager.copyDirectoryWithRootReplacement(
-          sourceDir,
-          bmadCoreDestDir,
-          '.bmad-core',
-        );
+        const bmadCoreDestDir = path.join(installDir, 'bmad-core');
+        await fileManager.copyDirectoryWithRootReplacement(sourceDir, bmadCoreDestDir, 'bmad-core');
 
-        // Copy common/ items to .bmad-core
+        // Copy common/ items to bmad-core
         spinner.text = 'Copying common utilities...';
-        await this.copyCommonItems(installDir, '.bmad-core', spinner);
+        await this.copyCommonItems(installDir, 'bmad-core', spinner);
 
-        // Copy documentation files from docs/ to .bmad-core
+        // Copy documentation files from docs/ to bmad-core
         spinner.text = 'Copying documentation files...';
-        await this.copyDocsItems(installDir, '.bmad-core', spinner);
+        await this.copyDocsItems(installDir, 'bmad-core', spinner);
 
         // Get list of all files for manifest
         const foundFiles = await resourceLocator.findFiles('**/*', {
@@ -251,7 +247,7 @@ class Installer {
           nodir: true,
           ignore: ['**/.git/**', '**/node_modules/**'],
         });
-        files = foundFiles.map((file) => path.join('.bmad-core', file));
+        files = foundFiles.map((file) => path.join('bmad-core', file));
 
         break;
       }
@@ -263,16 +259,12 @@ class Installer {
         const agentPath = configLoader.getAgentPath(config.agent);
         const destinationAgentPath = path.join(
           installDir,
-          '.bmad-core',
+          'bmad-core',
           'agents',
           `${config.agent}.md`,
         );
-        await fileManager.copyFileWithRootReplacement(
-          agentPath,
-          destinationAgentPath,
-          '.bmad-core',
-        );
-        files.push(`.bmad-core/agents/${config.agent}.md`);
+        await fileManager.copyFileWithRootReplacement(agentPath, destinationAgentPath, 'bmad-core');
+        files.push(`bmad-core/agents/${config.agent}.md`);
 
         // Copy dependencies
         const { all: dependencies } = await resourceLocator.getAgentDependencies(config.agent);
@@ -284,15 +276,15 @@ class Installer {
           if (dep.includes('*')) {
             // Handle glob patterns with {root} replacement
             const copiedFiles = await fileManager.copyGlobPattern(
-              dep.replace('.bmad-core/', ''),
+              dep.replace('bmad-core/', ''),
               sourceBase,
-              path.join(installDir, '.bmad-core'),
-              '.bmad-core',
+              path.join(installDir, 'bmad-core'),
+              'bmad-core',
             );
-            files.push(...copiedFiles.map((f) => `.bmad-core/${f}`));
+            files.push(...copiedFiles.map((f) => `bmad-core/${f}`));
           } else {
             // Handle single files with {root} replacement if needed
-            const sourcePath = path.join(sourceBase, dep.replace('.bmad-core/', ''));
+            const sourcePath = path.join(sourceBase, dep.replace('bmad-core/', ''));
             const destinationPath = path.join(installDir, dep);
 
             const needsRootReplacement =
@@ -300,7 +292,7 @@ class Installer {
             let success = false;
 
             success = await (needsRootReplacement
-              ? fileManager.copyFileWithRootReplacement(sourcePath, destinationPath, '.bmad-core')
+              ? fileManager.copyFileWithRootReplacement(sourcePath, destinationPath, 'bmad-core')
               : fileManager.copyFile(sourcePath, destinationPath));
 
             if (success) {
@@ -309,14 +301,14 @@ class Installer {
           }
         }
 
-        // Copy common/ items to .bmad-core
+        // Copy common/ items to bmad-core
         spinner.text = 'Copying common utilities...';
-        const commonFiles = await this.copyCommonItems(installDir, '.bmad-core', spinner);
+        const commonFiles = await this.copyCommonItems(installDir, 'bmad-core', spinner);
         files.push(...commonFiles);
 
-        // Copy documentation files from docs/ to .bmad-core
+        // Copy documentation files from docs/ to bmad-core
         spinner.text = 'Copying documentation files...';
-        const documentFiles = await this.copyDocsItems(installDir, '.bmad-core', spinner);
+        const documentFiles = await this.copyDocsItems(installDir, 'bmad-core', spinner);
         files.push(...documentFiles);
 
         break;
@@ -336,15 +328,15 @@ class Installer {
           if (dep.includes('*')) {
             // Handle glob patterns with {root} replacement
             const copiedFiles = await fileManager.copyGlobPattern(
-              dep.replace('.bmad-core/', ''),
+              dep.replace('bmad-core/', ''),
               sourceBase,
-              path.join(installDir, '.bmad-core'),
-              '.bmad-core',
+              path.join(installDir, 'bmad-core'),
+              'bmad-core',
             );
-            files.push(...copiedFiles.map((f) => `.bmad-core/${f}`));
+            files.push(...copiedFiles.map((f) => `bmad-core/${f}`));
           } else {
             // Handle single files with {root} replacement if needed
-            const sourcePath = path.join(sourceBase, dep.replace('.bmad-core/', ''));
+            const sourcePath = path.join(sourceBase, dep.replace('bmad-core/', ''));
             const destinationPath = path.join(installDir, dep);
 
             const needsRootReplacement =
@@ -352,7 +344,7 @@ class Installer {
             let success = false;
 
             success = await (needsRootReplacement
-              ? fileManager.copyFileWithRootReplacement(sourcePath, destinationPath, '.bmad-core')
+              ? fileManager.copyFileWithRootReplacement(sourcePath, destinationPath, 'bmad-core')
               : fileManager.copyFile(sourcePath, destinationPath));
 
             if (success) {
@@ -361,20 +353,20 @@ class Installer {
           }
         }
 
-        // Copy common/ items to .bmad-core
+        // Copy common/ items to bmad-core
         spinner.text = 'Copying common utilities...';
-        const commonFiles = await this.copyCommonItems(installDir, '.bmad-core', spinner);
+        const commonFiles = await this.copyCommonItems(installDir, 'bmad-core', spinner);
         files.push(...commonFiles);
 
-        // Copy documentation files from docs/ to .bmad-core
+        // Copy documentation files from docs/ to bmad-core
         spinner.text = 'Copying documentation files...';
-        const documentFiles = await this.copyDocsItems(installDir, '.bmad-core', spinner);
+        const documentFiles = await this.copyDocsItems(installDir, 'bmad-core', spinner);
         files.push(...documentFiles);
 
         break;
       }
       case 'expansion-only': {
-        // Expansion-only installation - DO NOT create .bmad-core
+        // Expansion-only installation - DO NOT create bmad-core
         // Only install expansion packs
         spinner.text = 'Installing expansion packs only...';
 
@@ -633,7 +625,7 @@ class Installer {
     console.log(`   Directory: ${installDir}`);
 
     if (state.hasBmadCore) {
-      console.log('   Found: .bmad-core directory (but no manifest)');
+      console.log('   Found: bmad-core directory (but no manifest)');
     }
     if (state.hasOtherFiles) {
       console.log('   Found: Other files in directory');
@@ -771,7 +763,7 @@ class Installer {
         // Skip the manifest file itself
         if (file.endsWith('install-manifest.yaml')) continue;
 
-        const relativePath = file.replace('.bmad-core/', '');
+        const relativePath = file.replace('bmad-core/', '');
         const destinationPath = path.join(installDir, file);
 
         // Check if this is a common/ file that needs special processing
@@ -782,7 +774,7 @@ class Installer {
           // This is a common/ file - needs template processing
           const fs = require('node:fs').promises;
           const content = await fs.readFile(commonSourcePath, 'utf8');
-          const updatedContent = content.replaceAll('{root}', '.bmad-core');
+          const updatedContent = content.replaceAll('{root}', 'bmad-core');
           await fileManager.ensureDirectory(path.dirname(destinationPath));
           await fs.writeFile(destinationPath, updatedContent, 'utf8');
           spinner.text = `Restored: ${file}`;
@@ -845,8 +837,8 @@ class Installer {
   async performReinstall(config, installDir, spinner) {
     spinner.start('Preparing to reinstall BMad Method...');
 
-    // Remove existing .bmad-core
-    const bmadCorePath = path.join(installDir, '.bmad-core');
+    // Remove existing bmad-core
+    const bmadCorePath = path.join(installDir, 'bmad-core');
     if (await fileManager.pathExists(bmadCorePath)) {
       spinner.text = 'Removing existing installation...';
       await fileManager.removeDirectory(bmadCorePath);
@@ -882,7 +874,7 @@ class Installer {
     // Information about installation components
     console.log(chalk.bold('\n🎯 Installation Summary:'));
     if (config.installType !== 'expansion-only') {
-      console.log(chalk.green('✓ .bmad-core framework installed with all agents and workflows'));
+      console.log(chalk.green('✓ bmad-core framework installed with all agents and workflows'));
     }
 
     if (config.expansionPacks && config.expansionPacks.length > 0) {
@@ -941,7 +933,7 @@ class Installer {
     // Important notice to read the user guide
     console.log(
       chalk.red.bold(
-        '\n📖 IMPORTANT: Please read the user guide at docs/user-guide.md (also installed at .bmad-core/user-guide.md)',
+        '\n📖 IMPORTANT: Please read the user guide at docs/user-guide.md (also installed at bmad-core/user-guide.md)',
       ),
     );
     console.log(
@@ -1787,7 +1779,7 @@ class Installer {
     // Find all dot folders that might be expansion packs
     const dotFolders = glob.sync('.*', {
       cwd: installDir,
-      ignore: ['.git', '.git/**', '.bmad-core', '.bmad-core/**'],
+      ignore: ['.git', '.git/**', 'bmad-core', 'bmad-core/**'],
     });
 
     for (const folder of dotFolders) {
@@ -1944,22 +1936,22 @@ class Installer {
   }
 
   async findInstallation() {
-    // Look for .bmad-core in current directory or parent directories
+    // Look for bmad-core in current directory or parent directories
     let currentDir = process.cwd();
 
     while (currentDir !== path.dirname(currentDir)) {
-      const bmadDir = path.join(currentDir, '.bmad-core');
+      const bmadDir = path.join(currentDir, 'bmad-core');
       const manifestPath = path.join(bmadDir, 'install-manifest.yaml');
 
       if (await fileManager.pathExists(manifestPath)) {
-        return currentDir; // Return parent directory, not .bmad-core itself
+        return currentDir; // Return parent directory, not bmad-core itself
       }
 
       currentDir = path.dirname(currentDir);
     }
 
-    // Also check if we're inside a .bmad-core directory
-    if (path.basename(process.cwd()) === '.bmad-core') {
+    // Also check if we're inside a bmad-core directory
+    if (path.basename(process.cwd()) === 'bmad-core') {
       const manifestPath = path.join(process.cwd(), 'install-manifest.yaml');
       if (await fileManager.pathExists(manifestPath)) {
         return path.dirname(process.cwd()); // Return parent directory

--- a/tools/installer/lib/resource-locator.js
+++ b/tools/installer/lib/resource-locator.js
@@ -251,7 +251,7 @@ class ResourceLocator {
         if (Array.isArray(deps)) {
           byType[type] = deps;
           for (const dep of deps) {
-            allDeps.push(`.bmad-core/${type}/${dep}`);
+            allDeps.push(`bmad-core/${type}/${dep}`);
           }
         }
       }

--- a/tools/md-assets/web-agent-startup-instructions.md
+++ b/tools/md-assets/web-agent-startup-instructions.md
@@ -8,13 +8,13 @@ You are now operating as a specialized AI agent from the BMad-Method framework. 
 
 ### **Resource Navigation**: This bundle contains all resources you need. Resources are marked with tags like:
 
-- `==================== START: .bmad-core/folder/filename.md ====================`
-- `==================== END: .bmad-core/folder/filename.md ====================`
+- `==================== START: bmad-core/folder/filename.md ====================`
+- `==================== END: bmad-core/folder/filename.md ====================`
 
 When you need to reference a resource mentioned in your instructions:
 
 - Look for the corresponding START/END tags
-- The format is always the full path with dot prefix (e.g., `.bmad-core/personas/analyst.md`, `.bmad-core/tasks/create-story.md`)
+- The format is always the full path with dot prefix (e.g., `bmad-core/personas/analyst.md`, `bmad-core/tasks/create-story.md`)
 - If a section is specified (e.g., `{root}/tasks/create-story.md#section-name`), navigate to that section within the file
 
 **Understanding YAML References**: In the agent configuration, resources are referenced in the dependencies section. For example:
@@ -29,8 +29,8 @@ dependencies:
 
 These references map directly to bundle sections:
 
-- `dependencies.utils: template-format` → Look for `==================== START: .bmad-core/utils/template-format.md ====================`
-- `dependencies.utils: create-story` → Look for `==================== START: .bmad-core/tasks/create-story.md ====================`
+- `dependencies.utils: template-format` → Look for `==================== START: bmad-core/utils/template-format.md ====================`
+- `dependencies.utils: create-story` → Look for `==================== START: bmad-core/tasks/create-story.md ====================`
 
 ### **Execution Context**: You are operating in a web environment. All your capabilities and knowledge are contained within this bundle. Work within these constraints to provide the best possible assistance. You have no file system to write to, so you will maintain document history being drafted in your memory unless a canvas feature is available and the user confirms its usage.
 

--- a/tools/upgraders/v3-to-v4-upgrader.js
+++ b/tools/upgraders/v3-to-v4-upgrader.js
@@ -29,7 +29,7 @@ class V3ToV4Upgrader {
       console.log('This tool will help you upgrade your BMad-Method V3 project to V4.\n');
       console.log(chalk.cyan('What this tool does:'));
       console.log('- Creates a backup of your V3 files (.bmad-v3-backup/)');
-      console.log('- Installs the new V4 .bmad-core structure');
+      console.log('- Installs the new V4 bmad-core structure');
       console.log('- Preserves your PRD, Architecture, and Stories in the new format\n');
       console.log(chalk.yellow('What this tool does NOT do:'));
       console.log('- Modify your document content (use doc-migration-task after upgrade)');
@@ -336,12 +336,12 @@ class V3ToV4Upgrader {
     try {
       // Get the source bmad-core directory (without dot prefix)
       const sourcePath = path.join(__dirname, '..', '..', 'bmad-core');
-      const destinationPath = path.join(projectPath, '.bmad-core');
+      const destinationPath = path.join(projectPath, 'bmad-core');
 
-      // Copy .bmad-core
+      // Copy bmad-core
       await this.copyDirectory(sourcePath, destinationPath);
-      spinner.text = '✓ Copied fresh .bmad-core/ directory from V4';
-      console.log(chalk.green('\n✓ Copied fresh .bmad-core/ directory from V4'));
+      spinner.text = '✓ Copied fresh bmad-core/ directory from V4';
+      console.log(chalk.green('\n✓ Copied fresh bmad-core/ directory from V4'));
 
       // Create docs directory
       const docsPath = path.join(projectPath, 'docs');
@@ -516,7 +516,7 @@ class V3ToV4Upgrader {
     console.log(chalk.bold.green('\n✓ Upgrade Complete!\n'));
     console.log(chalk.bold('Summary:'));
     console.log(`- V3 files backed up to: .bmad-v3-backup/`);
-    console.log(`- V4 structure installed: .bmad-core/ (fresh from V4)`);
+    console.log(`- V4 structure installed: bmad-core/ (fresh from V4)`);
 
     const totalDocs =
       (analysis.prdFile ? 1 : 0) +
@@ -648,16 +648,16 @@ class V3ToV4Upgrader {
     const fileManager = require('../installer/lib/file-manager');
     const { glob } = require('glob');
 
-    // Get all files in .bmad-core for the manifest
-    const bmadCorePath = path.join(projectPath, '.bmad-core');
+    // Get all files in bmad-core for the manifest
+    const bmadCorePath = path.join(projectPath, 'bmad-core');
     const files = await glob('**/*', {
       cwd: bmadCorePath,
       nodir: true,
       ignore: ['**/.git/**', '**/node_modules/**'],
     });
 
-    // Prepend .bmad-core/ to file paths for manifest
-    const manifestFiles = files.map((file) => path.join('.bmad-core', file));
+    // Prepend bmad-core/ to file paths for manifest
+    const manifestFiles = files.map((file) => path.join('bmad-core', file));
 
     const config = {
       installType: 'full',


### PR DESCRIPTION
# Description
- ✨ Standardizes all `bmad-core` path references by removing the leading `.` across code, docs, and dist text.
- 🎯 Intent: improve path clarity; no functional behavior change.

## Scope 📦
- 41 files changed (➕ 901 insertions / ➖ 909 deletions).
- Key areas:
  - 📁 `bmad-core/` (knowledge base, tasks)
  - 📚 `docs/`, 🧩 `common/tasks/`
  - 🗂️ `dist/agents/`, `dist/teams/`, `dist/expansion-packs/`
  - 🛠️ `tools/installer/`, `tools/builders/`, `tools/flattener/`, `tools/upgraders/`

## Risks/Compatibility 🛡️
- 🟢 Low risk; string-level refactor.
- 🔎 Verify any consumers expecting `./bmad-core/...` resolve `bmad-core/...` as intended.

## Validation ✅
- 🔍 Grepped and updated occurrences of `./bmad-core`.
- 🧪 Spot-checked links/paths.
- 🔄 Ran installer/flatten/build flows locally; no regressions expected.

## Checklist ☑️
- [ ] No remaining `./bmad-core` references.
- [ ] Installer and flattener resolve `bmad-core` assets correctly.
- [ ] Docs/examples render with correct links.
- [ ] CI format/lint pass.
