### PR TITLE
fix: correct sprint artifacts directory path in tech-spec workflow

### DIFF
--- a/src/modules/bmm/workflows/2-plan-workflows/tech-spec/workflow.yaml
+++ b/src/modules/bmm/workflows/2-plan-workflows/tech-spec/workflow.yaml
@@ -34,7 +34,7 @@ epics_template: "{installed_path}/epics-template.md"
 # Output configuration
 default_output_file: "{output_folder}/tech-spec.md"
 epics_file: "{output_folder}/epics.md"
-sprint_artifacts: "{output_folder}/sprint_artifacts"
+sprint_artifacts: "{config_source}:sprint_artifacts"
 
 # Smart input file references - handles both whole docs and sharded docs
 # Priority: Whole document first, then sharded version


### PR DESCRIPTION
## Summary
This PR fixes a hardcoded path in the tech-spec workflow that was creating docs/sprint_artifacts directory instead of putting the artifacts where prescribed by the .bmad/bmm/config.yaml

## Changes
- Updated [src/modules/bmm/workflows/2-plan-workflows/tech-spec/workflow.yaml](cci:7://file:///Users/alex/src/bmad/src/modules/bmm/workflows/2-plan-workflows/tech-spec/workflow.yaml:0:0-0:0) to use `{config_source}:sprint_artifacts` instead of hardcoded `{output_folder}/sprint_artifacts`

## Testing
Ran the tech-spec workflow, verified that it now correctly references the configuration value instead of using a hardcoded path.