### PR TITLE
feat: update shard-doc to use npx instead of npm install for markdown…

### DIFF
--- a/bmad-core/tasks/shard-doc.md
+++ b/bmad-core/tasks/shard-doc.md
@@ -10,21 +10,18 @@
 
 ## Primary Method: Automatic with markdown-tree
 
-[[LLM: First, check if markdownExploder is set to true in {root}/core-config.yaml. If it is, attempt to run the command: `md-tree explode {input file} {output path}`.
+[[LLM: First, check if markdownExploder is set to true in {root}/core-config.yaml. If it is, attempt to run the command: `npx @kayvan/markdown-tree-parser explode {input file} {output path}`.
 
 If the command succeeds, inform the user that the document has been sharded successfully and STOP - do not proceed further.
 
-If the command fails (especially with an error indicating the command is not found or not available), inform the user: "The markdownExploder setting is enabled but the md-tree command is not available. Please either:
+If the command fails (especially with an error indicating the command is not found or not available), inform the user: "The markdownExploder setting is enabled but the md-tree command failed. This could be due to package installation issues. Try using: `npx @kayvan/markdown-tree-parser explode {input file} {output path}` to automatically install and run the tool.
 
-1. Install @kayvan/markdown-tree-parser globally with: `npm install -g @kayvan/markdown-tree-parser`
-2. Or set markdownExploder to false in {root}/core-config.yaml
-
-**IMPORTANT: STOP HERE - do not proceed with manual sharding until one of the above actions is taken.**"
+**IMPORTANT: STOP HERE - do not proceed with manual sharding until the npx command is attempted.**"
 
 If markdownExploder is set to false, inform the user: "The markdownExploder setting is currently false. For better performance and reliability, you should:
 
 1. Set markdownExploder to true in {root}/core-config.yaml
-2. Install @kayvan/markdown-tree-parser globally with: `npm install -g @kayvan/markdown-tree-parser`
+2. Use `npx @kayvan/markdown-tree-parser explode {input file} {output path}` to automatically install and run the tool
 
 I will now proceed with the manual sharding process."
 
@@ -32,22 +29,25 @@ Then proceed with the manual method below ONLY if markdownExploder is false.]]
 
 ### Installation and Usage
 
-1. **Install globally**:
-
-   ```bash
-   npm install -g @kayvan/markdown-tree-parser
-   ```
-
-2. **Use the explode command**:
+1. **Use npx (recommended - no installation needed)**:
 
    ```bash
    # For PRD
-   md-tree explode docs/prd.md docs/prd
+   npx @kayvan/markdown-tree-parser explode docs/prd.md docs/prd
 
    # For Architecture
-   md-tree explode docs/architecture.md docs/architecture
+   npx @kayvan/markdown-tree-parser explode docs/architecture.md docs/architecture
 
    # For any document
+   npx @kayvan/markdown-tree-parser explode [source-document] [destination-folder]
+   ```
+
+2. **Alternative: Install globally** (if you prefer):
+
+   ```bash
+   npm install -g @kayvan/markdown-tree-parser
+   
+   # Then use the shorter command
    md-tree explode [source-document] [destination-folder]
    ```
 
@@ -57,7 +57,7 @@ Then proceed with the manual method below ONLY if markdownExploder is false.]]
    - Adjusts heading levels appropriately
    - Handles all edge cases with code blocks and special markdown
 
-If the user has @kayvan/markdown-tree-parser installed, use it and skip the manual process below.
+If the user has @kayvan/markdown-tree-parser available (either via npx or global install), use it and skip the manual process below.
 
 ---
 

--- a/dist/agents/bmad-master.txt
+++ b/dist/agents/bmad-master.txt
@@ -1960,21 +1960,18 @@ Would you like to proceed with documentation indexing? Please provide the requir
 
 ## Primary Method: Automatic with markdown-tree
 
-[[LLM: First, check if markdownExploder is set to true in .bmad-core/core-config.yaml. If it is, attempt to run the command: `md-tree explode {input file} {output path}`.
+[[LLM: First, check if markdownExploder is set to true in .bmad-core/core-config.yaml. If it is, attempt to run the command: `npx @kayvan/markdown-tree-parser explode {input file} {output path}`.
 
 If the command succeeds, inform the user that the document has been sharded successfully and STOP - do not proceed further.
 
-If the command fails (especially with an error indicating the command is not found or not available), inform the user: "The markdownExploder setting is enabled but the md-tree command is not available. Please either:
+If the command fails (especially with an error indicating the command is not found or not available), inform the user: "The markdownExploder setting is enabled but the md-tree command failed. This could be due to package installation issues. Try using: `npx @kayvan/markdown-tree-parser explode {input file} {output path}` to automatically install and run the tool.
 
-1. Install @kayvan/markdown-tree-parser globally with: `npm install -g @kayvan/markdown-tree-parser`
-2. Or set markdownExploder to false in .bmad-core/core-config.yaml
-
-**IMPORTANT: STOP HERE - do not proceed with manual sharding until one of the above actions is taken.**"
+**IMPORTANT: STOP HERE - do not proceed with manual sharding until the npx command is attempted.**"
 
 If markdownExploder is set to false, inform the user: "The markdownExploder setting is currently false. For better performance and reliability, you should:
 
 1. Set markdownExploder to true in .bmad-core/core-config.yaml
-2. Install @kayvan/markdown-tree-parser globally with: `npm install -g @kayvan/markdown-tree-parser`
+2. Use `npx @kayvan/markdown-tree-parser explode {input file} {output path}` to automatically install and run the tool
 
 I will now proceed with the manual sharding process."
 
@@ -1982,22 +1979,25 @@ Then proceed with the manual method below ONLY if markdownExploder is false.]]
 
 ### Installation and Usage
 
-1. **Install globally**:
-
-   ```bash
-   npm install -g @kayvan/markdown-tree-parser
-   ```
-
-2. **Use the explode command**:
+1. **Use npx (recommended - no installation needed)**:
 
    ```bash
    # For PRD
-   md-tree explode docs/prd.md docs/prd
+   npx @kayvan/markdown-tree-parser explode docs/prd.md docs/prd
 
    # For Architecture
-   md-tree explode docs/architecture.md docs/architecture
+   npx @kayvan/markdown-tree-parser explode docs/architecture.md docs/architecture
 
    # For any document
+   npx @kayvan/markdown-tree-parser explode [source-document] [destination-folder]
+   ```
+
+2. **Alternative: Install globally** (if you prefer):
+
+   ```bash
+   npm install -g @kayvan/markdown-tree-parser
+   
+   # Then use the shorter command
    md-tree explode [source-document] [destination-folder]
    ```
 
@@ -2007,7 +2007,7 @@ Then proceed with the manual method below ONLY if markdownExploder is false.]]
    - Adjusts heading levels appropriately
    - Handles all edge cases with code blocks and special markdown
 
-If the user has @kayvan/markdown-tree-parser installed, use it and skip the manual process below.
+If the user has @kayvan/markdown-tree-parser available (either via npx or global install), use it and skip the manual process below.
 
 ---
 

--- a/dist/agents/pm.txt
+++ b/dist/agents/pm.txt
@@ -985,17 +985,14 @@ The LLM will:
 
 If the command succeeds, inform the user that the document has been sharded successfully and STOP - do not proceed further.
 
-If the command fails (especially with an error indicating the command is not found or not available), inform the user: "The markdownExploder setting is enabled but the md-tree command is not available. Please either:
+If the command fails (especially with an error indicating the command is not found or not available), inform the user: "The markdownExploder setting is enabled but the md-tree command failed. This could be due to package installation issues. Try using: `npx @kayvan/markdown-tree-parser explode {input file} {output path}` to automatically install and run the tool.
 
