### PR TITLE
docs: fix installation instructions and improve development setup

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -37,6 +37,16 @@ CLAUDE.md
 .claude
 .gemini
 
+# Python virtual environments
+venv/
+env/
+.venv/
+.env/
+__pycache__/
+*.py[cod]
+*$py.class
+.Python
+
 # Project-specific
 .bmad-core
 .bmad-creator-tools

--- a/README.md
+++ b/README.md
@@ -104,7 +104,9 @@ This single command handles:
 ### Alternative: Clone and Build
 
 ```bash
-git clone https://github.com/bmadcode/bmad-method.git
+git clone https://github.com/bmad-code-org/BMAD-METHOD.git
+cd BMAD-METHOD
+npm install # Install dependencies first
 npm run install:bmad # build and install all to a destination folder
 ```
 


### PR DESCRIPTION
- Correct git clone URL to use bmad-code-org/BMAD-METHOD
- Add missing npm install step before npm run install:bmad
- Add cd BMAD-METHOD step for clarity
- Update .gitignore to include Python virtual environment patterns

Fixes the installation process that was failing due to missing dependencies and incorrect repository URL. Now users can successfully clone and install the BMAD-METHOD framework following the documented steps.