### PR TITLE
Feat/manifest ide selection

### DIFF
--- a/tools/cli/installers/lib/core/installer.js
+++ b/tools/cli/installers/lib/core/installer.js
@@ -385,7 +385,9 @@ class Installer {
       // Generate CSV manifests for workflows, agents, tasks AND ALL FILES with hashes BEFORE IDE setup
       spinner.start('Generating workflow and agent manifests...');
       const manifestGen = new ManifestGenerator();
-      const manifestStats = await manifestGen.generateManifests(bmadDir, config.modules || [], this.installedFiles);
+      const manifestStats = await manifestGen.generateManifests(bmadDir, config.modules || [], this.installedFiles, {
+        ides: config.ides || [],
+      });
 
       spinner.succeed(
         `Manifests generated: ${manifestStats.workflows} workflows, ${manifestStats.agents} agents, ${manifestStats.tasks} tasks, ${manifestStats.files} files`,

--- a/tools/cli/installers/lib/core/manifest-generator.js
+++ b/tools/cli/installers/lib/core/manifest-generator.js
@@ -14,6 +14,7 @@ class ManifestGenerator {
     this.tasks = [];
     this.modules = [];
     this.files = [];
+    this.selectedIdes = [];
   }
 
   /**
@@ -22,7 +23,7 @@ class ManifestGenerator {
    * @param {Array} selectedModules - Selected modules for installation
    * @param {Array} installedFiles - All installed files (optional, for hash tracking)
    */
-  async generateManifests(bmadDir, selectedModules, installedFiles = []) {
+  async generateManifests(bmadDir, selectedModules, installedFiles = [], options = {}) {
     // Create _cfg directory if it doesn't exist
     const cfgDir = path.join(bmadDir, '_cfg');
     await fs.ensureDir(cfgDir);
@@ -31,6 +32,17 @@ class ManifestGenerator {
     this.modules = ['core', ...selectedModules];
     this.bmadDir = bmadDir;
     this.allInstalledFiles = installedFiles;
+
+    if (!Object.prototype.hasOwnProperty.call(options, 'ides')) {
+      throw new Error('ManifestGenerator requires `options.ides` to be provided – installer should supply the selected IDEs array.');
+    }
+
+    const resolvedIdes = options.ides ?? [];
+    if (!Array.isArray(resolvedIdes)) {
+      throw new TypeError('ManifestGenerator expected `options.ides` to be an array.');
+    }
+
+    this.selectedIdes = resolvedIdes;
 
     // Collect workflow data
     await this.collectWorkflows(selectedModules);
@@ -324,7 +336,7 @@ class ManifestGenerator {
         lastUpdated: new Date().toISOString(),
       },
       modules: this.modules,
-      ides: ['claude-code'],
+      ides: this.selectedIdes,
     };
 
     const yamlStr = yaml.dump(manifest, {

--- a/tools/cli/regenerate-manifests.js
+++ b/tools/cli/regenerate-manifests.js
@@ -13,7 +13,7 @@ async function regenerateManifests() {
   console.log('Target directory:', bmadDir);
 
   try {
-    const result = await generator.generateManifests(bmadDir, selectedModules);
+    const result = await generator.generateManifests(bmadDir, selectedModules, [], { ides: [] });
     console.log('✓ Manifests generated successfully:');
     console.log(`  - ${result.workflows} workflows`);
     console.log(`  - ${result.agents} agents`);


### PR DESCRIPTION
## Summary
- require manifest generation to receive the caller’s IDE list
- forward the installer’s selected IDEs when building manifests
- update the standalone manifest regeneration helper to pass an empty IDE list

## Testing
Run the installer. Select some IDEs, with and without Claude Code. Look at the generated manifest. See that the IDEs listed are every time what you chose. 
Also run the installer, select "No IDEs". And see that the installer works and the list of installed IDEs in the manifest is empty. 