### PR TITLE
fix: remove .agent from gitignore for Antigravity workflow access

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -67,5 +67,4 @@ z*/
 
 .bmad
 .claude
-.agent
 .codex


### PR DESCRIPTION
Antigravity respects .gitignore rules which blocks access to workflow files in .agent/workflows/, preventing custom workflows from being discovered. Removing .agent from gitignore to allow Antigravity to scan workflow files.

Note: Codex and Claude Code ignore .gitignore when scanning for custom prompts, so this only affects Antigravity users.

When I was testing it yesterday, I must have forgotten to restart Antigravity after adding .agent to .,gitignore

The workaround appears to be putting .agent into .git/info/exclude

I have written a nastygramm to Google about this :)