### PR TITLE
fix: read version from root package.json in installer

### DIFF
--- a/tools/installer/bin/bmad.js
+++ b/tools/installer/bin/bmad.js
@@ -15,7 +15,8 @@ let installer;
 let packageName;
 try {
   // Try installer context first (when run from tools/installer/)
-  version = require('../package.json').version;
+  // Always read version from root package.json to avoid hardcoded versions
+  version = require('../../../package.json').version;
   packageName = require('../package.json').name;
   installer = require('../lib/installer');
 } catch (error) {

--- a/tools/installer/package.json
+++ b/tools/installer/package.json
@@ -1,6 +1,6 @@
 {
   "name": "bmad-method",
-  "version": "4.43.0",
+  "version": "4.44.2",
   "description": "BMad Method installer - AI-powered Agile development framework",
   "keywords": [
     "bmad",


### PR DESCRIPTION
## Summary
- Fixed hardcoded version in installer that was showing 4.43.0 instead of 4.44.2
- Updated `tools/installer/bin/bmad.js` to always read version from root `package.json`
- Synced `tools/installer/package.json` to match root version (4.44.2)

## Problem
When running `npx bmad-method@latest install`, the installer was displaying version 4.43.0 even though 4.44.2 was published. This was due to:
1. `tools/installer/bin/bmad.js` reading from `tools/installer/package.json` 
2. `tools/installer/package.json` having a hardcoded version (4.43.0)

## Solution
Updated the version loading logic to always read from the root `package.json`, ensuring the displayed version matches the published version.

## Test plan
- [x] Tested `node tools/installer/bin/bmad.js --version` - now shows 4.44.2
- [x] Code reads from root package.json correctly
- [x] Lint checks pass

## Related to
- Similar fix was also made in v6 branch for `manifest-generator.js`