### PR TITLE
fix: install auggie commands to augment directory

### DIFF
--- a/docs/ide-info/auggie.md
+++ b/docs/ide-info/auggie.md
@@ -6,8 +6,8 @@ BMAD agents can be installed in multiple locations based on your setup.
 
 ### Common Locations
 
-- User Home: `~/.auggie/commands/`
-- Project: `.auggie/commands/`
+- User Home: `~/.augment/commands/`
+- Project: `.augment/commands/`
 - Custom paths you selected
 
 ### How to Use

--- a/tools/cli/installers/lib/ide/auggie.js
+++ b/tools/cli/installers/lib/ide/auggie.js
@@ -12,11 +12,11 @@ class AuggieSetup extends BaseIdeSetup {
   constructor() {
     super('auggie', 'Auggie CLI');
     this.defaultLocations = [
-      { name: 'Project Directory (.auggie/commands)', value: '.auggie/commands', checked: true },
-      { name: 'User Home (~/.auggie/commands)', value: path.join(os.homedir(), '.auggie', 'commands') },
+      { name: 'Project Directory (.augment/commands)', value: '.augment/commands', checked: true },
+      { name: 'User Home (~/.augment/commands)', value: path.join(os.homedir(), '.augment', 'commands') },
       { name: 'Custom Location', value: 'custom' },
     ];
-    this.detectionPaths = ['.auggie'];
+    this.detectionPaths = ['.augment'];
   }
 
   /**
@@ -141,7 +141,7 @@ class AuggieSetup extends BaseIdeSetup {
       // Process the pre-collected locations to resolve relative paths
       const processedLocations = [];
       for (const loc of options.auggieLocations) {
-        if (loc === '.auggie/commands') {
+        if (loc === '.augment/commands') {
           // Relative to project directory
           processedLocations.push(path.join(projectDir, loc));
         } else {
@@ -183,7 +183,7 @@ class AuggieSetup extends BaseIdeSetup {
           },
         ]);
         locations.push(custom.path);
-      } else if (loc.startsWith('.auggie')) {
+      } else if (loc.startsWith('.augment')) {
         // Relative to project directory
         locations.push(path.join(projectDir, loc));
       } else {
@@ -239,7 +239,7 @@ BMAD ${task.module.toUpperCase()} module
     const fs = require('fs-extra');
 
     // Check common locations
-    const locations = [path.join(os.homedir(), '.auggie', 'commands'), path.join(projectDir, '.auggie', 'commands')];
+    const locations = [path.join(os.homedir(), '.augment', 'commands'), path.join(projectDir, '.augment', 'commands')];
 
     for (const location of locations) {
       const agentsDir = path.join(location, 'agents');


### PR DESCRIPTION
 ## What

  - Update the Auggie installer defaults and docs so CLI installs now target .augment/commands for both workspace and
    user scopes.

  ## Why

  - Auggie’s Custom Slash Commands guidance expects commands under .augment/commands, so the prior .auggie paths were writing to a deprecated location (https://docs.augmentcode.com/cli/custom-commands).

  ## How

  - Swapped Auggie installer defaults/detection to .augment/commands, ensuring project-relative paths resolve correctly.
  - Adjusted pre-collected location handling so .augment/commands maps to the project directory before installation.
  - Synced the Auggie CLI docs to reference .augment/commands for home and workspace setups.

  ## Testing

  - npm run lint