-1. Install @kayvan/markdown-tree-parser globally with: `npm install -g @kayvan/markdown-tree-parser`
-2. Or set markdownExploder to false in .bmad-core/core-config.yaml
-
-**IMPORTANT: STOP HERE - do not proceed with manual sharding until one of the above actions is taken.**"
+**IMPORTANT: STOP HERE - do not proceed with manual sharding until the npx command is attempted.**"
 
 If markdownExploder is set to false, inform the user: "The markdownExploder setting is currently false. For better performance and reliability, you should:
 
 1. Set markdownExploder to true in .bmad-core/core-config.yaml
-2. Install @kayvan/markdown-tree-parser globally with: `npm install -g @kayvan/markdown-tree-parser`
+2. Use `npx @kayvan/markdown-tree-parser explode {input file} {output path}` to automatically install and run the tool
 
 I will now proceed with the manual sharding process."
 
@@ -1003,22 +1000,25 @@ Then proceed with the manual method below ONLY if markdownExploder is false.]]
 
 ### Installation and Usage
 
-1. **Install globally**:
-
-   ```bash
-   npm install -g @kayvan/markdown-tree-parser
-   ```
-
-2. **Use the explode command**:
+1. **Use npx (recommended - no installation needed)**:
 
    ```bash
    # For PRD
-   md-tree explode docs/prd.md docs/prd
+   npx @kayvan/markdown-tree-parser explode docs/prd.md docs/prd
 
    # For Architecture
-   md-tree explode docs/architecture.md docs/architecture
+   npx @kayvan/markdown-tree-parser explode docs/architecture.md docs/architecture
 
    # For any document
+   npx @kayvan/markdown-tree-parser explode [source-document] [destination-folder]
+   ```
+
+2. **Alternative: Install globally** (if you prefer):
+
+   ```bash
+   npm install -g @kayvan/markdown-tree-parser
+   
+   # Then use the shorter command
    md-tree explode [source-document] [destination-folder]
    ```
 
@@ -1028,7 +1028,7 @@ Then proceed with the manual method below ONLY if markdownExploder is false.]]
    - Adjusts heading levels appropriately
    - Handles all edge cases with code blocks and special markdown
 
-If the user has @kayvan/markdown-tree-parser installed, use it and skip the manual process below.
+If the user has @kayvan/markdown-tree-parser available (either via npx or global install), use it and skip the manual process below.
 
 ---
 

--- a/dist/agents/po.txt
+++ b/dist/agents/po.txt
@@ -274,21 +274,18 @@ The LLM will:
 
 ## Primary Method: Automatic with markdown-tree
 
-[[LLM: First, check if markdownExploder is set to true in .bmad-core/core-config.yaml. If it is, attempt to run the command: `md-tree explode {input file} {output path}`.
+[[LLM: First, check if markdownExploder is set to true in .bmad-core/core-config.yaml. If it is, attempt to run the command: `npx @kayvan/markdown-tree-parser explode {input file} {output path}`.
 
 If the command succeeds, inform the user that the document has been sharded successfully and STOP - do not proceed further.
 
-If the command fails (especially with an error indicating the command is not found or not available), inform the user: "The markdownExploder setting is enabled but the md-tree command is not available. Please either:
+If the command fails (especially with an error indicating the command is not found or not available), inform the user: "The markdownExploder setting is enabled but the md-tree command failed. This could be due to package installation issues. Try using: `npx @kayvan/markdown-tree-parser explode {input file} {output path}` to automatically install and run the tool.
 
-1. Install @kayvan/markdown-tree-parser globally with: `npm install -g @kayvan/markdown-tree-parser`
-2. Or set markdownExploder to false in .bmad-core/core-config.yaml
-
-**IMPORTANT: STOP HERE - do not proceed with manual sharding until one of the above actions is taken.**"
+**IMPORTANT: STOP HERE - do not proceed with manual sharding until the npx command is attempted.**"
 
 If markdownExploder is set to false, inform the user: "The markdownExploder setting is currently false. For better performance and reliability, you should:
 
 1. Set markdownExploder to true in .bmad-core/core-config.yaml
-2. Install @kayvan/markdown-tree-parser globally with: `npm install -g @kayvan/markdown-tree-parser`
+2. Use `npx @kayvan/markdown-tree-parser explode {input file} {output path}` to automatically install and run the tool
 
 I will now proceed with the manual sharding process."
 
@@ -296,22 +293,25 @@ Then proceed with the manual method below ONLY if markdownExploder is false.]]
 
 ### Installation and Usage
 
-1. **Install globally**:
-
-   ```bash
-   npm install -g @kayvan/markdown-tree-parser
-   ```
-
-2. **Use the explode command**:
+1. **Use npx (recommended - no installation needed)**:
 
    ```bash
    # For PRD
-   md-tree explode docs/prd.md docs/prd
+   npx @kayvan/markdown-tree-parser explode docs/prd.md docs/prd
 
    # For Architecture
-   md-tree explode docs/architecture.md docs/architecture
+   npx @kayvan/markdown-tree-parser explode docs/architecture.md docs/architecture
 
    # For any document
+   npx @kayvan/markdown-tree-parser explode [source-document] [destination-folder]
+   ```
+
+2. **Alternative: Install globally** (if you prefer):
+
+   ```bash
+   npm install -g @kayvan/markdown-tree-parser
+   
+   # Then use the shorter command
    md-tree explode [source-document] [destination-folder]
    ```
 
@@ -321,7 +321,7 @@ Then proceed with the manual method below ONLY if markdownExploder is false.]]
    - Adjusts heading levels appropriately
    - Handles all edge cases with code blocks and special markdown
 
-If the user has @kayvan/markdown-tree-parser installed, use it and skip the manual process below.
+If the user has @kayvan/markdown-tree-parser available (either via npx or global install), use it and skip the manual process below.
 
 ---
 

--- a/dist/expansion-packs/bmad-2d-unity-game-dev/agents/game-architect.txt
+++ b/dist/expansion-packs/bmad-2d-unity-game-dev/agents/game-architect.txt
@@ -501,21 +501,18 @@ CRITICAL: collaborate with the user to develop specific, actionable research que
 
 ## Primary Method: Automatic with markdown-tree
 
