### PR TITLE
fix: give kilocode tool access to bmad modes

### DIFF
--- a/tools/cli/installers/lib/ide/kilo.js
+++ b/tools/cli/installers/lib/ide/kilo.js
@@ -123,6 +123,9 @@ class KiloSetup extends BaseIdeSetup {
     modeEntry += `   groups:\n`;
     modeEntry += `    - read\n`;
     modeEntry += `    - edit\n`;
+    modeEntry += `    - browser\n`;
+    modeEntry += `    - command\n`;
+    modeEntry += `    - mcp\n`;
 
     return modeEntry;
   }


### PR DESCRIPTION
Modes inside Kilo Code is too restricted when creating .kilocodemodes. `read` and `edit` alone is not sufficient. This PR should allow all modes to use `browser`, run `command` and have access to `mcp`