### PR TITLE
feat: default installer username to system user

### DIFF
--- a/tools/cli/installers/lib/core/config-collector.js
+++ b/tools/cli/installers/lib/core/config-collector.js
@@ -360,6 +360,25 @@ class ConfigCollector {
   }
 
   /**
+   * Get the default username from the system
+   * @returns {string} Capitalized username\
+   */
+  getDefaultUsername() {
+    let result = 'BMad';
+    try {
+      const os = require('node:os');
+      const userInfo = os.userInfo();
+      if (userInfo && userInfo.username) {
+        const username = userInfo.username;
+        result = username.charAt(0).toUpperCase() + username.slice(1);
+      }
+    } catch {
+      // Do nothing, just return 'BMad'
+    }
+    return result;
+  }
+
+  /**
    * Collect configuration for a single module
    * @param {string} moduleName - Module name
    * @param {string} projectDir - Target project directory
@@ -602,6 +621,11 @@ class ConfigCollector {
       if (detectedFolder) {
         existingValue = detectedFolder;
       }
+    }
+
+    // Special handling for user_name: default to system user
+    if (moduleName === 'core' && key === 'user_name' && !existingValue) {
+      item.default = this.getDefaultUsername();
     }
 
     // Determine question type and default value


### PR DESCRIPTION
This PR improves the installer's user experience by automatically detecting the system username to populate the default user_name configuration value.

Changes:

Modified ConfigCollector in tools/cli/installers/lib/core/config-collector.js

Added getDefaultUsername() method to retrieve the system username using os.userInfo().
Logic capitalizes the first letter of the detected username (e.g., "alex" -> "Alex").
Explicitly falls back to "BMad" if the system username cannot be determined.
Impact: Users will now see their actual name as the default option during installation, making the setup process feel more personalized and requiring one less manual edit for most users.