### PR TITLE
fix: Changed title to coding standards section of brownfield architecture template

### DIFF
--- a/bmad-core/templates/brownfield-architecture-tmpl.yaml
+++ b/bmad-core/templates/brownfield-architecture-tmpl.yaml
@@ -109,8 +109,8 @@ sections:
           - **UI/UX Consistency:** {{ui_compatibility}}
           - **Performance Impact:** {{performance_constraints}}
 
-  - id: tech-stack-alignment
-    title: Tech Stack Alignment
+  - id: tech-stack
+    title: Tech Stack
     instruction: |
       Ensure new components align with existing technology choices:
 
@@ -272,8 +272,8 @@ sections:
 
           **Error Handling:** {{error_handling_strategy}}
 
-  - id: source-tree-integration
-    title: Source Tree Integration
+  - id: source-tree
+    title: Source Tree
     instruction: |
       Define how new code will integrate with existing project structure:
 


### PR DESCRIPTION
Brownfield architecture template contains title which after flattening will create file 'architecture/coding-standards-and-conventions.md'

Dev agent cannot find this file then. By default this agent is looking for 'architecture/coding-standards.md'