### PR TITLE
feat(codex): activate with custom prompts instead of AGENTS.md

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,11 @@
 # Changelog
 
+## [Unreleased]
+
+### Codex Installer
+
+- Codex installer uses custom prompts in `.codex/prompts/`, instead of `AGENTS.md`
+
 ## [6.0.0-alpha.0]
 
 **Release: September 28, 2025**

--- a/docs/ide-info/claude-code.md
+++ b/docs/ide-info/claude-code.md
@@ -13,13 +13,13 @@ BMAD agents are installed as slash commands in `.claude/commands/bmad/`.
 ### Examples
 
 ```
-/bmad-dev - Activate development agent
-/bmad-architect - Activate architect agent
-/bmad-task-setup - Execute setup task
+/bmad:bmm:agents:dev - Activate development agent
+/bmad:bmm:agents:architect - Activate architect agent
+/bmad:bmm:workflows:dev-story - Execute dev-story workflow
 ```
 
 ### Notes
 
 - Commands are autocompleted when you type `/`
 - Agent remains active for the conversation
-- Start new conversation to switch agents
+- Start a new conversation to switch agents

--- a/docs/ide-info/codex.md
+++ b/docs/ide-info/codex.md
@@ -2,31 +2,20 @@
 
 ## Activating Agents
 
-BMAD agents are documented in `AGENTS.md` file in project root.
-
-### CLI Mode
-
-1. **Reference Agent**: Type `@{agent-name}` in prompt
-2. **Execute Task**: Type `@task-{task-name}`
-3. **Active Session**: Agent remains active for conversation
-
-### Web Mode
-
-1. **Navigate**: Go to Agents section in web interface
-2. **Select Agent**: Click to activate agent persona
-3. **Session**: Agent active for browser session
+BMAD agents, tasks and workflows are installed as custom prompts in
+`$CODEX_HOME/prompts/bmad-*.md` files. If `CODEX_HOME` is not set, it
+defaults to `$HOME/.codex/`.
 
 ### Examples
 
 ```
-@dev - Activate development agent
-@architect - Activate architect agent
-@task-setup - Execute setup task
+/bmad-bmm-agents-dev - Activate development agent
+/bmad-bmm-agents-architect - Activate architect agent
+/bmad-bmm-workflows-dev-story - Execute dev-story workflow
 ```
 
 ### Notes
 
-- All agents documented in AGENTS.md
-- CLI: Reference with @ syntax
-- Web: Use interface to select
-- One agent active at a time
+Prompts are autocompleted when you type /
+Agent remains active for the conversation
+Start a new conversation to switch agents

--- a/tools/cli/installers/lib/ide/manager.js
+++ b/tools/cli/installers/lib/ide/manager.js
@@ -1,6 +1,7 @@
 const fs = require('fs-extra');
 const path = require('node:path');
 const chalk = require('chalk');
+const os = require('node:os');
 
 /**
  * IDE Manager - handles IDE-specific setup
@@ -191,9 +192,13 @@ class IdeManager {
       }
     }
 
-    // Check for AGENTS.md (Codex)
-    if (await fs.pathExists(path.join(projectDir, 'AGENTS.md'))) {
-      detected.push('codex');
+    // Check Codex prompt directory for BMAD exports
+    const codexPromptDir = path.join(os.homedir(), '.codex', 'prompts');
+    if (await fs.pathExists(codexPromptDir)) {
+      const codexEntries = await fs.readdir(codexPromptDir);
+      if (codexEntries.some((file) => file.startsWith('bmad-'))) {
+        detected.push('codex');
+      }
     }
 
     return detected;

--- a/tools/cli/installers/lib/ide/shared/bmad-artifacts.js
+++ b/tools/cli/installers/lib/ide/shared/bmad-artifacts.js
@@ -1,0 +1,112 @@
+const path = require('node:path');
+const fs = require('fs-extra');
+
+/**
+ * Helpers for gathering BMAD agents/tasks from the installed tree.
+ * Shared by installers that need Claude-style exports.
+ */
+async function getAgentsFromBmad(bmadDir, selectedModules = []) {
+  const agents = [];
+
+  if (await fs.pathExists(path.join(bmadDir, 'core', 'agents'))) {
+    const coreAgents = await getAgentsFromDir(path.join(bmadDir, 'core', 'agents'), 'core');
+    agents.push(...coreAgents);
+  }
+
+  for (const moduleName of selectedModules) {
+    const agentsPath = path.join(bmadDir, moduleName, 'agents');
+
+    if (await fs.pathExists(agentsPath)) {
+      const moduleAgents = await getAgentsFromDir(agentsPath, moduleName);
+      agents.push(...moduleAgents);
+    }
+  }
+
+  return agents;
+}
+
+async function getTasksFromBmad(bmadDir, selectedModules = []) {
+  const tasks = [];
+
+  if (await fs.pathExists(path.join(bmadDir, 'core', 'tasks'))) {
+    const coreTasks = await getTasksFromDir(path.join(bmadDir, 'core', 'tasks'), 'core');
+    tasks.push(...coreTasks);
+  }
+
+  for (const moduleName of selectedModules) {
+    const tasksPath = path.join(bmadDir, moduleName, 'tasks');
+
+    if (await fs.pathExists(tasksPath)) {
+      const moduleTasks = await getTasksFromDir(tasksPath, moduleName);
+      tasks.push(...moduleTasks);
+    }
+  }
+
+  return tasks;
+}
+
+async function getAgentsFromDir(dirPath, moduleName) {
+  const agents = [];
+
+  if (!(await fs.pathExists(dirPath))) {
+    return agents;
+  }
+
+  const files = await fs.readdir(dirPath);
+
+  for (const file of files) {
+    if (!file.endsWith('.md')) {
+      continue;
+    }
+
+    if (file.includes('.customize.')) {
+      continue;
+    }
+
+    const filePath = path.join(dirPath, file);
+    const content = await fs.readFile(filePath, 'utf8');
+
+    if (content.includes('localskip="true"')) {
+      continue;
+    }
+
+    agents.push({
+      path: filePath,
+      name: file.replace('.md', ''),
+      module: moduleName,
+    });
+  }
+
+  return agents;
+}
+
+async function getTasksFromDir(dirPath, moduleName) {
+  const tasks = [];
+
+  if (!(await fs.pathExists(dirPath))) {
+    return tasks;
+  }
+
+  const files = await fs.readdir(dirPath);
+
+  for (const file of files) {
+    if (!file.endsWith('.md')) {
+      continue;
+    }
+
+    tasks.push({
+      path: path.join(dirPath, file),
+      name: file.replace('.md', ''),
+      module: moduleName,
+    });
+  }
+
+  return tasks;
+}
+
+module.exports = {
+  getAgentsFromBmad,
+  getTasksFromBmad,
+  getAgentsFromDir,
+  getTasksFromDir,
+};

