### PR TITLE
Fix: Add prompts and memories merging from customize.yaml

### DIFF
--- a/tools/cli/lib/yaml-xml-builder.js
+++ b/tools/cli/lib/yaml-xml-builder.js
@@ -119,6 +119,16 @@ class YamlXmlBuilder {
         if (customizeYaml.critical_actions) {
           merged.agent.critical_actions = [...(merged.agent.critical_actions || []), ...customizeYaml.critical_actions];
         }
+
+        // Append prompts
+        if (customizeYaml.prompts) {
+          merged.agent.prompts = [...(merged.agent.prompts || []), ...customizeYaml.prompts];
+        }
+
+        // Append memories
+        if (customizeYaml.memories) {
+          merged.agent.memories = [...(merged.agent.memories || []), ...customizeYaml.memories];
+        }
       }
     }
 
@@ -202,6 +212,11 @@ class YamlXmlBuilder {
     // Persona section
     xml += this.buildPersonaXml(agent.persona);
 
+    // Memories section (if exists)
+    if (agent.memories) {
+      xml += this.buildMemoriesXml(agent.memories);
+    }
+
     // Prompts section (if exists)
     if (agent.prompts) {
       xml += this.buildPromptsXml(agent.prompts);
@@ -269,6 +284,23 @@ class YamlXmlBuilder {
   }
 
   /**
+   * Build memories XML section
+   */
+  buildMemoriesXml(memories) {
+    if (!memories || memories.length === 0) return '';
+
+    let xml = '  <memories>\n';
+
+    for (const memory of memories) {
+      xml += `    <memory>${this.escapeXml(memory)}</memory>\n`;
+    }
+
+    xml += '  </memories>\n';
+
+    return xml;
+  }
+
+  /**
    * Build prompts XML section
    */
   buildPromptsXml(prompts) {
@@ -278,9 +310,9 @@ class YamlXmlBuilder {
 
     for (const prompt of prompts) {
       xml += `    <prompt id="${prompt.id || ''}">\n`;
-      xml += `      <![CDATA[\n`;
-      xml += `      ${prompt.content || ''}\n`;
-      xml += `      ]]>\n`;
+      xml += `      <content>\n`;
+      xml += `${this.escapeXml(prompt.content || '')}\n`;
+      xml += `      </content>\n`;
       xml += `    </prompt>\n`;
     }
 


### PR DESCRIPTION
- Add merging logic for customizeYaml.prompts and customizeYaml.memories in loadAndMergeAgent()
- Implement buildMemoriesXml() method to output memories XML section
- Update buildPromptsXml() to use <content> wrapper instead of CDATA for better compatibility
- Integrate memories output into convertToXml() between persona and prompts sections

Changes:
1. Line 123-131: Added prompts and memories append logic in loadAndMergeAgent()
2. Line 215-218: Added memories XML output in convertToXml()
3. Line 286-301: New buildMemoriesXml() method
4. Line 312-315: Updated prompts to use <content> wrapper for consistency

This allows users to customize agents via bmad/_cfg/agents/*.customize.yaml with:
- prompts: Array of {id, content} objects for action handlers
- memories: Array of strings for persistent agent memories