### PR TITLE
docs: playwright untils note in test-architecture.md

### DIFF
--- a/src/modules/bmm/docs/test-architecture.md
+++ b/src/modules/bmm/docs/test-architecture.md
@@ -402,6 +402,50 @@ MCP provides additional capabilities on top of TEA's default AI-based approach:
 
 </details>
 
+<details>
+<summary><strong>Optional Playwright Utils Integration</strong></summary>
+
+**Open-source Playwright utilities** from SEON Technologies (production-tested, npm published):
+
+- **Package**: `@seontechnologies/playwright-utils` ([npm](https://www.npmjs.com/package/@seontechnologies/playwright-utils) | [GitHub](https://github.com/seontechnologies/playwright-utils))
+- **Install**: `npm install -D @seontechnologies/playwright-utils`
+
+**How Playwright Utils Enhances TEA Workflows**:
+
+Provides fixture-based utilities that integrate into TEA's test generation and review workflows:
+
+1. `*framework`:
+   - Default: Basic Playwright scaffold
+   - **+ playwright-utils**: Scaffold with api-request, network-recorder, auth-session, burn-in, network-error-monitor fixtures pre-configured
+
+   Benefit: Production-ready patterns from day one
+
+2. `*automate`, `*atdd`:
+   - Default: Standard test patterns
+   - **+ playwright-utils**: Tests using api-request (schema validation), intercept-network-call (mocking), recurse (polling), log (structured logging), file-utils (CSV/PDF)
+
+   Benefit: Advanced patterns without boilerplate
+
+3. `*test-review`:
+   - Default: Reviews against core knowledge base (21 fragments)
+   - **+ playwright-utils**: Reviews against expanded knowledge base (32 fragments: 21 core + 11 playwright-utils)
+
+   Benefit: Reviews include fixture composition, auth patterns, network recording best practices
+
+4. `*ci`:
+   - Default: Standard CI workflow
+   - **+ playwright-utils**: CI workflow with burn-in script (smart test selection) and network-error-monitor integration
+
+   Benefit: Faster CI feedback, HTTP error detection
+
+**Utilities available** (11 total): api-request, network-recorder, auth-session, intercept-network-call, recurse, log, file-utils, burn-in, network-error-monitor, fixtures-composition
+
+**Enable during BMAD installation** by answering "Yes" when prompted, or manually set `tea_use_playwright_utils: true` in `{bmad_folder}/bmm/config.yaml`.
+
+**To disable**: Set `tea_use_playwright_utils: false` in `{bmad_folder}/bmm/config.yaml`.
+
+</details>
+
 <br></br>
 
 | Command        | Workflow README                                   | Primary Outputs                                                                               | Notes                                                | With Playwright MCP Enhancements                                                                             |


### PR DESCRIPTION
Added a short documentation section about `playwright-utils`, similar to the one about playwright mcps.