-[[LLM: First, check if markdownExploder is set to true in .bmad-2d-unity-game-dev/core-config.yaml. If it is, attempt to run the command: `md-tree explode {input file} {output path}`.
+[[LLM: First, check if markdownExploder is set to true in .bmad-2d-unity-game-dev/core-config.yaml. If it is, attempt to run the command: `npx @kayvan/markdown-tree-parser explode {input file} {output path}`.
 
 If the command succeeds, inform the user that the document has been sharded successfully and STOP - do not proceed further.
 
-If the command fails (especially with an error indicating the command is not found or not available), inform the user: "The markdownExploder setting is enabled but the md-tree command is not available. Please either:
+If the command fails (especially with an error indicating the command is not found or not available), inform the user: "The markdownExploder setting is enabled but the md-tree command failed. This could be due to package installation issues. Try using: `npx @kayvan/markdown-tree-parser explode {input file} {output path}` to automatically install and run the tool.
 
-1. Install @kayvan/markdown-tree-parser globally with: `npm install -g @kayvan/markdown-tree-parser`
-2. Or set markdownExploder to false in .bmad-2d-unity-game-dev/core-config.yaml
-
-**IMPORTANT: STOP HERE - do not proceed with manual sharding until one of the above actions is taken.**"
+**IMPORTANT: STOP HERE - do not proceed with manual sharding until the npx command is attempted.**"
 
 If markdownExploder is set to false, inform the user: "The markdownExploder setting is currently false. For better performance and reliability, you should:
 
 1. Set markdownExploder to true in .bmad-2d-unity-game-dev/core-config.yaml
-2. Install @kayvan/markdown-tree-parser globally with: `npm install -g @kayvan/markdown-tree-parser`
+2. Use `npx @kayvan/markdown-tree-parser explode {input file} {output path}` to automatically install and run the tool
 
 I will now proceed with the manual sharding process."
 
@@ -523,22 +520,25 @@ Then proceed with the manual method below ONLY if markdownExploder is false.]]
 
 ### Installation and Usage
 
-1. **Install globally**:
-
-   ```bash
-   npm install -g @kayvan/markdown-tree-parser
-   ```
-
-2. **Use the explode command**:
+1. **Use npx (recommended - no installation needed)**:
 
    ```bash
    # For PRD
-   md-tree explode docs/prd.md docs/prd
+   npx @kayvan/markdown-tree-parser explode docs/prd.md docs/prd
 
    # For Architecture
-   md-tree explode docs/architecture.md docs/architecture
+   npx @kayvan/markdown-tree-parser explode docs/architecture.md docs/architecture
 
    # For any document
+   npx @kayvan/markdown-tree-parser explode [source-document] [destination-folder]
+   ```
+
+2. **Alternative: Install globally** (if you prefer):
+
+   ```bash
+   npm install -g @kayvan/markdown-tree-parser
+   
+   # Then use the shorter command
    md-tree explode [source-document] [destination-folder]
    ```
 
@@ -548,7 +548,7 @@ Then proceed with the manual method below ONLY if markdownExploder is false.]]
    - Adjusts heading levels appropriately
    - Handles all edge cases with code blocks and special markdown
 
-If the user has @kayvan/markdown-tree-parser installed, use it and skip the manual process below.
+If the user has @kayvan/markdown-tree-parser available (either via npx or global install), use it and skip the manual process below.
 
 ---
 

--- a/dist/expansion-packs/bmad-2d-unity-game-dev/agents/game-designer.txt
+++ b/dist/expansion-packs/bmad-2d-unity-game-dev/agents/game-designer.txt
@@ -306,21 +306,18 @@ The LLM will:
 
 ## Primary Method: Automatic with markdown-tree
 
-[[LLM: First, check if markdownExploder is set to true in .bmad-2d-unity-game-dev/core-config.yaml. If it is, attempt to run the command: `md-tree explode {input file} {output path}`.
+[[LLM: First, check if markdownExploder is set to true in .bmad-2d-unity-game-dev/core-config.yaml. If it is, attempt to run the command: `npx @kayvan/markdown-tree-parser explode {input file} {output path}`.
 
 If the command succeeds, inform the user that the document has been sharded successfully and STOP - do not proceed further.
 
-If the command fails (especially with an error indicating the command is not found or not available), inform the user: "The markdownExploder setting is enabled but the md-tree command is not available. Please either:
+If the command fails (especially with an error indicating the command is not found or not available), inform the user: "The markdownExploder setting is enabled but the md-tree command failed. This could be due to package installation issues. Try using: `npx @kayvan/markdown-tree-parser explode {input file} {output path}` to automatically install and run the tool.
 
-1. Install @kayvan/markdown-tree-parser globally with: `npm install -g @kayvan/markdown-tree-parser`
-2. Or set markdownExploder to false in .bmad-2d-unity-game-dev/core-config.yaml
-
-**IMPORTANT: STOP HERE - do not proceed with manual sharding until one of the above actions is taken.**"
+**IMPORTANT: STOP HERE - do not proceed with manual sharding until the npx command is attempted.**"
 
 If markdownExploder is set to false, inform the user: "The markdownExploder setting is currently false. For better performance and reliability, you should:
 
 1. Set markdownExploder to true in .bmad-2d-unity-game-dev/core-config.yaml
-2. Install @kayvan/markdown-tree-parser globally with: `npm install -g @kayvan/markdown-tree-parser`
+2. Use `npx @kayvan/markdown-tree-parser explode {input file} {output path}` to automatically install and run the tool
 
 I will now proceed with the manual sharding process."
 
@@ -328,22 +325,25 @@ Then proceed with the manual method below ONLY if markdownExploder is false.]]
 
 ### Installation and Usage
 
-1. **Install globally**:
-
-   ```bash
-   npm install -g @kayvan/markdown-tree-parser
-   ```
-
-2. **Use the explode command**:
+1. **Use npx (recommended - no installation needed)**:
 
    ```bash
    # For PRD
-   md-tree explode docs/prd.md docs/prd
+   npx @kayvan/markdown-tree-parser explode docs/prd.md docs/prd
 
    # For Architecture
-   md-tree explode docs/architecture.md docs/architecture
+   npx @kayvan/markdown-tree-parser explode docs/architecture.md docs/architecture
 
    # For any document
+   npx @kayvan/markdown-tree-parser explode [source-document] [destination-folder]
+   ```
+
+2. **Alternative: Install globally** (if you prefer):
+
+   ```bash
+   npm install -g @kayvan/markdown-tree-parser
+   
+   # Then use the shorter command
    md-tree explode [source-document] [destination-folder]
    ```
 
@@ -353,7 +353,7 @@ Then proceed with the manual method below ONLY if markdownExploder is false.]]
    - Adjusts heading levels appropriately
    - Handles all edge cases with code blocks and special markdown
 
-If the user has @kayvan/markdown-tree-parser installed, use it and skip the manual process below.
+If the user has @kayvan/markdown-tree-parser available (either via npx or global install), use it and skip the manual process below.
 
 ---
 

--- a/dist/expansion-packs/bmad-2d-unity-game-dev/teams/unity-2d-game-team.txt
+++ b/dist/expansion-packs/bmad-2d-unity-game-dev/teams/unity-2d-game-team.txt
@@ -3639,21 +3639,18 @@ The LLM will:
 
 ## Primary Method: Automatic with markdown-tree
 
