### PR TITLE
fix: Codex options missing from the IDE selection menu

### DIFF
--- a/tools/installer/bin/bmad.js
+++ b/tools/installer/bin/bmad.js
@@ -406,6 +406,8 @@ async function promptInstallation() {
           { name: 'Qwen Code', value: 'qwen-code' },
           { name: 'Crush', value: 'crush' },
           { name: 'Github Copilot', value: 'github-copilot' },
+          { name: 'Codex CLI', value: 'codex' },
+          { name: 'Codex Web', value: 'codex-web' },
         ],
       },
     ]);


### PR DESCRIPTION
Fixes #534

Added Codex CLI and Codex Web options to the IDE selection menu.