### PR TITLE
chore: fix bundle urls

### DIFF
--- a/.github/workflows/bundle-latest.yaml
+++ b/.github/workflows/bundle-latest.yaml
@@ -33,10 +33,8 @@ jobs:
         run: |
           mkdir -p dist/bundles
 
-          # Copy bundles with clean structure
-          cp -r src/modules/bmm/sub-modules/* dist/bundles/ 2>/dev/null || true
-          cp -r src/modules/bmb/sub-modules/* dist/bundles/ 2>/dev/null || true
-          cp -r src/modules/cis/sub-modules/* dist/bundles/ 2>/dev/null || true
+          # Copy web bundles (XML files from npm run bundle output)
+          cp -r web-bundles/* dist/bundles/ 2>/dev/null || true
 
           # Verify bundles were copied (fail if completely empty)
           if [ ! "$(ls -A dist/bundles)" ]; then
@@ -45,11 +43,11 @@ jobs:
             exit 1
           fi
 
-          # Count bundles per platform
-          for platform in claude-code chatgpt gemini; do
-            if [ -d "dist/bundles/$platform" ]; then
-              COUNT=$(find dist/bundles/$platform -name '*.md' 2>/dev/null | wc -l)
-              echo "✅ $platform: $COUNT bundles"
+          # Count bundles per module
+          for module in bmm bmb cis bmgd; do
+            if [ -d "dist/bundles/$module/agents" ]; then
+              COUNT=$(find dist/bundles/$module/agents -name '*.xml' 2>/dev/null | wc -l)
+              echo "✅ $module: $COUNT agent bundles"
             fi
           done
 
@@ -83,49 +81,41 @@ jobs:
             <p><strong>Last Updated:</strong> <code>$TIMESTAMP</code></p>
             <p><strong>Commit:</strong> <code>$COMMIT_SHA</code></p>
 
-            <h2>Available Platforms</h2>
+            <h2>Available Modules</h2>
 
             <div class="platform">
-              <h3>Claude Code</h3>
+              <h3>BMM (BMad Method)</h3>
               <div class="module">
-                <strong>BMM (BMad Method)</strong><br>
-                <a href="./claude-code/sub-agents/bmm-agent-pm.md">PM Agent</a> |
-                <a href="./claude-code/sub-agents/bmm-agent-architect.md">Architect</a> |
-                <a href="./claude-code/sub-agents/bmm-agent-tea.md">TEA</a> |
-                <a href="./claude-code/sub-agents/bmm-agent-dev.md">Developer</a> |
-                <a href="./claude-code/sub-agents/">All BMM Agents</a>
-              </div>
-              <div class="module">
-                <strong>BMB (BMad Builder)</strong><br>
-                <a href="./claude-code/sub-agents/bmb-agent-builder.md">Builder Agent</a>
-              </div>
-              <div class="module">
-                <strong>CIS (Creative Intelligence Suite)</strong><br>
-                <a href="./claude-code/sub-agents/">CIS Agents</a>
+                <a href="./bmm/agents/pm.xml">PM</a> |
+                <a href="./bmm/agents/architect.xml">Architect</a> |
+                <a href="./bmm/agents/tea.xml">TEA</a> |
+                <a href="./bmm/agents/dev.xml">Developer</a> |
+                <a href="./bmm/agents/analyst.xml">Analyst</a> |
+                <a href="./bmm/agents/sm.xml">Scrum Master</a> |
+                <a href="./bmm/agents/ux-designer.xml">UX Designer</a> |
+                <a href="./bmm/agents/tech-writer.xml">Tech Writer</a> |
+                <a href="./bmm/agents/">All BMM Agents</a>
               </div>
             </div>
 
             <div class="platform">
-              <h3>ChatGPT</h3>
+              <h3>BMB (BMad Builder)</h3>
               <div class="module">
-                <strong>BMM</strong>: <a href="./chatgpt/sub-agents/">Browse BMM Agents</a><br>
-                <strong>BMB</strong>: <a href="./chatgpt/sub-agents/">Browse BMB Agents</a><br>
-                <strong>CIS</strong>: <a href="./chatgpt/sub-agents/">Browse CIS Agents</a>
+                <a href="./bmb/agents/bmad-builder.xml">Builder Agent</a> |
+                <a href="./bmb/agents/">All BMB Agents</a>
               </div>
             </div>
 
             <div class="platform">
-              <h3>Gemini</h3>
+              <h3>CIS (Creative Intelligence Suite)</h3>
               <div class="module">
-                <strong>BMM</strong>: <a href="./gemini/sub-agents/">Browse BMM Agents</a><br>
-                <strong>BMB</strong>: <a href="./gemini/sub-agents/">Browse BMB Agents</a><br>
-                <strong>CIS</strong>: <a href="./gemini/sub-agents/">Browse CIS Agents</a>
+                <a href="./cis/agents/">Browse CIS Agents</a>
               </div>
             </div>
 
             <h2>Usage</h2>
-            <p>Copy the raw markdown URL and paste into your AI platform's custom instructions or project knowledge.</p>
-            <p>Example: <code>https://raw.githubusercontent.com/bmad-code-org/bmad-bundles/main/claude-code/sub-agents/bmm-agent-pm.md</code></p>
+            <p>Copy the raw XML URL and paste into your AI platform's custom instructions or project knowledge.</p>
+            <p>Example: <code>https://raw.githubusercontent.com/bmad-code-org/bmad-bundles/main/bmm/agents/pm.xml</code></p>
 
             <h2>Installation (Recommended)</h2>
             <p>For full IDE integration with slash commands, use the installer:</p>

--- a/.github/workflows/manual-release.yaml
+++ b/.github/workflows/manual-release.yaml
@@ -68,45 +68,27 @@ jobs:
         run: |
           mkdir -p dist/release-bundles
 
-          # Create staging directory for each platform
-          mkdir -p dist/staging/{claude-code,chatgpt,gemini}
+          # Copy web bundles
+          cp -r web-bundles dist/release-bundles/bmad-bundles-v${{ steps.version.outputs.new_version }}
 
-          # Collect all modules per platform
-          cp -r src/modules/bmm/sub-modules/claude-code/* dist/staging/claude-code/ 2>/dev/null || true
-          cp -r src/modules/bmb/sub-modules/claude-code/* dist/staging/claude-code/ 2>/dev/null || true
-          cp -r src/modules/cis/sub-modules/claude-code/* dist/staging/claude-code/ 2>/dev/null || true
+          # Verify bundles exist
+          if [ ! "$(ls -A dist/release-bundles/bmad-bundles-v${{ steps.version.outputs.new_version }})" ]; then
+            echo "❌ ERROR: No bundles found"
+            echo "This likely means 'npm run bundle' failed"
+            exit 1
+          fi
 
-          cp -r src/modules/bmm/sub-modules/chatgpt/* dist/staging/chatgpt/ 2>/dev/null || true
-          cp -r src/modules/bmb/sub-modules/chatgpt/* dist/staging/chatgpt/ 2>/dev/null || true
-          cp -r src/modules/cis/sub-modules/chatgpt/* dist/staging/chatgpt/ 2>/dev/null || true
-
-          cp -r src/modules/bmm/sub-modules/gemini/* dist/staging/gemini/ 2>/dev/null || true
-          cp -r src/modules/bmb/sub-modules/gemini/* dist/staging/gemini/ 2>/dev/null || true
-          cp -r src/modules/cis/sub-modules/gemini/* dist/staging/gemini/ 2>/dev/null || true
-
-          # Verify bundles were copied (fail if completely empty)
-          for platform in claude-code chatgpt gemini; do
-            if [ ! "$(ls -A dist/staging/$platform)" ]; then
-              echo "❌ ERROR: No bundles found for $platform"
-              echo "This likely means 'npm run bundle' failed or bundles weren't generated"
-              exit 1
+          # Count and display bundles per module
+          for module in bmm bmb cis bmgd; do
+            if [ -d "dist/release-bundles/bmad-bundles-v${{ steps.version.outputs.new_version }}/$module/agents" ]; then
+              COUNT=$(find dist/release-bundles/bmad-bundles-v${{ steps.version.outputs.new_version }}/$module/agents -name '*.xml' 2>/dev/null | wc -l)
+              echo "✅ $module: $COUNT agents"
             fi
-            echo "✅ $platform: $(find dist/staging/$platform -name '*.md' | wc -l) bundles"
           done
 
-          # Create platform-specific archives
-          tar -czf dist/release-bundles/bmad-bundles-claude-code-v${{ steps.version.outputs.new_version }}.tar.gz \
-            -C dist/staging/claude-code .
-
-          tar -czf dist/release-bundles/bmad-bundles-chatgpt-v${{ steps.version.outputs.new_version }}.tar.gz \
-            -C dist/staging/chatgpt .
-
-          tar -czf dist/release-bundles/bmad-bundles-gemini-v${{ steps.version.outputs.new_version }}.tar.gz \
-            -C dist/staging/gemini .
-
-          # Create all-platforms archive
-          tar -czf dist/release-bundles/bmad-bundles-all-v${{ steps.version.outputs.new_version }}.tar.gz \
-            -C dist/staging .
+          # Create archive
+          tar -czf dist/release-bundles/bmad-bundles-v${{ steps.version.outputs.new_version }}.tar.gz \
+            -C dist/release-bundles/bmad-bundles-v${{ steps.version.outputs.new_version }} .
 
       - name: Commit version bump
         run: |
@@ -205,14 +187,11 @@ jobs:
 
             ## 📦 Web Bundles
 
-            Download platform-specific bundles for use in AI platforms:
+            Download XML bundles for use in AI platforms (Claude Projects, ChatGPT, Gemini):
 
-            - `bmad-bundles-claude-code-v${{ steps.version.outputs.new_version }}.tar.gz` - Claude Code / Claude Projects
-            - `bmad-bundles-chatgpt-v${{ steps.version.outputs.new_version }}.tar.gz` - ChatGPT Custom Instructions
-            - `bmad-bundles-gemini-v${{ steps.version.outputs.new_version }}.tar.gz` - Gemini Gems
-            - `bmad-bundles-all-v${{ steps.version.outputs.new_version }}.tar.gz` - All platforms
+            - `bmad-bundles-v${{ steps.version.outputs.new_version }}.tar.gz` - All modules (BMM, BMB, CIS, BMGD)
 
-            **Latest bundles** (bleeding edge): https://bmad-code-org.github.io/bmad-bundles/
+            **Browse online** (bleeding edge): https://bmad-code-org.github.io/bmad-bundles/
           draft: false
           prerelease: ${{ contains(steps.version.outputs.new_version, 'alpha') || contains(steps.version.outputs.new_version, 'beta') }}
           files: |

--- a/docs/USING_WEB_BUNDLES.md
+++ b/docs/USING_WEB_BUNDLES.md
@@ -11,10 +11,10 @@
 - **Stable:** `https://github.com/bmad-code-org/BMAD-METHOD/releases/latest`
 - **Latest:** `https://bmad-code-org.github.io/bmad-bundles/`
 
-**2. Copy raw markdown URL:**
+**2. Copy raw XML URL:**
 
 ```
-https://raw.githubusercontent.com/bmad-code-org/bmad-bundles/main/claude-code/sub-agents/bmm-agent-pm.md
+https://raw.githubusercontent.com/bmad-code-org/bmad-bundles/main/bmm/agents/pm.xml
 ```
 
 **3. Add to AI platform:**
@@ -25,17 +25,17 @@ https://raw.githubusercontent.com/bmad-code-org/bmad-bundles/main/claude-code/su
 
 ---
 
-## Available Agents
+## Available Modules
 
-### Claude Code
+### BMM (BMad Method)
 
-- [PM](https://raw.githubusercontent.com/bmad-code-org/bmad-bundles/main/claude-code/sub-agents/bmm-agent-pm.md) | [Architect](https://raw.githubusercontent.com/bmad-code-org/bmad-bundles/main/claude-code/sub-agents/bmm-agent-architect.md) | [TEA](https://raw.githubusercontent.com/bmad-code-org/bmad-bundles/main/claude-code/sub-agents/bmm-agent-tea.md) | [Developer](https://raw.githubusercontent.com/bmad-code-org/bmad-bundles/main/claude-code/sub-agents/bmm-agent-dev.md)
-- [All Agents](https://github.com/bmad-code-org/bmad-bundles/tree/main/claude-code/sub-agents)
+- [PM](https://raw.githubusercontent.com/bmad-code-org/bmad-bundles/main/bmm/agents/pm.xml) | [Architect](https://raw.githubusercontent.com/bmad-code-org/bmad-bundles/main/bmm/agents/architect.xml) | [TEA](https://raw.githubusercontent.com/bmad-code-org/bmad-bundles/main/bmm/agents/tea.xml) | [Developer](https://raw.githubusercontent.com/bmad-code-org/bmad-bundles/main/bmm/agents/dev.xml)
+- [All BMM Agents](https://github.com/bmad-code-org/bmad-bundles/tree/main/bmm/agents)
 
-### ChatGPT / Gemini
+### BMB / CIS
 
-- [Browse ChatGPT](https://github.com/bmad-code-org/bmad-bundles/tree/main/chatgpt/sub-agents)
-- [Browse Gemini](https://github.com/bmad-code-org/bmad-bundles/tree/main/gemini/sub-agents)
+- [BMB Builder](https://raw.githubusercontent.com/bmad-code-org/bmad-bundles/main/bmb/agents/bmad-builder.xml)
+- [Browse CIS Agents](https://github.com/bmad-code-org/bmad-bundles/tree/main/cis/agents)
 
 ---
 
@@ -75,13 +75,13 @@ Gives you:
 ## Troubleshooting
 
 **ChatGPT: "File too large"**
-→ Use stable release (compressed) or report issue
+→ Some agents (PM: 166KB, Analyst: 211KB) exceed ChatGPT limits. Use smaller agents or report issue.
 
 **Bundle not loading**
-→ Use raw URL (not GitHub UI link)
+→ Use raw URL (not GitHub UI link). URL should end in `.xml`.
 
 **Out of date**
-→ Wait 2-3 min after main merge, then refresh
+→ Wait 2-3 min after main merge, then refresh.
 
 ---
 


### PR DESCRIPTION
Fix bundle paths: Use web-bundles/ output (not sub-modules/)

  Bug: Workflows copied from gitignored sub-modules/ directory. Bundles were empty.

  Fix:
  - Copy from web-bundles/{module}/agents/*.xml (actual npm run bundle output)
  - Updated docs to reflect XML structure: bmm/agents/pm.xml
  - Simplified release to single archive (all modules)