-[[LLM: First, check if markdownExploder is set to true in .bmad-2d-unity-game-dev/core-config.yaml. If it is, attempt to run the command: `md-tree explode {input file} {output path}`.
+[[LLM: First, check if markdownExploder is set to true in .bmad-2d-unity-game-dev/core-config.yaml. If it is, attempt to run the command: `npx @kayvan/markdown-tree-parser explode {input file} {output path}`.
 
 If the command succeeds, inform the user that the document has been sharded successfully and STOP - do not proceed further.
 
-If the command fails (especially with an error indicating the command is not found or not available), inform the user: "The markdownExploder setting is enabled but the md-tree command is not available. Please either:
+If the command fails (especially with an error indicating the command is not found or not available), inform the user: "The markdownExploder setting is enabled but the md-tree command failed. This could be due to package installation issues. Try using: `npx @kayvan/markdown-tree-parser explode {input file} {output path}` to automatically install and run the tool.
 
-1. Install @kayvan/markdown-tree-parser globally with: `npm install -g @kayvan/markdown-tree-parser`
-2. Or set markdownExploder to false in .bmad-2d-unity-game-dev/core-config.yaml
-
-**IMPORTANT: STOP HERE - do not proceed with manual sharding until one of the above actions is taken.**"
+**IMPORTANT: STOP HERE - do not proceed with manual sharding until the npx command is attempted.**"
 
 If markdownExploder is set to false, inform the user: "The markdownExploder setting is currently false. For better performance and reliability, you should:
 
 1. Set markdownExploder to true in .bmad-2d-unity-game-dev/core-config.yaml
-2. Install @kayvan/markdown-tree-parser globally with: `npm install -g @kayvan/markdown-tree-parser`
+2. Use `npx @kayvan/markdown-tree-parser explode {input file} {output path}` to automatically install and run the tool
 
 I will now proceed with the manual sharding process."
 
@@ -3661,22 +3658,25 @@ Then proceed with the manual method below ONLY if markdownExploder is false.]]
 
 ### Installation and Usage
 
-1. **Install globally**:
-
-   ```bash
-   npm install -g @kayvan/markdown-tree-parser
-   ```
-
-2. **Use the explode command**:
+1. **Use npx (recommended - no installation needed)**:
 
    ```bash
    # For PRD
-   md-tree explode docs/prd.md docs/prd
+   npx @kayvan/markdown-tree-parser explode docs/prd.md docs/prd
 
    # For Architecture
-   md-tree explode docs/architecture.md docs/architecture
+   npx @kayvan/markdown-tree-parser explode docs/architecture.md docs/architecture
 
    # For any document
+   npx @kayvan/markdown-tree-parser explode [source-document] [destination-folder]
+   ```
+
+2. **Alternative: Install globally** (if you prefer):
+
+   ```bash
+   npm install -g @kayvan/markdown-tree-parser
+   
+   # Then use the shorter command
    md-tree explode [source-document] [destination-folder]
    ```
 
@@ -3686,7 +3686,7 @@ Then proceed with the manual method below ONLY if markdownExploder is false.]]
    - Adjusts heading levels appropriately
    - Handles all edge cases with code blocks and special markdown
 
-If the user has @kayvan/markdown-tree-parser installed, use it and skip the manual process below.
+If the user has @kayvan/markdown-tree-parser available (either via npx or global install), use it and skip the manual process below.
 
 ---
 

--- a/dist/expansion-packs/bmad-godot-game-dev/agents/game-architect.txt
+++ b/dist/expansion-packs/bmad-godot-game-dev/agents/game-architect.txt
@@ -567,21 +567,18 @@ CRITICAL: collaborate with the user to develop specific, actionable research que
 
 ## Primary Method: Automatic with markdown-tree
 
-[[LLM: First, check if markdownExploder is set to true in .bmad-godot-game-dev/config.yaml. If it is, attempt to run the command: `md-tree explode {input file} {output path}`.
+[[LLM: First, check if markdownExploder is set to true in .bmad-godot-game-dev/config.yaml. If it is, attempt to run the command: `npx @kayvan/markdown-tree-parser explode {input file} {output path}`.
 
 If the command succeeds, inform the user that the document has been sharded successfully and STOP - do not proceed further.
 
-If the command fails (especially with an error indicating the command is not found or not available), inform the user: "The markdownExploder setting is enabled but the md-tree command is not available. Please either:
+If the command fails (especially with an error indicating the command is not found or not available), inform the user: "The markdownExploder setting is enabled but the md-tree command failed. This could be due to package installation issues. Try using: `npx @kayvan/markdown-tree-parser explode {input file} {output path}` to automatically install and run the tool.
 
-1. Install @kayvan/markdown-tree-parser globally with: `npm install -g @kayvan/markdown-tree-parser`
-2. Or set markdownExploder to false in .bmad-godot-game-dev/config.yaml
-
-**IMPORTANT: STOP HERE - do not proceed with manual sharding until one of the above actions is taken.**"
+**IMPORTANT: STOP HERE - do not proceed with manual sharding until the npx command is attempted.**"
 
 If markdownExploder is set to false, inform the user: "The markdownExploder setting is currently false. For better performance and reliability, you should:
 
 1. Set markdownExploder to true in .bmad-godot-game-dev/config.yaml
-2. Install @kayvan/markdown-tree-parser globally with: `npm install -g @kayvan/markdown-tree-parser`
+2. Use `npx @kayvan/markdown-tree-parser explode {input file} {output path}` to automatically install and run the tool
 
 I will now proceed with the manual sharding process."
 
@@ -589,22 +586,25 @@ Then proceed with the manual method below ONLY if markdownExploder is false.]]
 
 ### Installation and Usage
 
-1. **Install globally**:
-
-   ```bash
-   npm install -g @kayvan/markdown-tree-parser
-   ```
-
-2. **Use the explode command**:
+1. **Use npx (recommended - no installation needed)**:
 
    ```bash
    # For PRD
-   md-tree explode docs/prd.md docs/prd
+   npx @kayvan/markdown-tree-parser explode docs/prd.md docs/prd
 
    # For Architecture
-   md-tree explode docs/architecture.md docs/architecture
+   npx @kayvan/markdown-tree-parser explode docs/architecture.md docs/architecture
 
    # For any document
+   npx @kayvan/markdown-tree-parser explode [source-document] [destination-folder]
+   ```
+
+2. **Alternative: Install globally** (if you prefer):
+
+   ```bash
+   npm install -g @kayvan/markdown-tree-parser
+   
+   # Then use the shorter command
    md-tree explode [source-document] [destination-folder]
    ```
 
@@ -614,7 +614,7 @@ Then proceed with the manual method below ONLY if markdownExploder is false.]]
    - Adjusts heading levels appropriately
    - Handles all edge cases with code blocks and special markdown
 
-If the user has @kayvan/markdown-tree-parser installed, use it and skip the manual process below.
+If the user has @kayvan/markdown-tree-parser available (either via npx or global install), use it and skip the manual process below.
 
 ---
 

--- a/dist/expansion-packs/bmad-godot-game-dev/agents/game-designer.txt
+++ b/dist/expansion-packs/bmad-godot-game-dev/agents/game-designer.txt
@@ -309,21 +309,18 @@ The LLM will:
 
 ## Primary Method: Automatic with markdown-tree
 
-[[LLM: First, check if markdownExploder is set to true in .bmad-godot-game-dev/config.yaml. If it is, attempt to run the command: `md-tree explode {input file} {output path}`.
+[[LLM: First, check if markdownExploder is set to true in .bmad-godot-game-dev/config.yaml. If it is, attempt to run the command: `npx @kayvan/markdown-tree-parser explode {input file} {output path}`.
 
 If the command succeeds, inform the user that the document has been sharded successfully and STOP - do not proceed further.
 
-If the command fails (especially with an error indicating the command is not found or not available), inform the user: "The markdownExploder setting is enabled but the md-tree command is not available. Please either:
+If the command fails (especially with an error indicating the command is not found or not available), inform the user: "The markdownExploder setting is enabled but the md-tree command failed. This could be due to package installation issues. Try using: `npx @kayvan/markdown-tree-parser explode {input file} {output path}` to automatically install and run the tool.
 
-1. Install @kayvan/markdown-tree-parser globally with: `npm install -g @kayvan/markdown-tree-parser`
-2. Or set markdownExploder to false in .bmad-godot-game-dev/config.yaml
-
-**IMPORTANT: STOP HERE - do not proceed with manual sharding until one of the above actions is taken.**"
+**IMPORTANT: STOP HERE - do not proceed with manual sharding until the npx command is attempted.**"
 
 If markdownExploder is set to false, inform the user: "The markdownExploder setting is currently false. For better performance and reliability, you should:
 
 1. Set markdownExploder to true in .bmad-godot-game-dev/config.yaml
-2. Install @kayvan/markdown-tree-parser globally with: `npm install -g @kayvan/markdown-tree-parser`
+2. Use `npx @kayvan/markdown-tree-parser explode {input file} {output path}` to automatically install and run the tool
 
 I will now proceed with the manual sharding process."
 
@@ -331,22 +328,25 @@ Then proceed with the manual method below ONLY if markdownExploder is false.]]
 
 ### Installation and Usage
 
-1. **Install globally**:
-
-   ```bash
-   npm install -g @kayvan/markdown-tree-parser
-   ```
-
-2. **Use the explode command**:
+1. **Use npx (recommended - no installation needed)**:
 
    ```bash
    # For PRD
-   md-tree explode docs/prd.md docs/prd
+   npx @kayvan/markdown-tree-parser explode docs/prd.md docs/prd
 
    # For Architecture
-   md-tree explode docs/architecture.md docs/architecture
+   npx @kayvan/markdown-tree-parser explode docs/architecture.md docs/architecture
 
    # For any document
+   npx @kayvan/markdown-tree-parser explode [source-document] [destination-folder]
+   ```
+
+2. **Alternative: Install globally** (if you prefer):
+
+   ```bash
+   npm install -g @kayvan/markdown-tree-parser
+   
+   # Then use the shorter command
    md-tree explode [source-document] [destination-folder]
    ```
 
@@ -356,7 +356,7 @@ Then proceed with the manual method below ONLY if markdownExploder is false.]]
    - Adjusts heading levels appropriately
    - Handles all edge cases with code blocks and special markdown
 
