### PR TITLE
fix: correct status terminology to match story template

### DIFF
--- a/bmad-core/agents/dev.md
+++ b/bmad-core/agents/dev.md
@@ -65,7 +65,7 @@ commands:
           - CRITICAL: DO NOT modify Status, Story, Acceptance Criteria, Dev Notes, Testing sections, or any other sections not listed above
       - blocking: 'HALT for: Unapproved deps needed, confirm with user | Ambiguous after story check | 3 failures attempting to implement or fix something repeatedly | Missing config | Failing regression'
       - ready-for-review: 'Code matches requirements + All validations pass + Follows standards + File List complete'
-      - completion: "All Tasks and Subtasks marked [x] and have tests→Validations and full regression passes (DON'T BE LAZY, EXECUTE ALL TESTS and CONFIRM)→Ensure File List is Complete→run the task execute-checklist for the checklist story-dod-checklist→set story status: 'Ready for Review'→HALT"
+      - completion: "All Tasks and Subtasks marked [x] and have tests→Validations and full regression passes (DON'T BE LAZY, EXECUTE ALL TESTS and CONFIRM)→Ensure File List is Complete→run the task execute-checklist for the checklist story-dod-checklist→set story status: 'Review'→HALT"
   - explain: teach me what and why you did whatever you just did in detail so I can learn. Explain to me as if you were training a junior engineer.
   - review-qa: run task `apply-qa-fixes.md'
   - run-tests: Execute linting and tests

--- a/bmad-core/tasks/apply-qa-fixes.md
+++ b/bmad-core/tasks/apply-qa-fixes.md
@@ -104,8 +104,8 @@ CRITICAL: Dev agent is ONLY authorized to update these sections of the story fil
 
 Status Rule:
 
-- If gate was PASS and all identified gaps are closed → set `Status: Ready for Done`
-- Otherwise → set `Status: Ready for Review` and notify QA to re-run the review
+- If gate was PASS and all identified gaps are closed → set `Status: Done`
+- Otherwise → set `Status: Review` and notify QA to re-run the review
 
 ### 6) Do NOT Edit Gate Files
 


### PR DESCRIPTION
## Description
Fixes agents setting invalid status values that don't match the story template.

## Problem
- `bmad-core/templates/story-tmpl.yaml` defines valid status choices as: `[Draft, Approved, InProgress, Review, Done]`
- `bmad-core/agents/dev.md` completion command instructed agents to set status: `'Ready for Review'`
- `bmad-core/tasks/apply-qa-fixes.md` instructed agents to set status: `'Ready for Done'` or `'Ready for Review'`
- These values don't match the valid choices, causing agents to set invalid status values

## Solution
Changed status terminology to match valid choices:
- `dev.md`: `'Ready for Review'` → `'Review'`
- `apply-qa-fixes.md`: `'Ready for Done'` → `'Done'`, `'Ready for Review'` → `'Review'`

## Testing
- ✅ `npm run validate` - All agent configs valid
- ✅ `npm run format:check` - All files properly formatted
- ✅ `npm run lint` - No linting issues

## Type of Change
- [x] Bug fix (non-breaking change which fixes an issue)