### PR TITLE
 use INIT_CWD as default dir cause it's current working dir

### DIFF
--- a/tools/bmad-npx-wrapper.js
+++ b/tools/bmad-npx-wrapper.js
@@ -27,7 +27,7 @@ if (isNpxExecution) {
     // Execute CLI from user's working directory (process.cwd()), not npm cache
     execSync(`node "${bmadCliPath}" ${args.join(' ')}`, {
       stdio: 'inherit',
-      cwd: process.cwd(), // This preserves the user's working directory
+      cwd: process.env.INIT_CWD || process.cwd(), // This preserves the user's working directory
     });
   } catch (error) {
     process.exit(error.status || 1);

--- a/tools/cli/bundlers/bundle-web.js
+++ b/tools/cli/bundlers/bundle-web.js
@@ -27,7 +27,7 @@ program
   .action(async (options) => {
     try {
       // Clean output directory first
-      const outputDir = path.isAbsolute(options.output) ? options.output : path.join(process.cwd(), options.output);
+      const outputDir = path.isAbsolute(options.output) ? options.output : path.join(process.env.INIT_CWD || process.cwd(), options.output);
 
       if (await fs.pathExists(outputDir)) {
         console.log(chalk.cyan(`🧹 Cleaning ${options.output}...`));
@@ -156,7 +156,7 @@ program
   .action(async () => {
     try {
       const fs = require('fs-extra');
-      const outputDir = path.join(process.cwd(), 'web-bundles');
+      const outputDir = path.join(process.env.INIT_CWD || process.cwd(), 'web-bundles');
 
       if (await fs.pathExists(outputDir)) {
         await fs.remove(outputDir);

--- a/tools/cli/bundlers/web-bundler.js
+++ b/tools/cli/bundlers/web-bundler.js
@@ -28,7 +28,7 @@ class WebBundler {
     this.discoveredTeams = [];
 
     // Temporary directory for generated manifests
-    this.tempDir = path.join(process.cwd(), '.bundler-temp');
+    this.tempDir = path.join(process.env.INIT_CWD || process.cwd(), '.bundler-temp');
     this.tempManifestDir = path.join(this.tempDir, 'bmad', '_cfg');
 
     // Bundle statistics

--- a/tools/cli/lib/ui.js
+++ b/tools/cli/lib/ui.js
@@ -127,7 +127,7 @@ class UI {
     // Check for existing configured IDEs
     const { Detector } = require('../installers/lib/core/detector');
     const detector = new Detector();
-    const bmadDir = path.join(projectDir || process.cwd(), 'bmad');
+    const bmadDir = path.join(projectDir || process.env.INIT_CWD || process.cwd(), 'bmad');
     const existingInstall = await detector.detect(bmadDir);
     const configuredIdes = existingInstall.ides || [];
 
@@ -404,12 +404,12 @@ class UI {
         type: 'input',
         name: 'directory',
         message: `Installation directory:`,
-        default: process.cwd(),
+        default: process.env.INIT_CWD || process.cwd(),
         validate: async (input) => this.validateDirectory(input),
         filter: (input) => {
           // If empty, use the default
           if (!input || input.trim() === '') {
-            return process.cwd();
+            return process.env.INIT_CWD || process.cwd();
           }
           return this.expandUserPath(input);
         },

--- a/tools/cli/regenerate-manifests.js
+++ b/tools/cli/regenerate-manifests.js
@@ -4,7 +4,7 @@ const { ManifestGenerator } = require('./installers/lib/core/manifest-generator'
 async function regenerateManifests() {
   const generator = new ManifestGenerator();
   const targetDir = process.argv[2] || 'z1';
-  const bmadDir = path.join(process.cwd(), targetDir, 'bmad');
+  const bmadDir = path.join(process.env.INIT_CWD || process.cwd(), targetDir, 'bmad');
 
   // List of modules to include in manifests
   const selectedModules = ['bmb', 'bmm', 'cis'];

--- a/tools/flattener/main.js
+++ b/tools/flattener/main.js
@@ -70,7 +70,7 @@ program
   .name('bmad-flatten')
   .description('BMad-Method codebase flattener tool')
   .version('1.0.0')
-  .option('-i, --input <path>', 'Input directory to flatten', process.cwd())
+  .option('-i, --input <path>', 'Input directory to flatten', process.env.INIT_CWD || process.cwd())
   .option('-o, --output <path>', 'Output file path', 'flattened-codebase.xml')
   .action(async (options) => {
     let inputDir = path.resolve(options.input);
@@ -83,7 +83,7 @@ program
     const noPathArguments = !userSpecifiedInput && !userSpecifiedOutput;
 
     if (noPathArguments) {
-      const detectedRoot = await findProjectRoot(process.cwd());
+      const detectedRoot = await findProjectRoot(process.env.INIT_CWD || process.cwd());
       const suggestedOutput = detectedRoot ? path.join(detectedRoot, 'flattened-codebase.xml') : path.resolve('flattened-codebase.xml');
 
       if (detectedRoot) {
@@ -95,12 +95,12 @@ program
           inputDir = detectedRoot;
           outputPath = suggestedOutput;
         } else {
-          inputDir = await promptPath('Enter input directory path', process.cwd());
+          inputDir = await promptPath('Enter input directory path', process.env.INIT_CWD || process.cwd());
           outputPath = await promptPath('Enter output file path', path.join(inputDir, 'flattened-codebase.xml'));
         }
       } else {
         console.log('Could not auto-detect a project root.');
-        inputDir = await promptPath('Enter input directory path', process.cwd());
+        inputDir = await promptPath('Enter input directory path', process.env.INIT_CWD || process.cwd());
         outputPath = await promptPath('Enter output file path', path.join(inputDir, 'flattened-codebase.xml'));
       }
     }


### PR DESCRIPTION
as for now, npm run install:bmad --prefix git-repo-dir doesn't take current working dir as default input(it always take the git repo dir as default dir), the patch add use INIT_CWD, so it will fill with current working dir, you don't need copy path now