-If the user has @kayvan/markdown-tree-parser installed, use it and skip the manual process below.
+If the user has @kayvan/markdown-tree-parser available (either via npx or global install), use it and skip the manual process below.
 
 ---
 

--- a/dist/expansion-packs/bmad-godot-game-dev/agents/game-pm.txt
+++ b/dist/expansion-packs/bmad-godot-game-dev/agents/game-pm.txt
@@ -1707,21 +1707,18 @@ The LLM will:
 
 ## Primary Method: Automatic with markdown-tree
 
-[[LLM: First, check if markdownExploder is set to true in .bmad-godot-game-dev/config.yaml. If it is, attempt to run the command: `md-tree explode {input file} {output path}`.
+[[LLM: First, check if markdownExploder is set to true in .bmad-godot-game-dev/config.yaml. If it is, attempt to run the command: `npx @kayvan/markdown-tree-parser explode {input file} {output path}`.
 
 If the command succeeds, inform the user that the document has been sharded successfully and STOP - do not proceed further.
 
-If the command fails (especially with an error indicating the command is not found or not available), inform the user: "The markdownExploder setting is enabled but the md-tree command is not available. Please either:
+If the command fails (especially with an error indicating the command is not found or not available), inform the user: "The markdownExploder setting is enabled but the md-tree command failed. This could be due to package installation issues. Try using: `npx @kayvan/markdown-tree-parser explode {input file} {output path}` to automatically install and run the tool.
 
-1. Install @kayvan/markdown-tree-parser globally with: `npm install -g @kayvan/markdown-tree-parser`
-2. Or set markdownExploder to false in .bmad-godot-game-dev/config.yaml
-
-**IMPORTANT: STOP HERE - do not proceed with manual sharding until one of the above actions is taken.**"
+**IMPORTANT: STOP HERE - do not proceed with manual sharding until the npx command is attempted.**"
 
 If markdownExploder is set to false, inform the user: "The markdownExploder setting is currently false. For better performance and reliability, you should:
 
 1. Set markdownExploder to true in .bmad-godot-game-dev/config.yaml
-2. Install @kayvan/markdown-tree-parser globally with: `npm install -g @kayvan/markdown-tree-parser`
+2. Use `npx @kayvan/markdown-tree-parser explode {input file} {output path}` to automatically install and run the tool
 
 I will now proceed with the manual sharding process."
 
@@ -1729,22 +1726,25 @@ Then proceed with the manual method below ONLY if markdownExploder is false.]]
 
 ### Installation and Usage
 
-1. **Install globally**:
-
-   ```bash
-   npm install -g @kayvan/markdown-tree-parser
-   ```
-
-2. **Use the explode command**:
+1. **Use npx (recommended - no installation needed)**:
 
    ```bash
    # For PRD
-   md-tree explode docs/prd.md docs/prd
+   npx @kayvan/markdown-tree-parser explode docs/prd.md docs/prd
 
    # For Architecture
-   md-tree explode docs/architecture.md docs/architecture
+   npx @kayvan/markdown-tree-parser explode docs/architecture.md docs/architecture
 
    # For any document
+   npx @kayvan/markdown-tree-parser explode [source-document] [destination-folder]
+   ```
+
+2. **Alternative: Install globally** (if you prefer):
+
+   ```bash
+   npm install -g @kayvan/markdown-tree-parser
+   
+   # Then use the shorter command
    md-tree explode [source-document] [destination-folder]
    ```
 
@@ -1754,7 +1754,7 @@ Then proceed with the manual method below ONLY if markdownExploder is false.]]
    - Adjusts heading levels appropriately
    - Handles all edge cases with code blocks and special markdown
 
-If the user has @kayvan/markdown-tree-parser installed, use it and skip the manual process below.
+If the user has @kayvan/markdown-tree-parser available (either via npx or global install), use it and skip the manual process below.
 
 ---
 

--- a/dist/expansion-packs/bmad-godot-game-dev/teams/godot-game-team.txt
+++ b/dist/expansion-packs/bmad-godot-game-dev/teams/godot-game-team.txt
@@ -4452,21 +4452,18 @@ The LLM will:
 
 ## Primary Method: Automatic with markdown-tree
 
-[[LLM: First, check if markdownExploder is set to true in .bmad-godot-game-dev/config.yaml. If it is, attempt to run the command: `md-tree explode {input file} {output path}`.
+[[LLM: First, check if markdownExploder is set to true in .bmad-godot-game-dev/config.yaml. If it is, attempt to run the command: `npx @kayvan/markdown-tree-parser explode {input file} {output path}`.
 
 If the command succeeds, inform the user that the document has been sharded successfully and STOP - do not proceed further.
 
-If the command fails (especially with an error indicating the command is not found or not available), inform the user: "The markdownExploder setting is enabled but the md-tree command is not available. Please either:
+If the command fails (especially with an error indicating the command is not found or not available), inform the user: "The markdownExploder setting is enabled but the md-tree command failed. This could be due to package installation issues. Try using: `npx @kayvan/markdown-tree-parser explode {input file} {output path}` to automatically install and run the tool.
 
-1. Install @kayvan/markdown-tree-parser globally with: `npm install -g @kayvan/markdown-tree-parser`
-2. Or set markdownExploder to false in .bmad-godot-game-dev/config.yaml
-
-**IMPORTANT: STOP HERE - do not proceed with manual sharding until one of the above actions is taken.**"
+**IMPORTANT: STOP HERE - do not proceed with manual sharding until the npx command is attempted.**"
 
 If markdownExploder is set to false, inform the user: "The markdownExploder setting is currently false. For better performance and reliability, you should:
 
 1. Set markdownExploder to true in .bmad-godot-game-dev/config.yaml
-2. Install @kayvan/markdown-tree-parser globally with: `npm install -g @kayvan/markdown-tree-parser`
+2. Use `npx @kayvan/markdown-tree-parser explode {input file} {output path}` to automatically install and run the tool
 
 I will now proceed with the manual sharding process."
 
@@ -4474,22 +4471,25 @@ Then proceed with the manual method below ONLY if markdownExploder is false.]]
 
 ### Installation and Usage
 
-1. **Install globally**:
-
-   ```bash
-   npm install -g @kayvan/markdown-tree-parser
-   ```
-
-2. **Use the explode command**:
+1. **Use npx (recommended - no installation needed)**:
 
    ```bash
    # For PRD
-   md-tree explode docs/prd.md docs/prd
+   npx @kayvan/markdown-tree-parser explode docs/prd.md docs/prd
 
    # For Architecture
-   md-tree explode docs/architecture.md docs/architecture
+   npx @kayvan/markdown-tree-parser explode docs/architecture.md docs/architecture
 
    # For any document
+   npx @kayvan/markdown-tree-parser explode [source-document] [destination-folder]
+   ```
+
+2. **Alternative: Install globally** (if you prefer):
+
+   ```bash
+   npm install -g @kayvan/markdown-tree-parser
+   
+   # Then use the shorter command
    md-tree explode [source-document] [destination-folder]
    ```
 
@@ -4499,7 +4499,7 @@ Then proceed with the manual method below ONLY if markdownExploder is false.]]
    - Adjusts heading levels appropriately
    - Handles all edge cases with code blocks and special markdown
 
