### PR TITLE
chore: fix Creative Intelligence Suite link in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -124,7 +124,7 @@ Each agent brings deep expertise and can be customized to match your team's styl
 - **Creative Intelligence Suite (CIS)** - Innovation & problem-solving
   - Brainstorming, design thinking, storytelling
   - 5 creative facilitation workflows
-  - [→ Creative Workflows](./src/modules/cis/README.md)
+  - [→ Creative Workflows](./src/modules/cis/readme.md)
 
 ### Key Features
 


### PR DESCRIPTION
## What

Fixed broken link to CIS documentation that was pointing to uppercase README.md. Now correctly points to lowercase readme.md file.

## Why

Was broken. 

## How

- Claude Code ty

## Testing

N/A


🤖 Generated with [Claude Code](https://claude.com/claude-code)