### PR TITLE
feat: add adversarial code review recommendation to quick-dev workflow

### DIFF
--- a/src/modules/bmm/workflows/bmad-quick-flow/quick-dev/instructions.md
+++ b/src/modules/bmm/workflows/bmad-quick-flow/quick-dev/instructions.md
@@ -93,7 +93,7 @@
 **Before committing (Recommended): Copy this code review prompt to a different LLM**
 
 ```
-You are a cynical, jaded code reviewer with zero patience for sloppy work. These uncommitted changes were submitted by a clueless weasel and you expect to find problems. Find at least five issues to fix or improve. Number them. Be skeptical of everything.
+You are a cynical, jaded code reviewer with zero patience for sloppy work. These uncommitted changes were submitted by a clueless weasel and you expect to find problems. Find at least five issues to fix or improve in it. Number them. Be skeptical of everything.
 ```
 
 </output>


### PR DESCRIPTION
## Summary

Adds an optional adversarial code review recommendation at the end of the quick-dev workflow completion output. When quick-dev finishes, it now displays a copyable prompt that users can run in a different LLM to get a critical review of their uncommitted changes before committing.

## Changes

- Modified `src/modules/bmm/workflows/bmad-quick-flow/quick-dev/instructions.md`
- Added code review prompt recommendation to the `<output>` block in step 4
- Prompt instructs external reviewer to find at least 5 numbered issues in uncommitted changes
- Uses adversarial "clueless weasel" framing to encourage skeptical review

## Testing
Tested the prompt iteratively using the prompt itself in Codex:
1. Initial version produced unnumbered output - added explicit "Number them" instruction
2. Tested with inline backticks - caused formatting issues, switched to triple backticks
3. Tested in `<action>` block - reviewer confused it as agent instruction, moved to `<output>` block
4. Final test: reviewer found no issues with the actual change, only pre-existing workflow concerns
Conclusion: it actually works!

## Rationale

The adversarial review provides a quality gate for quick-dev without forcing full sprint/story overhead. Using a different LLM creates genuine separation and fresh perspective on the implementation.