### PR TITLE
fix(bmm): correct code-review workflow status logic and checklist

### DIFF
--- a/src/modules/bmm/workflows/4-implementation/code-review/checklist.md
+++ b/src/modules/bmm/workflows/4-implementation/code-review/checklist.md
@@ -1,7 +1,7 @@
 # Senior Developer Review - Validation Checklist
 
 - [ ] Story file loaded from `{{story_path}}`
-- [ ] Story Status verified as one of: {{allow_status_values}}
+- [ ] Story Status verified as reviewable (review)
 - [ ] Epic and Story IDs resolved ({{epic_num}}.{{story_num}})
 - [ ] Story Context located or warning recorded
 - [ ] Epic Tech Spec located or warning recorded
@@ -17,6 +17,7 @@
 - [ ] Review notes appended under "Senior Developer Review (AI)"
 - [ ] Change Log updated with review entry
 - [ ] Status updated according to settings (if enabled)
+- [ ] Sprint status synced (if sprint tracking enabled)
 - [ ] Story saved successfully
 
 _Reviewer: {{user_name}} on {{date}}_

--- a/src/modules/bmm/workflows/4-implementation/code-review/instructions.xml
+++ b/src/modules/bmm/workflows/4-implementation/code-review/instructions.xml
@@ -16,6 +16,7 @@
   <step n="1" goal="Load story and discover changes">
     <action>Use provided {{story_path}} or ask user which story file to review</action>
     <action>Read COMPLETE story file</action>
+    <action>Set {{story_key}} = extracted key from filename (e.g., "1-2-user-authentication.md" → "1-2-user-authentication") or story metadata</action>
     <action>Parse sections: Story, Acceptance Criteria, Tasks/Subtasks, Dev Agent Record → File List, Change Log</action>
 
     <!-- Discover actual changes via git -->
@@ -106,6 +107,8 @@
 
   <step n="4" goal="Present findings and fix them">
     <action>Categorize findings: HIGH (must fix), MEDIUM (should fix), LOW (nice to fix)</action>
+    <action>Set {{fixed_count}} = 0</action>
+    <action>Set {{action_count}} = 0</action>
 
     <output>**🔥 CODE REVIEW FINDINGS, {user_name}!**
 
@@ -145,11 +148,15 @@
       <action>Add/update tests as needed</action>
       <action>Update File List in story if files changed</action>
       <action>Update story Dev Agent Record with fixes applied</action>
+      <action>Set {{fixed_count}} = number of HIGH and MEDIUM issues fixed</action>
+      <action>Set {{action_count}} = 0</action>
     </check>
 
     <check if="user chooses 2">
       <action>Add "Review Follow-ups (AI)" subsection to Tasks/Subtasks</action>
       <action>For each issue: `- [ ] [AI-Review][Severity] Description [file:line]`</action>
+      <action>Set {{action_count}} = number of action items created</action>
+      <action>Set {{fixed_count}} = 0</action>
     </check>
 
     <check if="user chooses 3">
@@ -158,10 +165,51 @@
     </check>
   </step>
 
-  <step n="5" goal="Update story status">
-    <action>If all HIGH issues fixed and ACs implemented → Update story Status to "done"</action>
-    <action>If issues remain → Update story Status to "in-progress"</action>
+  <step n="5" goal="Update story status and sync sprint tracking">
+    <!-- Determine new status based on review outcome -->
+    <check if="all HIGH and MEDIUM issues fixed AND all ACs implemented">
+      <action>Set {{new_status}} = "done"</action>
+      <action>Update story Status field to "done"</action>
+    </check>
+    <check if="HIGH or MEDIUM issues remain OR ACs not fully implemented">
+      <action>Set {{new_status}} = "in-progress"</action>
+      <action>Update story Status field to "in-progress"</action>
+    </check>
     <action>Save story file</action>
+
+    <!-- Determine sprint tracking status -->
+    <check if="{sprint_status} file exists">
+      <action>Set {{current_sprint_status}} = "enabled"</action>
+    </check>
+    <check if="{sprint_status} file does NOT exist">
+      <action>Set {{current_sprint_status}} = "no-sprint-tracking"</action>
+    </check>
+
+    <!-- Sync sprint-status.yaml when story status changes (only if sprint tracking enabled) -->
+    <check if="{{current_sprint_status}} != 'no-sprint-tracking'">
+      <action>Load the FULL file: {sprint_status}</action>
+      <action>Find development_status key matching {{story_key}}</action>
+
+      <check if="{{new_status}} == 'done'">
+        <action>Update development_status[{{story_key}}] = "done"</action>
+        <action>Save file, preserving ALL comments and structure</action>
+        <output>✅ Sprint status synced: {{story_key}} → done</output>
+      </check>
+
+      <check if="{{new_status}} == 'in-progress'">
+        <action>Update development_status[{{story_key}}] = "in-progress"</action>
+        <action>Save file, preserving ALL comments and structure</action>
+        <output>🔄 Sprint status synced: {{story_key}} → in-progress</output>
+      </check>
+
+      <check if="story key not found in sprint status">
+        <output>⚠️ Story file updated, but sprint-status sync failed: {{story_key}} not found in sprint-status.yaml</output>
+      </check>
+    </check>
+
+    <check if="{{current_sprint_status}} == 'no-sprint-tracking'">
+      <output>ℹ️ Story status updated (no sprint tracking configured)</output>
+    </check>
 
     <output>**✅ Review Complete!**
 


### PR DESCRIPTION
Fixes #1015

## Summary

- Fix checklist to only accept 'review' status (not non-existent 'ready-for-review')
- Include MEDIUM issues in done/in-progress status determination
- Initialize and track fixed_count/action_count variables for summary
- Add sprint-status.yaml sync when story status changes

## Testing

### Unit Tests (30 cases)

Tested isolated LLM decision-making snippets:

| Snippet | Tests | Result |
|---------|-------|--------|
| code-review-status | 8 | ✅ 8/8 pass |
| quick-dev-escalation | 12 | ✅ 11/12 pass, 1 borderline |
| sprint-status-routing | 10 | ✅ 10/10 pass |

Key test: CR-04 validates MEDIUM issues block "done" status.

### Integration Tests (5 scenarios)

| Test | Scenario | Result |
|------|----------|--------|
| INT-01 | Happy path - clean code, approve | ✅ PASS |
| INT-02 | Find issues, defer to action items | ✅ PASS |
| INT-03 | Find issues, fix code directly | ✅ PASS |
| INT-05 | No sprint-status.yaml (graceful degradation) | ✅ PASS |
| INT-06 | Story key missing from sprint-status | ✅ PASS |

Verified:
- Review quality (finds real issues with severity + file:line)
- Story updates (Status, Review section, Change Log, ACs)
- Code fixes (actually modifies source files)
- Action items (properly formatted `[AI-Review][Severity]`)
- Sprint sync (updates when file exists and key present)
- Graceful degradation (no crash when sprint file missing)
- Error handling (warning when story key not found)

🤖 Generated with [Claude Code](https://claude.com/claude-code)