### PR TITLE
fix: Correct path to instructions in bmad-init workflow

### DIFF
--- a/src/core/workflows/bmad-init/workflow.yaml
+++ b/src/core/workflows/bmad-init/workflow.yaml
@@ -9,6 +9,6 @@ date: system-generated
 
 # This is an action workflow - no template output
 template: false
-instructions: "{project-root}/src/core/workflows/bmad-init/instructions.md"
+instructions: "{project-root}/bmad/core/workflows/bmad-init/instructions.md"
 
 web_bundle: false


### PR DESCRIPTION
Corrected the path to the instructions.md that the bmad-init workflow was searching for.