--- a/tools/cli/installers/lib/ide/shared/module-injections.js
+++ b/tools/cli/installers/lib/ide/shared/module-injections.js
@@ -1,0 +1,133 @@
+const path = require('node:path');
+const fs = require('fs-extra');
+const yaml = require('js-yaml');
+const { glob } = require('glob');
+const { getSourcePath } = require('../../../../lib/project-root');
+
+async function loadModuleInjectionConfig(handler, moduleName) {
+  const sourceModulesPath = getSourcePath('modules');
+  const handlerBaseDir = path.join(sourceModulesPath, moduleName, 'sub-modules', handler);
+  const configPath = path.join(handlerBaseDir, 'injections.yaml');
+
+  if (!(await fs.pathExists(configPath))) {
+    return null;
+  }
+
+  const configContent = await fs.readFile(configPath, 'utf8');
+  const config = yaml.load(configContent) || {};
+
+  return {
+    config,
+    handlerBaseDir,
+    configPath,
+  };
+}
+
+function shouldApplyInjection(injection, subagentChoices) {
+  if (!subagentChoices || subagentChoices.install === 'none') {
+    return false;
+  }
+
+  if (subagentChoices.install === 'all') {
+    return true;
+  }
+
+  if (subagentChoices.install === 'selective') {
+    const selected = subagentChoices.selected || [];
+
+    if (injection.requires === 'any' && selected.length > 0) {
+      return true;
+    }
+
+    if (injection.requires) {
+      const required = `${injection.requires}.md`;
+      return selected.includes(required);
+    }
+
+    if (injection.point) {
+      const selectedNames = selected.map((file) => file.replace('.md', ''));
+      return selectedNames.some((name) => injection.point.includes(name));
+    }
+  }
+
+  return false;
+}
+
+function filterAgentInstructions(content, selectedFiles) {
+  if (!selectedFiles || selectedFiles.length === 0) {
+    return '';
+  }
+
+  const selectedAgents = selectedFiles.map((file) => file.replace('.md', ''));
+  const lines = content.split('\n');
+  const filteredLines = [];
+
+  for (const line of lines) {
+    if (line.includes('<llm') || line.includes('</llm>')) {
+      filteredLines.push(line);
+    } else if (line.includes('subagent')) {
+      let shouldInclude = false;
+      for (const agent of selectedAgents) {
+        if (line.includes(agent)) {
+          shouldInclude = true;
+          break;
+        }
+      }
+
+      if (shouldInclude) {
+        filteredLines.push(line);
+      }
+    } else if (line.includes('When creating PRDs') || line.includes('ACTIVELY delegate')) {
+      filteredLines.push(line);
+    }
+  }
+
+  if (filteredLines.length > 2) {
+    return filteredLines.join('\n');
+  }
+
+  return '';
+}
+
+async function resolveSubagentFiles(handlerBaseDir, subagentConfig, subagentChoices) {
+  if (!subagentConfig || !subagentConfig.files) {
+    return [];
+  }
+
+  if (!subagentChoices || subagentChoices.install === 'none') {
+    return [];
+  }
+
+  let filesToCopy = subagentConfig.files;
+
+  if (subagentChoices.install === 'selective') {
+    filesToCopy = subagentChoices.selected || [];
+  }
+
+  const sourceDir = path.join(handlerBaseDir, subagentConfig.source || '');
+  const resolved = [];
+
+  for (const file of filesToCopy) {
+    const pattern = path.join(sourceDir, '**', file);
+    const matches = await glob(pattern);
+
+    if (matches.length > 0) {
+      const absolutePath = matches[0];
+      resolved.push({
+        file,
+        absolutePath,
+        relativePath: path.relative(sourceDir, absolutePath),
+        sourceDir,
+      });
+    }
+  }
+
+  return resolved;
+}
+
+module.exports = {
+  loadModuleInjectionConfig,
+  shouldApplyInjection,
+  filterAgentInstructions,
+  resolveSubagentFiles,
+};


### PR DESCRIPTION
## Summary
- refactor Codex installer to install per-agent/task/workflow prompts under `.codex/prompts/` instead of relying on `AGENTS.md`
- align Claude Code documentation with the new prompt naming and activation commands
- extract shared installer helpers (`bmad-artifacts`, `module-injections`) and update workflow manifest handling
- does not deal with $CODEX_HOME and recommendations for project-local setups. That will be in a later PR.

See #673 

## Testing

`npm run bmad:install`, select Codex, check contents of `~/.codex/prompts/` , run `codex`, see that `/bmad*.md` prompts are available and working.