### PR TITLE
Fix: Correct dependency path format in bmad-master agent

### DIFF
--- a/bmad-core/agents/bmad-master.md
+++ b/bmad-core/agents/bmad-master.md
@@ -11,16 +11,16 @@ CRITICAL: Read the full YAML BLOCK that FOLLOWS IN THIS FILE to understand your 
 ```yaml
 IDE-FILE-RESOLUTION:
   - FOR LATER USE ONLY - NOT FOR ACTIVATION, when executing commands that reference dependencies
-  - Dependencies map to root/type/name
+  - Dependencies map to {root}/{type}/{name}
   - type=folder (tasks|templates|checklists|data|utils|etc...), name=file-name
-  - Example: create-doc.md → root/tasks/create-doc.md
+  - Example: create-doc.md → {root}/tasks/create-doc.md
   - IMPORTANT: Only load these files when user requests specific command execution
 REQUEST-RESOLUTION: Match user requests to your commands/dependencies flexibly (e.g., "draft story"→*create→create-next-story task, "make a new prd" would be dependencies->tasks->create-doc combined with the dependencies->templates->prd-tmpl.md), ALWAYS ask for clarification if no clear match.
 activation-instructions:
   - STEP 1: Read THIS ENTIRE FILE - it contains your complete persona definition
   - STEP 2: Adopt the persona defined in the 'agent' and 'persona' sections below
-  - STEP 3: Load and read bmad-core/core-config.yaml (project configuration) before any greeting
-  - STEP 4: Greet user with your name/role and immediately run *help to display available commands
+  - STEP 3: Load and read `bmad-core/core-config.yaml` (project configuration) before any greeting
+  - STEP 4: Greet user with your name/role and immediately run `*help` to display available commands
   - DO NOT: Load any other agent files during activation
   - ONLY load dependency files when user selects them for execution via command or request of a task
   - The agent.customization field ALWAYS takes precedence over any conflicting instructions


### PR DESCRIPTION
**Describe the bug**
The bmad-master agent incorrectly resolves dependency paths due to missing
variable interpolation syntax in the IDE-FILE-RESOLUTION documentation. Line 14
shows Dependencies map to root/type/name instead of Dependencies map to 
{root}/{type}/{name}, causing the agent to treat "root" as a literal directory
name rather than a variable placeholder.

**Steps to Reproduce**
1. Use the bmad-master agent to execute any task that requires loading
dependencies
2. The agent attempts to resolve paths like bmad/tasks/create-doc.md instead of
.bmad/tasks/create-doc.md
3. Files fail to load because the root directory is interpreted as literal "bmad"
rather than the actual project root (typically .bmad)
4. Agent cannot find project core-config.yaml and other dependencies

**PR**
Working on a fix - correcting the path format to use proper variable interpolation
syntax {root}/{type}/{name}.

**Expected behavior**
Dependencies should resolve to the correct path format using variable
interpolation, allowing the agent to properly locate project files in the .bmad
directory structure.

**Please be Specific if relevant**
- Model(s) Used: Any model using bmad-master agent
- Agentic IDE Used: Any IDE implementing BMAD Method
- Project Language: N/A (affects all projects)
- BMad Method version: Current main branch

**Screenshots or Links**
File: bmad-core/agents/bmad-master.md:14
Current (incorrect): Dependencies map to root/type/nameFixed: Dependencies map to 
{root}/{type}/{name}

**Additional context**
This is a documentation bug in the agent definition that causes runtime path
resolution failures. The missing curly braces prevent proper variable
interpolation, making "root" a literal string instead of a placeholder for the
actual project root directory.