-If the user has @kayvan/markdown-tree-parser installed, use it and skip the manual process below.
+If the user has @kayvan/markdown-tree-parser available (either via npx or global install), use it and skip the manual process below.
 
 ---
 
@@ -23437,21 +23437,18 @@ After review:
 
 ## Primary Method: Automatic with markdown-tree
 
-[[LLM: First, check if markdownExploder is set to true in .bmad-godot-game-dev/config.yaml. If it is, attempt to run the command: `md-tree explode {input file} {output path}`.
+[[LLM: First, check if markdownExploder is set to true in .bmad-godot-game-dev/config.yaml. If it is, attempt to run the command: `npx @kayvan/markdown-tree-parser explode {input file} {output path}`.
 
 If the command succeeds, inform the user that the document has been sharded successfully and STOP - do not proceed further.
 
-If the command fails (especially with an error indicating the command is not found or not available), inform the user: "The markdownExploder setting is enabled but the md-tree command is not available. Please either:
+If the command fails (especially with an error indicating the command is not found or not available), inform the user: "The markdownExploder setting is enabled but the md-tree command failed. This could be due to package installation issues. Try using: `npx @kayvan/markdown-tree-parser explode {input file} {output path}` to automatically install and run the tool.
 
-1. Install @kayvan/markdown-tree-parser globally with: `npm install -g @kayvan/markdown-tree-parser`
-2. Or set markdownExploder to false in .bmad-godot-game-dev/config.yaml
-
-**IMPORTANT: STOP HERE - do not proceed with manual sharding until one of the above actions is taken.**"
+**IMPORTANT: STOP HERE - do not proceed with manual sharding until the npx command is attempted.**"
 
 If markdownExploder is set to false, inform the user: "The markdownExploder setting is currently false. For better performance and reliability, you should:
 
 1. Set markdownExploder to true in .bmad-godot-game-dev/config.yaml
-2. Install @kayvan/markdown-tree-parser globally with: `npm install -g @kayvan/markdown-tree-parser`
+2. Use `npx @kayvan/markdown-tree-parser explode {input file} {output path}` to automatically install and run the tool
 
 I will now proceed with the manual sharding process."
 
@@ -23459,22 +23456,25 @@ Then proceed with the manual method below ONLY if markdownExploder is false.]]
 
 ### Installation and Usage
 
-1. **Install globally**:
-
-   ```bash
-   npm install -g @kayvan/markdown-tree-parser
-   ```
-
-2. **Use the explode command**:
+1. **Use npx (recommended - no installation needed)**:
 
    ```bash
    # For PRD
-   md-tree explode docs/prd.md docs/prd
+   npx @kayvan/markdown-tree-parser explode docs/prd.md docs/prd
 
    # For Architecture
-   md-tree explode docs/architecture.md docs/architecture
+   npx @kayvan/markdown-tree-parser explode docs/architecture.md docs/architecture
 
    # For any document
+   npx @kayvan/markdown-tree-parser explode [source-document] [destination-folder]
+   ```
+
+2. **Alternative: Install globally** (if you prefer):
+
+   ```bash
+   npm install -g @kayvan/markdown-tree-parser
+   
+   # Then use the shorter command
    md-tree explode [source-document] [destination-folder]
    ```
 
@@ -23484,7 +23484,7 @@ Then proceed with the manual method below ONLY if markdownExploder is false.]]
    - Adjusts heading levels appropriately
    - Handles all edge cases with code blocks and special markdown
 
-If the user has @kayvan/markdown-tree-parser installed, use it and skip the manual process below.
+If the user has @kayvan/markdown-tree-parser available (either via npx or global install), use it and skip the manual process below.
 
 ---
 

--- a/dist/teams/team-all.txt
+++ b/dist/teams/team-all.txt
@@ -7270,21 +7270,18 @@ The story creation is successful when:
 
 ## Primary Method: Automatic with markdown-tree
 
-[[LLM: First, check if markdownExploder is set to true in .bmad-core/core-config.yaml. If it is, attempt to run the command: `md-tree explode {input file} {output path}`.
+[[LLM: First, check if markdownExploder is set to true in .bmad-core/core-config.yaml. If it is, attempt to run the command: `npx @kayvan/markdown-tree-parser explode {input file} {output path}`.
 
 If the command succeeds, inform the user that the document has been sharded successfully and STOP - do not proceed further.
 
-If the command fails (especially with an error indicating the command is not found or not available), inform the user: "The markdownExploder setting is enabled but the md-tree command is not available. Please either:
+If the command fails (especially with an error indicating the command is not found or not available), inform the user: "The markdownExploder setting is enabled but the md-tree command failed. This could be due to package installation issues. Try using: `npx @kayvan/markdown-tree-parser explode {input file} {output path}` to automatically install and run the tool.
 
-1. Install @kayvan/markdown-tree-parser globally with: `npm install -g @kayvan/markdown-tree-parser`
-2. Or set markdownExploder to false in .bmad-core/core-config.yaml
-
-**IMPORTANT: STOP HERE - do not proceed with manual sharding until one of the above actions is taken.**"
+**IMPORTANT: STOP HERE - do not proceed with manual sharding until the npx command is attempted.**"
 
 If markdownExploder is set to false, inform the user: "The markdownExploder setting is currently false. For better performance and reliability, you should:
 
 1. Set markdownExploder to true in .bmad-core/core-config.yaml
-2. Install @kayvan/markdown-tree-parser globally with: `npm install -g @kayvan/markdown-tree-parser`
+2. Use `npx @kayvan/markdown-tree-parser explode {input file} {output path}` to automatically install and run the tool
 
 I will now proceed with the manual sharding process."
 
@@ -7292,22 +7289,25 @@ Then proceed with the manual method below ONLY if markdownExploder is false.]]
 
 ### Installation and Usage
 
-1. **Install globally**:
-
-   ```bash
-   npm install -g @kayvan/markdown-tree-parser
-   ```
-
-2. **Use the explode command**:
+1. **Use npx (recommended - no installation needed)**:
 
    ```bash
    # For PRD
-   md-tree explode docs/prd.md docs/prd
+   npx @kayvan/markdown-tree-parser explode docs/prd.md docs/prd
 
    # For Architecture
-   md-tree explode docs/architecture.md docs/architecture
+   npx @kayvan/markdown-tree-parser explode docs/architecture.md docs/architecture
 
    # For any document
+   npx @kayvan/markdown-tree-parser explode [source-document] [destination-folder]
+   ```
+
+2. **Alternative: Install globally** (if you prefer):
+
+   ```bash
+   npm install -g @kayvan/markdown-tree-parser
+   
+   # Then use the shorter command
    md-tree explode [source-document] [destination-folder]
    ```
 
@@ -7317,7 +7317,7 @@ Then proceed with the manual method below ONLY if markdownExploder is false.]]
    - Adjusts heading levels appropriately
    - Handles all edge cases with code blocks and special markdown
 
