### PR TITLE
feat(installer): add --update-manifest-only installer option

### DIFF
--- a/package.json
+++ b/package.json
@@ -43,6 +43,7 @@
     "release:patch": "gh workflow run \"Manual Release\" -f version_bump=patch",
     "release:watch": "gh run watch",
     "setup:hooks": "chmod +x tools/setup-hooks.sh && ./tools/setup-hooks.sh",
+    "update:manifest": "node tools/installer/bin/bmad.js install --update-manifest-only",
     "validate": "node tools/cli.js validate",
     "version:all": "node tools/bump-all-versions.js",
     "version:all:major": "node tools/bump-all-versions.js major",

--- a/tools/installer/bin/bmad.js
+++ b/tools/installer/bin/bmad.js
@@ -47,6 +47,7 @@ program
   .option('-f, --full', 'Install complete BMad Method')
   .option('-x, --expansion-only', 'Install only expansion packs (no bmad-core)')
   .option('-d, --directory <path>', 'Installation directory')
+  .option('--update-manifest-only', 'Only rebuild/update the install-manifest.yaml file')
   .option(
     '-i, --ide <ide...>',
     'Configure for specific IDE(s) - can specify multiple (cursor, claude-code, windsurf, trae, roo, kilo, cline, gemini, qwen-code, github-copilot, codex, codex-web, auggie-cli, iflow-cli, opencode, other)',
@@ -57,7 +58,15 @@ program
   )
   .action(async (options) => {
     try {
-      if (!options.full && !options.expansionOnly) {
+      if (options.updateManifestOnly) {
+        // Manifest-only update mode
+        const config = {
+          directory: options.directory || '.',
+          updateManifestOnly: true,
+        };
+        await installer.updateManifestOnly(config);
+        process.exit(0);
+      } else if (!options.full && !options.expansionOnly) {
         // Interactive mode
         const answers = await promptInstallation();
         if (!answers._alreadyInstalled) {
@@ -196,12 +205,12 @@ async function promptInstallation() {
   // Display ASCII logo
   console.log(
     chalk.bold.cyan(`
-██████╗ ███╗   ███╗ █████╗ ██████╗       ███╗   ███╗███████╗████████╗██╗  ██╗ ██████╗ ██████╗ 
+██████╗ ███╗   ███╗ █████╗ ██████╗       ███╗   ███╗███████╗████████╗██╗  ██╗ ██████╗ ██████╗
 ██╔══██╗████╗ ████║██╔══██╗██╔══██╗      ████╗ ████║██╔════╝╚══██╔══╝██║  ██║██╔═══██╗██╔══██╗
 ██████╔╝██╔████╔██║███████║██║  ██║█████╗██╔████╔██║█████╗     ██║   ███████║██║   ██║██║  ██║
 ██╔══██╗██║╚██╔╝██║██╔══██║██║  ██║╚════╝██║╚██╔╝██║██╔══╝     ██║   ██╔══██║██║   ██║██║  ██║
 ██████╔╝██║ ╚═╝ ██║██║  ██║██████╔╝      ██║ ╚═╝ ██║███████╗   ██║   ██║  ██║╚██████╔╝██████╔╝
-╚═════╝ ╚═╝     ╚═╝╚═╝  ╚═╝╚═════╝       ╚═╝     ╚═╝╚══════╝   ╚═╝   ╚═╝  ╚═╝ ╚═════╝ ╚═════╝ 
+╚═════╝ ╚═╝     ╚═╝╚═╝  ╚═╝╚═════╝       ╚═╝     ╚═╝╚══════╝   ╚═╝   ╚═╝  ╚═╝ ╚═════╝ ╚═════╝
   `),
   );
 


### PR DESCRIPTION
Addresses #628 Fast manifest updates for out-of-sync BMad installations

Add new CLI option to update installation manifests based only on changes without full reinstallation:

• Add --update-manifest-only flag to installer CLI • Implement comprehensive manifest update logic in installer.js • Scan existing installations and regenerate accurate manifests • Preserve configuration while updating file hashes and metadata • Add npm run update:manifest convenience script

Features:
- Validates existing .bmad-core installations
- Scans all files recursively and generates current state manifests
- Supports both core and expansion pack installations
- Compatible with all usage patterns (CLI, npm, npx)
- Fast execution with zero file disruption

Resolves manifest sync issues when installations drift from recorded state. Eliminates need for full reinstallation when only manifest needs updating.