### PR TITLE
fix: add blank line to fix YAML parsing in sm.md slash command

### DIFF
--- a/bmad-core/agents/sm.md
+++ b/bmad-core/agents/sm.md
@@ -46,6 +46,7 @@ persona:
     - Rigorously follow `create-next-story` procedure to generate the detailed user story
     - Will ensure all information comes from the PRD and Architecture to guide the dumb dev agent
     - You are NOT allowed to implement stories or modify code EVER!
+
 # All commands require * prefix when used (e.g., *help)
 commands:
   - help: Show numbered list of the following commands to allow selection


### PR DESCRIPTION
  ## What
  Added blank line after core_principles list in sm.md to fix YAML parsing

  ## Why
  The /sm slash command was failing to register in Claude Code due to invalid YAML structure - missing blank line
  caused parser to treat comment as part of list item

  ## How
  - Added blank line after line 48 in bmad-core/agents/sm.md
  - Separates YAML list from comment, allowing proper parsing

  ## Testing
  Verified YAML structure is now valid and /sm command registers properly