-If the user has @kayvan/markdown-tree-parser installed, use it and skip the manual process below.
+If the user has @kayvan/markdown-tree-parser available (either via npx or global install), use it and skip the manual process below.
 
 ---
 

--- a/dist/teams/team-fullstack.txt
+++ b/dist/teams/team-fullstack.txt
@@ -4085,21 +4085,18 @@ The LLM will:
 
 ## Primary Method: Automatic with markdown-tree
 
-[[LLM: First, check if markdownExploder is set to true in .bmad-core/core-config.yaml. If it is, attempt to run the command: `md-tree explode {input file} {output path}`.
+[[LLM: First, check if markdownExploder is set to true in .bmad-core/core-config.yaml. If it is, attempt to run the command: `npx @kayvan/markdown-tree-parser explode {input file} {output path}`.
 
 If the command succeeds, inform the user that the document has been sharded successfully and STOP - do not proceed further.
 
-If the command fails (especially with an error indicating the command is not found or not available), inform the user: "The markdownExploder setting is enabled but the md-tree command is not available. Please either:
+If the command fails (especially with an error indicating the command is not found or not available), inform the user: "The markdownExploder setting is enabled but the md-tree command failed. This could be due to package installation issues. Try using: `npx @kayvan/markdown-tree-parser explode {input file} {output path}` to automatically install and run the tool.
 
-1. Install @kayvan/markdown-tree-parser globally with: `npm install -g @kayvan/markdown-tree-parser`
-2. Or set markdownExploder to false in .bmad-core/core-config.yaml
-
-**IMPORTANT: STOP HERE - do not proceed with manual sharding until one of the above actions is taken.**"
+**IMPORTANT: STOP HERE - do not proceed with manual sharding until the npx command is attempted.**"
 
 If markdownExploder is set to false, inform the user: "The markdownExploder setting is currently false. For better performance and reliability, you should:
 
 1. Set markdownExploder to true in .bmad-core/core-config.yaml
-2. Install @kayvan/markdown-tree-parser globally with: `npm install -g @kayvan/markdown-tree-parser`
+2. Use `npx @kayvan/markdown-tree-parser explode {input file} {output path}` to automatically install and run the tool
 
 I will now proceed with the manual sharding process."
 
@@ -4107,22 +4104,25 @@ Then proceed with the manual method below ONLY if markdownExploder is false.]]
 
 ### Installation and Usage
 
-1. **Install globally**:
-
-   ```bash
-   npm install -g @kayvan/markdown-tree-parser
-   ```
-
-2. **Use the explode command**:
+1. **Use npx (recommended - no installation needed)**:
 
    ```bash
    # For PRD
-   md-tree explode docs/prd.md docs/prd
+   npx @kayvan/markdown-tree-parser explode docs/prd.md docs/prd
 
    # For Architecture
-   md-tree explode docs/architecture.md docs/architecture
+   npx @kayvan/markdown-tree-parser explode docs/architecture.md docs/architecture
 
    # For any document
+   npx @kayvan/markdown-tree-parser explode [source-document] [destination-folder]
+   ```
+
+2. **Alternative: Install globally** (if you prefer):
+
+   ```bash
+   npm install -g @kayvan/markdown-tree-parser
+   
+   # Then use the shorter command
    md-tree explode [source-document] [destination-folder]
    ```
 
@@ -4132,7 +4132,7 @@ Then proceed with the manual method below ONLY if markdownExploder is false.]]
    - Adjusts heading levels appropriately
    - Handles all edge cases with code blocks and special markdown
 
-If the user has @kayvan/markdown-tree-parser installed, use it and skip the manual process below.
+If the user has @kayvan/markdown-tree-parser available (either via npx or global install), use it and skip the manual process below.
 
 ---
 

--- a/dist/teams/team-ide-minimal.txt
+++ b/dist/teams/team-ide-minimal.txt
@@ -1930,21 +1930,18 @@ The LLM will:
 
 ## Primary Method: Automatic with markdown-tree
 
-[[LLM: First, check if markdownExploder is set to true in .bmad-core/core-config.yaml. If it is, attempt to run the command: `md-tree explode {input file} {output path}`.
+[[LLM: First, check if markdownExploder is set to true in .bmad-core/core-config.yaml. If it is, attempt to run the command: `npx @kayvan/markdown-tree-parser explode {input file} {output path}`.
 
 If the command succeeds, inform the user that the document has been sharded successfully and STOP - do not proceed further.
 
-If the command fails (especially with an error indicating the command is not found or not available), inform the user: "The markdownExploder setting is enabled but the md-tree command is not available. Please either:
+If the command fails (especially with an error indicating the command is not found or not available), inform the user: "The markdownExploder setting is enabled but the md-tree command failed. This could be due to package installation issues. Try using: `npx @kayvan/markdown-tree-parser explode {input file} {output path}` to automatically install and run the tool.
 
-1. Install @kayvan/markdown-tree-parser globally with: `npm install -g @kayvan/markdown-tree-parser`
-2. Or set markdownExploder to false in .bmad-core/core-config.yaml
-
-**IMPORTANT: STOP HERE - do not proceed with manual sharding until one of the above actions is taken.**"
+**IMPORTANT: STOP HERE - do not proceed with manual sharding until the npx command is attempted.**"
 
 If markdownExploder is set to false, inform the user: "The markdownExploder setting is currently false. For better performance and reliability, you should:
 
 1. Set markdownExploder to true in .bmad-core/core-config.yaml
-2. Install @kayvan/markdown-tree-parser globally with: `npm install -g @kayvan/markdown-tree-parser`
+2. Use `npx @kayvan/markdown-tree-parser explode {input file} {output path}` to automatically install and run the tool
 
 I will now proceed with the manual sharding process."
 
@@ -1952,22 +1949,25 @@ Then proceed with the manual method below ONLY if markdownExploder is false.]]
 
 ### Installation and Usage
 
-1. **Install globally**:
-
-   ```bash
-   npm install -g @kayvan/markdown-tree-parser
-   ```
-
-2. **Use the explode command**:
+1. **Use npx (recommended - no installation needed)**:
 
    ```bash
    # For PRD
-   md-tree explode docs/prd.md docs/prd
+   npx @kayvan/markdown-tree-parser explode docs/prd.md docs/prd
 
    # For Architecture
-   md-tree explode docs/architecture.md docs/architecture
+   npx @kayvan/markdown-tree-parser explode docs/architecture.md docs/architecture
 
    # For any document
+   npx @kayvan/markdown-tree-parser explode [source-document] [destination-folder]
+   ```
+
+2. **Alternative: Install globally** (if you prefer):
+
+   ```bash
+   npm install -g @kayvan/markdown-tree-parser
+   
+   # Then use the shorter command
    md-tree explode [source-document] [destination-folder]
    ```
 
@@ -1977,7 +1977,7 @@ Then proceed with the manual method below ONLY if markdownExploder is false.]]
    - Adjusts heading levels appropriately
    - Handles all edge cases with code blocks and special markdown
 
-If the user has @kayvan/markdown-tree-parser installed, use it and skip the manual process below.
+If the user has @kayvan/markdown-tree-parser available (either via npx or global install), use it and skip the manual process below.
 
 ---
 

