### PR TITLE
Fix principles serialization in YAML→XML builder

### DIFF
--- a/tools/cli/lib/agent-party-generator.js
+++ b/tools/cli/lib/agent-party-generator.js
@@ -50,7 +50,7 @@ const AgentPartyGenerator = {
       <role>${this.escapeXml(agent.role || '')}</role>
       <identity>${this.escapeXml(agent.identity || '')}</identity>
       <communication_style>${this.escapeXml(agent.communicationStyle || '')}</communication_style>
-      <principles>${agent.principles || ''}</principles>
+      <principles>${this.escapeXml(agent.principles || '')}</principles>
     </persona>
   </agent>\n`;
       }

--- a/tools/cli/lib/yaml-xml-builder.js
+++ b/tools/cli/lib/yaml-xml-builder.js
@@ -234,13 +234,31 @@ class YamlXmlBuilder {
     }
 
     if (persona.principles) {
-      // Principles can be array or string
-      let principlesText;
+      // Principles can be array, object, or string
+      let principlesText = '';
+
+      const stringifyEntry = (entry) => {
+        if (entry == null) return '';
+        if (typeof entry === 'string') return entry;
+        if (Array.isArray(entry)) return entry.map(stringifyEntry).filter(Boolean).join(' ');
+        if (typeof entry === 'object') {
+          const pairs = Object.entries(entry).map(([k, v]) => {
+            const vStr = Array.isArray(v) ? v.map(String).join(' ') : String(v ?? '');
+            return `${k}: ${vStr}`;
+          });
+          return pairs.join(' ');
+        }
+        return String(entry);
+      };
+
       if (Array.isArray(persona.principles)) {
-        principlesText = persona.principles.join(' ');
+        principlesText = persona.principles.map(stringifyEntry).filter(Boolean).join(' ');
+      } else if (typeof persona.principles === 'object') {
+        principlesText = stringifyEntry(persona.principles);
       } else {
-        principlesText = persona.principles;
+        principlesText = String(persona.principles);
       }
+
       xml += `    <principles>${this.escapeXml(principlesText)}</principles>\n`;
     }
 


### PR DESCRIPTION
Fix principles serialization in YAML→XML builder when list items are objects; 
escape principles in agent-party generator (#713)