### PR TITLE
fix(workflows): correct installed_path for implementation workflows

### DIFF
--- a/src/modules/bmm/workflows/4-implementation/create-story/workflow.yaml
+++ b/src/modules/bmm/workflows/4-implementation/create-story/workflow.yaml
@@ -10,7 +10,7 @@ communication_language: "{config_source}:communication_language"
 date: system-generated
 
 # Workflow components
-installed_path: "{project-root}/bmad/bmm/workflows/create-story"
+installed_path: "{project-root}/bmad/bmm/workflows/4-implementation/create-story"
 template: "{installed_path}/template.md"
 instructions: "{installed_path}/instructions.md"
 validation: "{installed_path}/checklist.md"

--- a/src/modules/bmm/workflows/4-implementation/dev-story/workflow.yaml
+++ b/src/modules/bmm/workflows/4-implementation/dev-story/workflow.yaml
@@ -10,7 +10,7 @@ communication_language: "{config_source}:communication_language"
 date: system-generated
 
 # Workflow components
-installed_path: "{project-root}/bmad/bmm/workflows/dev-story"
+installed_path: "{project-root}/bmad/bmm/workflows/4-implementation/dev-story"
 instructions: "{installed_path}/instructions.md"
 validation: "{installed_path}/checklist.md"
 

--- a/src/modules/bmm/workflows/4-implementation/review-story/workflow.yaml
+++ b/src/modules/bmm/workflows/4-implementation/review-story/workflow.yaml
@@ -11,7 +11,7 @@ communication_language: "{config_source}:communication_language"
 date: system-generated
 
 # Workflow components
-installed_path: "{project-root}/bmad/bmm/workflows/review-story"
+installed_path: "{project-root}/bmad/bmm/workflows/4-implementation/review-story"
 instructions: "{installed_path}/instructions.md"
 validation: "{installed_path}/checklist.md"
 

--- a/src/modules/bmm/workflows/4-implementation/story-context/workflow.yaml
+++ b/src/modules/bmm/workflows/4-implementation/story-context/workflow.yaml
@@ -11,7 +11,7 @@ communication_language: "{config_source}:communication_language"
 date: system-generated
 
 # Workflow components
-installed_path: "{project-root}/bmad/bmm/workflows/story-context"
+installed_path: "{project-root}/bmad/bmm/workflows/4-implementation/story-context"
 template: "{installed_path}/context-template.xml"
 instructions: "{installed_path}/instructions.md"
 validation: "{installed_path}/checklist.md"


### PR DESCRIPTION
## Summary
- Fixed `installed_path` in workflow configuration files to include correct subdirectory structure
- Updated 4 workflow files under `4-implementation/` to use proper paths including the category folder

## Test plan
- [x] Verify workflow paths resolve correctly when workflows are installed
- [x] Confirm create-story, dev-story, review-story, and story-context workflows work properly
- [x] Test that workflow template and instruction files are found at the correct paths

🤖 Generated with [Claude Code](https://claude.com/claude-code)