--- a/dist/teams/team-no-ui.txt
+++ b/dist/teams/team-no-ui.txt
@@ -4031,21 +4031,18 @@ The LLM will:
 
 ## Primary Method: Automatic with markdown-tree
 
-[[LLM: First, check if markdownExploder is set to true in .bmad-core/core-config.yaml. If it is, attempt to run the command: `md-tree explode {input file} {output path}`.
+[[LLM: First, check if markdownExploder is set to true in .bmad-core/core-config.yaml. If it is, attempt to run the command: `npx @kayvan/markdown-tree-parser explode {input file} {output path}`.
 
 If the command succeeds, inform the user that the document has been sharded successfully and STOP - do not proceed further.
 
-If the command fails (especially with an error indicating the command is not found or not available), inform the user: "The markdownExploder setting is enabled but the md-tree command is not available. Please either:
+If the command fails (especially with an error indicating the command is not found or not available), inform the user: "The markdownExploder setting is enabled but the md-tree command failed. This could be due to package installation issues. Try using: `npx @kayvan/markdown-tree-parser explode {input file} {output path}` to automatically install and run the tool.
 
-1. Install @kayvan/markdown-tree-parser globally with: `npm install -g @kayvan/markdown-tree-parser`
-2. Or set markdownExploder to false in .bmad-core/core-config.yaml
-
-**IMPORTANT: STOP HERE - do not proceed with manual sharding until one of the above actions is taken.**"
+**IMPORTANT: STOP HERE - do not proceed with manual sharding until the npx command is attempted.**"
 
 If markdownExploder is set to false, inform the user: "The markdownExploder setting is currently false. For better performance and reliability, you should:
 
 1. Set markdownExploder to true in .bmad-core/core-config.yaml
-2. Install @kayvan/markdown-tree-parser globally with: `npm install -g @kayvan/markdown-tree-parser`
+2. Use `npx @kayvan/markdown-tree-parser explode {input file} {output path}` to automatically install and run the tool
 
 I will now proceed with the manual sharding process."
 
@@ -4053,22 +4050,25 @@ Then proceed with the manual method below ONLY if markdownExploder is false.]]
 
 ### Installation and Usage
 
-1. **Install globally**:
-
-   ```bash
-   npm install -g @kayvan/markdown-tree-parser
-   ```
-
-2. **Use the explode command**:
+1. **Use npx (recommended - no installation needed)**:
 
    ```bash
    # For PRD
-   md-tree explode docs/prd.md docs/prd
+   npx @kayvan/markdown-tree-parser explode docs/prd.md docs/prd
 
    # For Architecture
-   md-tree explode docs/architecture.md docs/architecture
+   npx @kayvan/markdown-tree-parser explode docs/architecture.md docs/architecture
 
    # For any document
+   npx @kayvan/markdown-tree-parser explode [source-document] [destination-folder]
+   ```
+
+2. **Alternative: Install globally** (if you prefer):
+
+   ```bash
+   npm install -g @kayvan/markdown-tree-parser
+   
+   # Then use the shorter command
    md-tree explode [source-document] [destination-folder]
    ```
 
@@ -4078,7 +4078,7 @@ Then proceed with the manual method below ONLY if markdownExploder is false.]]
    - Adjusts heading levels appropriately
    - Handles all edge cases with code blocks and special markdown
 
-If the user has @kayvan/markdown-tree-parser installed, use it and skip the manual process below.
+If the user has @kayvan/markdown-tree-parser available (either via npx or global install), use it and skip the manual process below.
 
 ---
 

--- a/expansion-packs/bmad-godot-game-dev/tasks/shard-doc.md
+++ b/expansion-packs/bmad-godot-game-dev/tasks/shard-doc.md
@@ -10,21 +10,18 @@
 
 ## Primary Method: Automatic with markdown-tree
 
-[[LLM: First, check if markdownExploder is set to true in .bmad-godot-game-dev/config.yaml. If it is, attempt to run the command: `md-tree explode {input file} {output path}`.
+[[LLM: First, check if markdownExploder is set to true in .bmad-godot-game-dev/config.yaml. If it is, attempt to run the command: `npx @kayvan/markdown-tree-parser explode {input file} {output path}`.
 
 If the command succeeds, inform the user that the document has been sharded successfully and STOP - do not proceed further.
 
-If the command fails (especially with an error indicating the command is not found or not available), inform the user: "The markdownExploder setting is enabled but the md-tree command is not available. Please either:
+If the command fails (especially with an error indicating the command is not found or not available), inform the user: "The markdownExploder setting is enabled but the md-tree command failed. This could be due to package installation issues. Try using: `npx @kayvan/markdown-tree-parser explode {input file} {output path}` to automatically install and run the tool.
 
-1. Install @kayvan/markdown-tree-parser globally with: `npm install -g @kayvan/markdown-tree-parser`
-2. Or set markdownExploder to false in .bmad-godot-game-dev/config.yaml
-
-**IMPORTANT: STOP HERE - do not proceed with manual sharding until one of the above actions is taken.**"
+**IMPORTANT: STOP HERE - do not proceed with manual sharding until the npx command is attempted.**"
 
 If markdownExploder is set to false, inform the user: "The markdownExploder setting is currently false. For better performance and reliability, you should:
 
 1. Set markdownExploder to true in .bmad-godot-game-dev/config.yaml
-2. Install @kayvan/markdown-tree-parser globally with: `npm install -g @kayvan/markdown-tree-parser`
+2. Use `npx @kayvan/markdown-tree-parser explode {input file} {output path}` to automatically install and run the tool
 
 I will now proceed with the manual sharding process."
 
@@ -32,22 +29,25 @@ Then proceed with the manual method below ONLY if markdownExploder is false.]]
 
 ### Installation and Usage
 
-1. **Install globally**:
-
-   ```bash
-   npm install -g @kayvan/markdown-tree-parser
-   ```
-
-2. **Use the explode command**:
+1. **Use npx (recommended - no installation needed)**:
 
    ```bash
    # For PRD
-   md-tree explode docs/prd.md docs/prd
+   npx @kayvan/markdown-tree-parser explode docs/prd.md docs/prd
 
    # For Architecture
-   md-tree explode docs/architecture.md docs/architecture
+   npx @kayvan/markdown-tree-parser explode docs/architecture.md docs/architecture
 
    # For any document
+   npx @kayvan/markdown-tree-parser explode [source-document] [destination-folder]
+   ```
+
+2. **Alternative: Install globally** (if you prefer):
+
+   ```bash
+   npm install -g @kayvan/markdown-tree-parser
+   
+   # Then use the shorter command
    md-tree explode [source-document] [destination-folder]
    ```
 
@@ -57,7 +57,7 @@ Then proceed with the manual method below ONLY if markdownExploder is false.]]
    - Adjusts heading levels appropriately
    - Handles all edge cases with code blocks and special markdown
 
-If the user has @kayvan/markdown-tree-parser installed, use it and skip the manual process below.
+If the user has @kayvan/markdown-tree-parser available (either via npx or global install), use it and skip the manual process below.
 
 ---
 


### PR DESCRIPTION
…-tree-parser

Replace global npm install with npx to prevent permission issues:
- Updated LLM instructions to use npx @kayvan/markdown-tree-parser explode
- Changed installation method from npm install -g to npx (recommended)
- Updated error messages to suggest npx approach
- Applied changes across all dist/ agent and team files
- Updated expansion pack shard-doc.md files

🤖 Generated with [Claude Code](https://claude.ai/code)