### PR TITLE
fix: correct retrospective workflow handoff

### DIFF
--- a/src/modules/bmm/workflows/4-implementation/story-approved/instructions.md
+++ b/src/modules/bmm/workflows/4-implementation/story-approved/instructions.md
@@ -118,7 +118,7 @@ Congratulations! You have completed all stories for this project.
 
 **Next Steps:**
 
-1. Run `retrospective` workflow with PM agent to review the project
+1. Run `retrospective` workflow with SM agent to review the project
 2. Close out the project
 3. Celebrate! 🎊
    {{/if}}

--- a/src/modules/bmm/workflows/workflow-status/paths/brownfield-level-3.yaml
+++ b/src/modules/bmm/workflows/workflow-status/paths/brownfield-level-3.yaml
@@ -128,7 +128,7 @@ phases:
         command: "integration-test"
       - id: "retrospective"
         required: true
-        agent: "pm"
+        agent: "sm"
         command: "retrospective"
 
 story_naming: "story-<epic>.<story>.md"

--- a/src/modules/bmm/workflows/workflow-status/paths/brownfield-level-4.yaml
+++ b/src/modules/bmm/workflows/workflow-status/paths/brownfield-level-4.yaml
@@ -136,7 +136,7 @@ phases:
     epic_completion:
       - id: "retrospective"
         required: true
-        agent: "pm"
+        agent: "sm"
         command: "retrospective"
         note: "Critical for enterprise-scale learning"
 

--- a/src/modules/bmm/workflows/workflow-status/paths/game-design.yaml
+++ b/src/modules/bmm/workflows/workflow-status/paths/game-design.yaml
@@ -109,7 +109,7 @@ phases:
             command: "playtest"
           - id: "retrospective"
             optional: true
-            agent: "pm"
+            agent: "sm"
 
 story_naming:
   level_0_1: "story-<feature>.md"

--- a/src/modules/bmm/workflows/workflow-status/paths/greenfield-level-2.yaml
+++ b/src/modules/bmm/workflows/workflow-status/paths/greenfield-level-2.yaml
@@ -84,7 +84,7 @@ phases:
     epic_completion:
       - id: "retrospective"
         optional: true
-        agent: "pm"
+        agent: "sm"
         command: "retrospective"
         note: "After each epic completes"
 

--- a/src/modules/bmm/workflows/workflow-status/paths/greenfield-level-3.yaml
+++ b/src/modules/bmm/workflows/workflow-status/paths/greenfield-level-3.yaml
@@ -101,7 +101,7 @@ phases:
     epic_completion:
       - id: "retrospective"
         recommended: true
-        agent: "pm"
+        agent: "sm"
         command: "retrospective"
 
 story_naming: "story-<epic>.<story>.md"

--- a/src/modules/bmm/workflows/workflow-status/paths/greenfield-level-4.yaml
+++ b/src/modules/bmm/workflows/workflow-status/paths/greenfield-level-4.yaml
@@ -108,7 +108,7 @@ phases:
     epic_completion:
       - id: "retrospective"
         required: true
-        agent: "pm"
+        agent: "sm"
         command: "retrospective"
         note: "Critical for enterprise-scale learning"
 


### PR DESCRIPTION
## Summary
- align every workflow-status path so epic retrospectives hand off to the Scrum Master, matching documentation and actual SM ownership
- update the story-approved workflow's next-step guidance so completed epics are routed to the SM for retrospectives
- keeps workflow-status recommendations and exported prompts consistent with the process teams follow after an epic closes

## Testing
- manual: rebuilt BMAD agents and regenerated Codex prompts to verify the SM ownership propagates
