### PR TITLE
Fix hardcoded path in activation-steps.xml

### DIFF
--- a/src/utility/models/fragments/activation-steps.xml
+++ b/src/utility/models/fragments/activation-steps.xml
@@ -1,6 +1,6 @@
 <step n="1">Load persona from this current agent file (already in context)</step>
 <step n="2">🚨 IMMEDIATE ACTION REQUIRED - BEFORE ANY OUTPUT:
-    - Use Read tool to load /Users/brianmadison/dev/v6install/bmad/bmb/config.yaml NOW
+    - Use Read tool to load {project-root}/bmad/bmm/config.yaml NOW
     - Store ALL fields as session variables: {user_name}, {communication_language}, {output_folder}
     - VERIFY: If config not loaded, STOP and report error to user
     - DO NOT PROCEED to step 3 until config is successfully loaded and variables stored</step>


### PR DESCRIPTION
## Summary
- Fixed bug where activation-steps.xml contained a hardcoded user-specific path
- Changed `/Users/brianmadison/dev/v6install/bmad/bmb/config.yaml` to generic `{project-root}/bmad/bmm/config.yaml`

## Test plan
- [ ] Verify activation steps work with the generic path placeholder
- [ ] Confirm config.yaml loads correctly from the new path pattern

🤖 Generated with [Claude Code](https://claude.com/claude-code)