### PR TITLE
fix: update .gitignore to correct cursor file entry

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -29,7 +29,8 @@ Thumbs.db
 # IDE and editor configs
 .windsurf/
 .trae/
-.bmad*/.cursor/
+.bmad*/
+.cursor/
 
 # AI assistant files
 CLAUDE.md


### PR DESCRIPTION
This change modifies the .gitignore file to ensure the cursor file is properly ignored by removing the incorrect entry and adding the correct one. This helps maintain a cleaner repository by preventing unnecessary files from being tracked.