### PR TITLE
refactor(ide): delegate detection to handlers

### DIFF
--- a/tools/cli/installers/lib/ide/auggie.js
+++ b/tools/cli/installers/lib/ide/auggie.js
@@ -16,6 +16,7 @@ class AuggieSetup extends BaseIdeSetup {
       { name: 'User Home (~/.auggie/commands)', value: path.join(os.homedir(), '.auggie', 'commands') },
       { name: 'Custom Location', value: 'custom' },
     ];
+    this.detectionPaths = ['.auggie'];
   }
 
   /**

--- a/tools/cli/installers/lib/ide/codex.js
+++ b/tools/cli/installers/lib/ide/codex.js
@@ -81,6 +81,20 @@ class CodexSetup extends BaseIdeSetup {
   }
 
   /**
+   * Detect Codex installation by checking for BMAD prompt exports
+   */
+  async detect(_projectDir) {
+    const destDir = this.getCodexPromptDir();
+
+    if (!(await fs.pathExists(destDir))) {
+      return false;
+    }
+
+    const entries = await fs.readdir(destDir);
+    return entries.some((entry) => entry.startsWith('bmad-'));
+  }
+
+  /**
    * Collect Claude-style artifacts for Codex export.
    * Returns the normalized artifact list for further processing.
    */

--- a/tools/cli/installers/lib/ide/manager.js
+++ b/tools/cli/installers/lib/ide/manager.js
@@ -1,7 +1,6 @@
 const fs = require('fs-extra');
 const path = require('node:path');
 const chalk = require('chalk');
-const os = require('node:os');
 
 /**
  * IDE Manager - handles IDE-specific setup
@@ -166,38 +165,9 @@ class IdeManager {
   async detectInstalledIdes(projectDir) {
     const detected = [];
 
-    // Check for IDE-specific directories
-    const ideChecks = {
-      cursor: '.cursor',
-      'claude-code': '.claude',
-      windsurf: '.windsurf',
-      cline: '.clinerules',
-      roo: '.roomodes',
-      trae: '.trae',
-      kilo: '.kilocodemodes',
-      gemini: '.gemini',
-      qwen: '.qwen',
-      crush: '.crush',
-      iflow: '.iflow',
-      auggie: '.auggie',
-      'github-copilot': '.github/chatmodes',
-      vscode: '.vscode',
-      idea: '.idea',
-    };
-
-    for (const [ide, dir] of Object.entries(ideChecks)) {
-      const idePath = path.join(projectDir, dir);
-      if (await fs.pathExists(idePath)) {
-        detected.push(ide);
-      }
-    }
-
-    // Check Codex prompt directory for BMAD exports
-    const codexPromptDir = path.join(os.homedir(), '.codex', 'prompts');
-    if (await fs.pathExists(codexPromptDir)) {
-      const codexEntries = await fs.readdir(codexPromptDir);
-      if (codexEntries.some((file) => file.startsWith('bmad-'))) {
-        detected.push('codex');
+    for (const [name, handler] of this.handlers) {
+      if (typeof handler.detect === 'function' && (await handler.detect(projectDir))) {
+        detected.push(name);
       }
     }
 


### PR DESCRIPTION
Refactors the IDE installer manager so detection happens inside each handler instead of the shared loader, adds reusable detection helpers to BaseIdeSetup, and wires Codex/Auggie to keep parity with the previous behavior (validated via an old-vs-new comparison script).