### PR TITLE
feat(bmm): enhance PRD workflow with brownfield project support

### DIFF
--- a/src/modules/bmm/docs/agents-guide.md
+++ b/src/modules/bmm/docs/agents-guide.md
@@ -144,7 +144,6 @@ The BMad Method Module (BMM) provides a comprehensive team of specialized AI age
 
 - `workflow-status` - Check what to do next
 - `create-architecture` - Produce a Scale Adaptive Architecture
-- `validate-architecture` - Validate architecture document
 - `implementation-readiness` - Validate PRD + Architecture + Epics + UX (optional)
 
 **Communication Style:** Comprehensive yet pragmatic. Uses architectural metaphors. Balances technical depth with accessibility. Connects decisions to business value.
@@ -644,7 +643,6 @@ Many workflows have optional validation workflows that perform independent revie
 | Validation                 | Agent       | Validates                                  |
 | -------------------------- | ----------- | ------------------------------------------ |
 | `implementation-readiness` | Architect   | PRD + Architecture + Epics + UX (optional) |
-| `validate-architecture`    | Architect   | Architecture document                      |
 | `validate-design`          | UX Designer | UX specification and artifacts             |
 | `validate-create-story`    | SM          | Story draft                                |
 
@@ -976,7 +974,7 @@ Quick reference for agent selection:
 | **PM**                  | 📋   | 2 (Planning)            | prd, tech-spec, epics-stories                 | Planning, requirements docs             |
 | **UX Designer**         | 🎨   | 2 (Planning)            | create-ux-design, validate-design             | UX-heavy projects, design               |
 | **Architect**           | 🏗️   | 3 (Solutioning)         | architecture, implementation-readiness        | Technical design, architecture          |
-| **SM**                  | 🏃   | 4 (Implementation)      | sprint-planning, create-story, story-context  | Story management, sprint coordination   |
+| **SM**                  | 🏃   | 4 (Implementation)      | sprint-planning, create-story                 | Story management, sprint coordination   |
 | **DEV**                 | 💻   | 4 (Implementation)      | develop-story, code-review                    | Implementation, coding                  |
 | **TEA**                 | 🧪   | All Phases              | framework, atdd, automate, trace, ci          | Testing, quality assurance              |
 | **Paige (Tech Writer)** | 📚   | All Phases              | document-project, diagrams, validation        | Documentation, diagrams                 |

--- a/src/modules/bmm/docs/brownfield-guide.md
+++ b/src/modules/bmm/docs/brownfield-guide.md
@@ -250,8 +250,8 @@ Without AI-optimized documentation, workflows fail:
 
 - **tech-spec** (Quick Flow) can't auto-detect stack/patterns → Makes wrong assumptions
 - **PRD** (BMad Method) can't reference existing code → Designs incompatible features
-- **architecture** can't build on existing structure → Suggests conflicting patterns
-- **story-context** can't inject existing patterns → Dev agent rewrites working code
+- **create-architecture** can't build on existing structure → Suggests conflicting patterns
+- **create-story** can't provide existing pattern context → Stories lack integration guidance
 - **dev-story** invents implementations → Breaks existing integrations
 
 ### Key Principle
@@ -370,7 +370,7 @@ When workflow-init asks about your work:
 
 ### 4. Respect Existing Patterns
 
-Tech-spec and story-context will detect conventions. Follow them unless explicitly modernizing.
+Tech-spec and create-story workflows will detect conventions from existing documentation. Follow them unless explicitly modernizing.
 
 ### 5. Plan Integration Points Explicitly
 
@@ -446,7 +446,7 @@ Document in tech-spec/architecture:
    - Analyzes existing auth patterns
    - Confirms conventions
    - Creates tech-spec.md + epic + 3-5 stories
-3. **Implement:** Load SM → `sprint-planning` → `create-story` → `story-context`
+3. **Implement:** Load SM → `sprint-planning` → `create-story`
    Load DEV → `dev-story` for each story
 4. **Review:** Load DEV → `code-review`
 
@@ -512,12 +512,9 @@ Document in tech-spec/architecture:
    - `product-brief` - Strategic document
 3. **Plan:** Load PM → `prd` (comprehensive FRs/NFRs)
 4. **Solution:**
-   - `create-architecture` - Full system architecture
-   - `integration-planning` - Phased migration strategy
-   - `create-architecture` - Multi-tenancy architecture
-   - `validate-architecture` - External review
+   - `create-architecture` - Full system architecture including multi-tenancy design
    - `create-epics-and-stories` - Create epics and stories
-   - `implementation-readiness` - Executive approval
+   - `implementation-readiness` - Final validation before implementation
 5. **Implement:** Phased sprint-based (50+ stories)
 
 **Time:** 3-6 months
@@ -564,7 +561,7 @@ Document in tech-spec/architecture:
 **Solution:**
 
 1. Ensure `document-project` captured existing architecture
-2. Check `story-context` - should document integration points
+2. Check story files created by `create-story` - should include integration context
 3. In tech-spec/architecture - explicitly document:
    - Which existing modules to modify
    - What APIs/services to integrate with
@@ -597,7 +594,7 @@ Document in tech-spec/architecture:
 
 1. Check convention detection (Quick Spec Flow should detect patterns)
 2. Review documentation - ensure `document-project` captured patterns
-3. Use `story-context` - injects pattern guidance
+3. Use `create-story` workflow - it loads context from existing documentation
 4. Add to code-review checklist: pattern adherence, convention consistency
 5. Run retrospective to identify deviations early
 
@@ -626,9 +623,9 @@ prd                     # BMad Method/Enterprise tracks
 
 # Phase 3: Solutioning (BMad Method/Enterprise)
 # Architect agent:
-architecture                 # Create/extend architecture
+create-architecture          # Create/extend architecture
 create-epics-and-stories     # Create epics and stories (after architecture)
-implementation-readiness       # Final validation
+implementation-readiness     # Final validation
 
 # Phase 4: Implementation (All Tracks)
 # SM agent:

--- a/src/modules/bmm/docs/faq.md
+++ b/src/modules/bmm/docs/faq.md
@@ -193,15 +193,9 @@ PRDs are for Level 2-4 projects with multiple features requiring product-level c
 
 ## Implementation
 
-### Q: Do I need story-context for every story?
+### Q: Does create-story include implementation context?
 
-**A:** Technically no, but it's recommended. story-context provides implementation-specific guidance, references existing patterns, and injects expertise. Skip it only if:
-
-- Very simple story (self-explanatory)
-- You're already expert in the area
-- Time is extremely limited
-
-For Level 0-1 using tech-spec, story-context is less critical because tech-spec is already comprehensive.
+**A:** Yes! The create-story workflow generates story files that include implementation-specific guidance, references existing patterns from your documentation, and provides technical context. The workflow loads your architecture, PRD, and existing project documentation to create comprehensive stories. For Quick Flow projects using tech-spec, the tech-spec itself is already comprehensive, so stories can be simpler.
 
 ### Q: How do I mark a story as done?
 

--- a/src/modules/bmm/docs/glossary.md
+++ b/src/modules/bmm/docs/glossary.md
@@ -187,7 +187,7 @@ backlog → drafted → ready-for-dev → in-progress → review → done
 
 - **backlog** - Story exists in epic but not yet drafted
 - **drafted** - Story file created by SM via create-story
-- **ready-for-dev** - Story has context, ready for DEV via story-context
+- **ready-for-dev** - Story drafted and reviewed, ready for DEV
 - **in-progress** - DEV is implementing via dev-story
 - **review** - Implementation complete, awaiting code-review
 - **done** - Completed with DoD met
@@ -238,7 +238,7 @@ Markdown file containing story details: description, acceptance criteria, techni
 
 ### Story Context
 
-Technical guidance document created via story-context workflow that provides implementation-specific context, references existing patterns, suggests approaches, and injects expertise for the specific story.
+Implementation guidance embedded within story files during the create-story workflow. Provides implementation-specific context, references existing patterns, suggests approaches, and helps maintain consistency with established codebase conventions.
 
 ### Sprint Planning
 

--- a/src/modules/bmm/docs/quick-start.md
+++ b/src/modules/bmm/docs/quick-start.md
@@ -313,11 +313,10 @@ flowchart LR
         direction TB
         D1[Per Epic:<br/>epic context]
         D2[Per Story:<br/>create-story]
-        D3[story-context]
-        D4[dev-story]
-        D5[code-review]
-        D6[SM, DEV]
-        D1 ~~~ D2 ~~~ D3 ~~~ D4 ~~~ D5 ~~~ D6
+        D3[dev-story]
+        D4[code-review]
+        D5[SM, DEV]
+        D1 ~~~ D2 ~~~ D3 ~~~ D4 ~~~ D5
     end
 
     P1 --> P2

--- a/src/modules/bmm/docs/workflows-implementation.md
+++ b/src/modules/bmm/docs/workflows-implementation.md
@@ -70,7 +70,7 @@ For a visual representation of the complete workflow, see: [workflow-method-gree
 Stories move through these states in the sprint status file:
 
 1. **TODO** - Story identified but not started
-2. **IN PROGRESS** - Story being implemented (create-story → story-context → dev-story)
+2. **IN PROGRESS** - Story being implemented (create-story → dev-story)
 3. **READY FOR REVIEW** - Implementation complete, awaiting code review
 4. **DONE** - Accepted and complete
 

--- a/src/modules/bmm/workflows/2-plan-workflows/prd/prd-template.md
+++ b/src/modules/bmm/workflows/2-plan-workflows/prd/prd-template.md
@@ -1,6 +1,13 @@
 ---
 stepsCompleted: []
 inputDocuments: []
+documentCounts:
+  briefs: 0
+  research: 0
+  brainstorming: 0
+  projectDocs: 0
+workflowType: 'prd'
+lastStep: 0
 ---
 
 # Product Requirements Document - {{project_name}}

--- a/src/modules/bmm/workflows/2-plan-workflows/prd/steps/step-01-init.md
+++ b/src/modules/bmm/workflows/2-plan-workflows/prd/steps/step-01-init.md
@@ -1,43 +1,75 @@
+---
+name: 'step-01-init'
+description: 'Initialize the PRD workflow by detecting continuation state and setting up the document'
+
+# Path Definitions
+workflow_path: '{project-root}/{bmad_folder}/bmm/workflows/2-plan-workflows/prd'
+
+# File References
+thisStepFile: '{workflow_path}/steps/step-01-init.md'
+nextStepFile: '{workflow_path}/steps/step-02-discovery.md'
+continueStepFile: '{workflow_path}/steps/step-01b-continue.md'
+workflowFile: '{workflow_path}/workflow.md'
+outputFile: '{output_folder}/prd.md'
+
+# Template References
+prdTemplate: '{workflow_path}/prd-template.md'
+---
+
 # Step 1: Workflow Initialization
 
-**Progress: Step 1 of 10** - Next: Project Discovery
+**Progress: Step 1 of 11** - Next: Project Discovery
+
+## STEP GOAL:
+
+Initialize the PRD workflow by detecting continuation state, discovering input documents, and setting up the document structure for collaborative product requirement discovery.
 
 ## MANDATORY EXECUTION RULES (READ FIRST):
 
-- 🛑 NEVER generate content without user input
+### Universal Rules:
 
-- 📖 CRITICAL: ALWAYS read the complete step file before taking any action - partial understanding leads to incomplete decisions
-- 🔄 CRITICAL: When loading next step with 'C', ensure the entire file is read and understood before proceeding
-- ✅ ALWAYS treat this as collaborative discovery between PM peers
+- 🛑 NEVER generate content without user input
+- 📖 CRITICAL: Read the complete step file before taking any action
+- 🔄 CRITICAL: When loading next step with 'C', ensure entire file is read
 - 📋 YOU ARE A FACILITATOR, not a content generator
-- 💬 FOCUS on initialization and setup only - don't look ahead to future steps
-- 🚪 DETECT existing workflow state and handle continuation properly
+
+### Role Reinforcement:
+
+- ✅ You are a product-focused PM facilitator collaborating with an expert peer
+- ✅ If you already have been given a name, communication_style and persona, continue to use those while playing this new role
+- ✅ We engage in collaborative dialogue, not command-response
+- ✅ You bring structured thinking and facilitation skills, while the user brings domain expertise and product vision
+
+### Step-Specific Rules:
+
+- 🎯 Focus only on initialization and setup - no content generation yet
+- 🚫 FORBIDDEN to look ahead to future steps or assume knowledge from them
+- 💬 Approach: Systematic setup with clear reporting to user
+- 🚪 Detect existing workflow state and handle continuation properly
 
 ## EXECUTION PROTOCOLS:
 
-- 🎯 Show your analysis before taking any action
-- 💾 Initialize document and update frontmatter
+- 🎯 Show your analysis of current state before taking any action
+- 💾 Initialize document structure and update frontmatter appropriately
 - 📖 Set up frontmatter `stepsCompleted: [1]` before loading next step
-- 🚫 FORBIDDEN to load next step until setup is complete
+- 🚫 FORBIDDEN to load next step until user selects 'C' (Continue)
 
 ## CONTEXT BOUNDARIES:
 
-- Variables from workflow.md are available in memory
-- Previous context = what's in output document + frontmatter
-- Don't assume knowledge from other steps
-- Input document discovery happens in this step
+- Available context: Variables from workflow.md are available in memory
+- Focus: Workflow initialization and document setup only
+- Limits: Don't assume knowledge from other steps or create content yet
+- Dependencies: Configuration loaded from workflow.md initialization
 
-## YOUR TASK:
+## Sequence of Instructions (Do not deviate, skip, or optimize)
 
-Initialize the PRD workflow by detecting continuation state and setting up the document.
-
-## INITIALIZATION SEQUENCE:
-
-### 1. Check for Existing Workflow
+### 1. Check for Existing Workflow State
 
 First, check if the output document already exists:
 
-- Look for file at `{output_folder}/prd.md`
+**Workflow State Detection:**
+
+- Look for file at `{outputFile}`
 - If exists, read the complete file including frontmatter
 - If not exists, this is a fresh workflow
 
@@ -45,9 +77,12 @@ First, check if the output document already exists:
 
 If the document exists and has frontmatter with `stepsCompleted`:
 
-- **STOP here** and load `./step-01b-continue.md` immediately
+**Continuation Protocol:**
+
+- **STOP immediately** and load `{continueStepFile}`
 - Do not proceed with any initialization tasks
-- Let step-01b handle the continuation logic
+- Let step-01b handle all continuation logic
+- This is an auto-proceed situation - no user choice needed
 
 ### 3. Fresh Workflow Setup (If No Document)
 
@@ -55,7 +90,18 @@ If no document exists or no `stepsCompleted` in frontmatter:
 
 #### A. Input Document Discovery
 
-Discover and load context documents using smart discovery:
+Discover and load context documents using smart discovery.
+
+**IMPORTANT: Track document counts as you discover files.**
+
+Initialize counters:
+
+```
+briefCount = 0
+researchCount = 0
+brainstormingCount = 0
+projectDocsCount = 0
+```
 
 **Product Brief (Priority: Analysis → Main → Sharded → Whole):**
 
@@ -64,6 +110,7 @@ Discover and load context documents using smart discovery:
 3. If no main files: Check for sharded brief folder: `{output_folder}/*brief*/**/*.md`
 4. If sharded folder exists: Load EVERY file in that folder completely
 5. Add discovered files to `inputDocuments` frontmatter
+6. **Update briefCount with number of files found**
 
 **Research Documents (Priority: Analysis → Main → Sharded → Whole):**
 
@@ -72,20 +119,23 @@ Discover and load context documents using smart discovery:
 3. If no main files: Check for sharded research folder: `{output_folder}/*research*/**/*.md`
 4. Load useful research files completely
 5. Add discovered files to `inputDocuments` frontmatter
+6. **Update researchCount with number of files found**
 
 **Brainstorming Documents (Priority: Analysis → Main):**
 
 1. Check analysis folder: `{output_folder}/analysis/brainstorming/*brainstorming*.md`
 2. If no analysis files: Try main folder: `{output_folder}/*brainstorming*.md`
 3. Add discovered files to `inputDocuments` frontmatter
+4. **Update brainstormingCount with number of files found**
 
-**Project Documentation (Existing Projects):**
+**Project Documentation (Existing Projects - Brownfield):**
 
 1. Look for index file: `{output_folder}/index.md`
 2. CRITICAL: Load index.md to understand what project files are available
 3. Read available files from index to understand existing project context
 4. This provides essential context for extending existing project with new PRD
 5. Add discovered files to `inputDocuments` frontmatter
+6. **Update projectDocsCount with number of files found (including index.md)**
 
 **Loading Rules:**
 
@@ -96,13 +146,20 @@ Discover and load context documents using smart discovery:
 
 #### B. Create Initial Document
 
-Copy the template from `{installed_path}/prd-template.md` to `{output_folder}/prd.md`
-Initialize frontmatter with:
+**Document Setup:**
+
+- Copy the template from `{prdTemplate}` to `{outputFile}`
+- Initialize frontmatter with proper structure including document counts:
 
 ```yaml
 ---
 stepsCompleted: []
 inputDocuments: []
+documentCounts:
+  briefs: { { briefCount } }
+  research: { { researchCount } }
+  brainstorming: { { brainstormingCount } }
+  projectDocs: { { projectDocsCount } }
 workflowType: 'prd'
 lastStep: 0
 project_name: '{{project_name}}'
@@ -111,51 +168,76 @@ date: '{{date}}'
 ---
 ```
 
-#### C. Complete Initialization and Report
+#### C. Present Initialization Results
 
-Complete setup and report to user:
+**Setup Report to User:**
+
+"Welcome {{user_name}}! I've set up your PRD workspace for {{project_name}}.
 
 **Document Setup:**
 
-- Created: `{output_folder}/prd.md` from template
+- Created: `{outputFile}` from template
 - Initialized frontmatter with workflow state
 
 **Input Documents Discovered:**
-Report what was found:
-"Welcome {{user_name}}! I've set up your PRD workspace for {{project_name}}.
 
-**Documents Found:**
-
-- Product brief: {number of brief files loaded or "None found"}
-- Research: {number of research files loaded or "None found"}
-- Project docs: {number of project files loaded or "None found"}
+- Product briefs: {{briefCount}} files {if briefCount > 0}✓ loaded{else}(none found){/if}
+- Research: {{researchCount}} files {if researchCount > 0}✓ loaded{else}(none found){/if}
+- Brainstorming: {{brainstormingCount}} files {if brainstormingCount > 0}✓ loaded{else}(none found){/if}
+- Project docs: {{projectDocsCount}} files {if projectDocsCount > 0}✓ loaded (brownfield project){else}(none found - greenfield project){/if}
 
 **Files loaded:** {list of specific file names or "No additional documents found"}
 
-Do you have any other documents you'd like me to include, or shall we continue to the next step?
+{if projectDocsCount > 0}
+📋 **Note:** This is a **brownfield project**. Your existing project documentation has been loaded. In the next step, I'll ask specifically about what new features or changes you want to add to your existing system.
+{/if}
 
-[C] Continue - Save this and move to Project Discovery (Step 2 of 10)
+Do you have any other documents you'd like me to include, or shall we continue to the next step?"
 
-## SUCCESS METRICS:
+### 4. Present MENU OPTIONS
 
-✅ Existing workflow detected and handed off to step-01b correctly
-✅ Fresh workflow initialized with template and frontmatter
-✅ Input documents discovered and loaded using sharded-first logic
-✅ All discovered files tracked in frontmatter `inputDocuments`
-✅ User confirmed document setup and can proceed
+Display menu after setup report:
 
-## FAILURE MODES:
+"[C] Continue - Save this and move to Project Discovery (Step 2 of 11)"
 
-❌ Proceeding with fresh initialization when existing workflow exists
-❌ Not updating frontmatter with discovered input documents
-❌ Creating document without proper template
-❌ Not checking sharded folders first before whole files
-❌ Not reporting what documents were found to user
+#### Menu Handling Logic:
 
-❌ **CRITICAL**: Reading only partial step file - leads to incomplete understanding and poor decisions
-❌ **CRITICAL**: Proceeding with 'C' without fully reading and understanding the next step file
-❌ **CRITICAL**: Making decisions without complete understanding of step requirements and protocols
+- IF C: Update frontmatter with `stepsCompleted: [1]`, then load, read entire file, then execute {nextStepFile}
+- IF user provides additional files: Load them, update inputDocuments and documentCounts, redisplay report
+- IF user asks questions: Answer and redisplay menu
 
-## NEXT STEP:
+#### EXECUTION RULES:
 
-After user selects [C] to continue, load `{installed_path}/step/step-02-discovery.md` to begin the project discovery phase.
+- ALWAYS halt and wait for user input after presenting menu
+- ONLY proceed to next step when user selects 'C'
+
+## CRITICAL STEP COMPLETION NOTE
+
+ONLY WHEN [C continue option] is selected and [frontmatter properly updated with stepsCompleted: [1] and documentCounts], will you then load and read fully `{nextStepFile}` to execute and begin project discovery.
+
+---
+
+## 🚨 SYSTEM SUCCESS/FAILURE METRICS
+
+### ✅ SUCCESS:
+
+- Existing workflow detected and properly handed off to step-01b
+- Fresh workflow initialized with template and proper frontmatter
+- Input documents discovered and loaded using sharded-first logic
+- All discovered files tracked in frontmatter `inputDocuments`
+- **Document counts stored in frontmatter `documentCounts`**
+- User clearly informed of brownfield vs greenfield status
+- Menu presented and user input handled correctly
+- Frontmatter updated with `stepsCompleted: [1]` before proceeding
+
+### ❌ SYSTEM FAILURE:
+
+- Proceeding with fresh initialization when existing workflow exists
+- Not updating frontmatter with discovered input documents
+- **Not storing document counts in frontmatter**
+- Creating document without proper template structure
+- Not checking sharded folders first before whole files
+- Not reporting discovered documents to user clearly
+- Proceeding without user selecting 'C' (Continue)
+
+**Master Rule:** Skipping steps, optimizing sequences, or not following exact instructions is FORBIDDEN and constitutes SYSTEM FAILURE.

--- a/src/modules/bmm/workflows/2-plan-workflows/prd/steps/step-01b-continue.md
+++ b/src/modules/bmm/workflows/2-plan-workflows/prd/steps/step-01b-continue.md
@@ -1,56 +1,81 @@
+---
+name: 'step-01b-continue'
+description: 'Resume an interrupted PRD workflow from the last completed step'
+
+# Path Definitions
+workflow_path: '{project-root}/{bmad_folder}/bmm/workflows/2-plan-workflows/prd'
+
+# File References
+thisStepFile: '{workflow_path}/steps/step-01b-continue.md'
+workflowFile: '{workflow_path}/workflow.md'
+outputFile: '{output_folder}/prd.md'
+---
+
 # Step 1B: Workflow Continuation
+
+## STEP GOAL:
+
+Resume the PRD workflow from where it was left off, ensuring smooth continuation with full context restoration.
 
 ## MANDATORY EXECUTION RULES (READ FIRST):
 
-- 🛑 NEVER generate content without user input
+### Universal Rules:
 
-- 📖 CRITICAL: ALWAYS read the complete step file before taking any action - partial understanding leads to incomplete decisions
-- 🔄 CRITICAL: When loading next step with 'C', ensure the entire file is read and understood before proceeding
-- ✅ ALWAYS treat this as collaborative discovery between PM peers
+- 🛑 NEVER generate content without user input
+- 📖 CRITICAL: Read the complete step file before taking any action
+- 🔄 CRITICAL: When loading next step with 'C', ensure entire file is read
 - 📋 YOU ARE A FACILITATOR, not a content generator
+
+### Role Reinforcement:
+
+- ✅ You are a product-focused PM facilitator collaborating with an expert peer
+- ✅ We engage in collaborative dialogue, not command-response
+- ✅ Resume workflow from exact point where it was interrupted
+
+### Step-Specific Rules:
+
 - 💬 FOCUS on understanding where we left off and continuing appropriately
-- 🚪 RESUME workflow from exact point where it was interrupted
+- 🚫 FORBIDDEN to modify content completed in previous steps
+- 📖 Only reload documents that were already tracked in `inputDocuments`
 
 ## EXECUTION PROTOCOLS:
 
 - 🎯 Show your analysis of current state before taking action
 - 💾 Keep existing frontmatter `stepsCompleted` values
 - 📖 Only load documents that were already tracked in `inputDocuments`
-- 🚫 FORBIDDEN to modify content completed in previous steps
+- 🚫 FORBIDDEN to discover new input documents during continuation
 
 ## CONTEXT BOUNDARIES:
 
-- Current document and frontmatter are already loaded
-- Previous context = complete document + existing frontmatter
-- Input documents listed in frontmatter were already processed
-- Last completed step = `lastStep` value from frontmatter
+- Available context: Current document and frontmatter are already loaded
+- Focus: Workflow state analysis and continuation logic only
+- Limits: Don't assume knowledge beyond what's in the document
+- Dependencies: Existing workflow state from previous session
 
-## YOUR TASK:
-
-Resume the PRD workflow from where it was left off, ensuring smooth continuation.
-
-## CONTINUATION SEQUENCE:
+## Sequence of Instructions (Do not deviate, skip, or optimize)
 
 ### 1. Analyze Current State
 
+**State Assessment:**
 Review the frontmatter to understand:
 
 - `stepsCompleted`: Which steps are already done
 - `lastStep`: The most recently completed step number
 - `inputDocuments`: What context was already loaded
+- `documentCounts`: briefs, research, brainstorming, projectDocs counts
 - All other frontmatter variables
 
-### 2. Load All Input Documents
+### 2. Restore Context Documents
 
-Reload the context documents listed in `inputDocuments`:
+**Context Reloading:**
 
 - For each document in `inputDocuments`, load the complete file
 - This ensures you have full context for continuation
 - Don't discover new documents - only reload what was previously processed
 
-### 3. Summarize Current Progress
+### 3. Present Current Progress
 
-Welcome the user back and provide context:
+**Progress Report to User:**
 "Welcome back {{user_name}}! I'm resuming our PRD collaboration for {{project_name}}.
 
 **Current Progress:**
@@ -66,47 +91,29 @@ Welcome the user back and provide context:
 
 Does this look right, or do you want to make any adjustments before we proceed?"
 
-### 4. Determine Next Step
+### 4. Determine Continuation Path
 
+**Next Step Logic:**
 Based on `lastStep` value, determine which step to load next:
 
 - If `lastStep = 1` → Load `./step-02-discovery.md`
 - If `lastStep = 2` → Load `./step-03-success.md`
 - If `lastStep = 3` → Load `./step-04-journeys.md`
-- Continue this pattern for all steps
-- If `lastStep = 10` → Workflow already complete
+- If `lastStep = 4` → Load `./step-05-domain.md`
+- If `lastStep = 5` → Load `./step-06-innovation.md`
+- If `lastStep = 6` → Load `./step-07-project-type.md`
+- If `lastStep = 7` → Load `./step-08-scoping.md`
+- If `lastStep = 8` → Load `./step-09-functional.md`
+- If `lastStep = 9` → Load `./step-10-nonfunctional.md`
+- If `lastStep = 10` → Load `./step-11-complete.md`
+- If `lastStep = 11` → Workflow already complete
 
-### 5. Present Continuation Options
+### 5. Handle Workflow Completion
 
-After presenting current progress, ask:
-"Ready to continue with Step {nextStepNumber}: {nextStepTitle}?
-
-[C] Continue to Step {nextStepNumber}"
-
-## SUCCESS METRICS:
-
-✅ All previous input documents successfully reloaded
-✅ Current workflow state accurately analyzed and presented
-✅ User confirms understanding of progress
-✅ Correct next step identified and prepared for loading
-
-## FAILURE MODES:
-
-❌ Discovering new input documents instead of reloading existing ones
-❌ Modifying content from already completed steps
-❌ Loading wrong next step based on `lastStep` value
-❌ Proceeding without user confirmation of current state
-
-❌ **CRITICAL**: Reading only partial step file - leads to incomplete understanding and poor decisions
-❌ **CRITICAL**: Proceeding with 'C' without fully reading and understanding the next step file
-❌ **CRITICAL**: Making decisions without complete understanding of step requirements and protocols
-
-## WORKFLOW ALREADY COMPLETE?
-
-If `lastStep = 10` (final step completed):
+**If workflow already complete (`lastStep = 11`):**
 "Great news! It looks like we've already completed the PRD workflow for {{project_name}}.
 
-The final document is ready at {output_folder}/prd.md with all sections completed through step 10.
+The final document is ready at `{outputFile}` with all sections completed through step 11.
 
 Would you like me to:
 
@@ -116,8 +123,43 @@ Would you like me to:
 
 What would be most helpful?"
 
-## NEXT STEP:
+### 6. Present MENU OPTIONS
 
-After user confirms they're ready to continue, load the appropriate next step file based on the `lastStep` value from frontmatter.
+**If workflow not complete:**
+Display: "Ready to continue with Step {nextStepNumber}?
 
-Remember: Do NOT load the next step until user explicitly selects [C] to continue!
+**Select an Option:** [C] Continue to next step"
+
+#### Menu Handling Logic:
+
+- IF C: Load, read entire file, then execute the appropriate next step file based on `lastStep`
+- IF Any other comments or queries: respond and redisplay menu
+
+#### EXECUTION RULES:
+
+- ALWAYS halt and wait for user input after presenting menu
+- ONLY proceed to next step when user selects 'C'
+
+## CRITICAL STEP COMPLETION NOTE
+
+ONLY WHEN [C continue option] is selected and [current state confirmed], will you then load and read fully the appropriate next step file to resume the workflow.
+
+---
+
+## 🚨 SYSTEM SUCCESS/FAILURE METRICS
+
+### ✅ SUCCESS:
+
+- All previous input documents successfully reloaded
+- Current workflow state accurately analyzed and presented
+- User confirms understanding of progress before continuation
+- Correct next step identified and prepared for loading
+
+### ❌ SYSTEM FAILURE:
+
+- Discovering new input documents instead of reloading existing ones
+- Modifying content from already completed steps
+- Loading wrong next step based on `lastStep` value
+- Proceeding without user confirmation of current state
+
+**Master Rule:** Skipping steps, optimizing sequences, or not following exact instructions is FORBIDDEN and constitutes SYSTEM FAILURE.

--- a/src/modules/bmm/workflows/2-plan-workflows/prd/steps/step-02-discovery.md
+++ b/src/modules/bmm/workflows/2-plan-workflows/prd/steps/step-02-discovery.md
@@ -1,16 +1,53 @@
+---
+name: 'step-02-discovery'
+description: 'Conduct project and domain discovery with data-driven classification'
+
+# Path Definitions
+workflow_path: '{project-root}/{bmad_folder}/bmm/workflows/2-plan-workflows/prd'
+
+# File References
+thisStepFile: '{workflow_path}/steps/step-02-discovery.md'
+nextStepFile: '{workflow_path}/steps/step-03-success.md'
+workflowFile: '{workflow_path}/workflow.md'
+outputFile: '{output_folder}/prd.md'
+
+# Data Files
+projectTypesCSV: '{workflow_path}/project-types.csv'
+domainComplexityCSV: '{workflow_path}/domain-complexity.csv'
+
+# Task References
+advancedElicitationTask: '{project-root}/{bmad_folder}/core/tasks/advanced-elicitation.xml'
+partyModeWorkflow: '{project-root}/{bmad_folder}/core/workflows/party-mode/workflow.md'
+---
+
 # Step 2: Project & Domain Discovery
 
-**Progress: Step 2 of 10** - Next: Success Criteria Definition
+**Progress: Step 2 of 11** - Next: Success Criteria Definition
+
+## STEP GOAL:
+
+Conduct comprehensive project discovery that leverages existing input documents while allowing user refinement, with data-driven classification, and generate the Executive Summary content.
 
 ## MANDATORY EXECUTION RULES (READ FIRST):
 
-- 🛑 NEVER generate content without user input
+### Universal Rules:
 
-- 📖 CRITICAL: ALWAYS read the complete step file before taking any action - partial understanding leads to incomplete decisions
-- 🔄 CRITICAL: When loading next step with 'C', ensure the entire file is read and understood before proceeding
-- ✅ ALWAYS treat this as collaborative discovery between PM peers
+- 🛑 NEVER generate content without user input
+- 📖 CRITICAL: Read the complete step file before taking any action
+- 🔄 CRITICAL: When loading next step with 'C', ensure entire file is read
 - 📋 YOU ARE A FACILITATOR, not a content generator
-- 💬 FOCUS on project classification and vision alignment only
+
+### Role Reinforcement:
+
+- ✅ You are a product-focused PM facilitator collaborating with an expert peer
+- ✅ We engage in collaborative dialogue, not command-response
+- ✅ You bring structured thinking and facilitation skills, while the user brings domain expertise and product vision
+
+### Step-Specific Rules:
+
+- 🎯 Focus on project classification and vision alignment only
+- 🚫 FORBIDDEN to generate content without real user input
+- 💬 APPROACH: Adapt questions based on document context (brownfield vs greenfield)
 - 🎯 LOAD classification data BEFORE starting discovery conversation
 
 ## EXECUTION PROTOCOLS:
@@ -31,8 +68,8 @@ This step will generate content and present choices:
 
 ## PROTOCOL INTEGRATION:
 
-- When 'A' selected: Execute {project-root}/{bmad_folder}/core/tasks/advanced-elicitation.xml
-- When 'P' selected: Execute {project-root}/{bmad_folder}/core/workflows/party-mode/workflow.md
+- When 'A' selected: Execute {advancedElicitationTask}
+- When 'P' selected: Execute {partyModeWorkflow}
 - PROTOCOLS always return to this step's A/P/C menu
 - User accepts/rejects protocol changes before proceeding
 
@@ -40,40 +77,56 @@ This step will generate content and present choices:
 
 - Current document and frontmatter from step 1 are available
 - Input documents already loaded are in memory (product briefs, research, brainstorming, project docs)
+- **Document counts available in frontmatter `documentCounts`**
 - Classification CSV data will be loaded in this step only
 - This will be the first content section appended to the document
-- LEVERAGE existing input documents to accelerate discovery process
-- installed_path = `{project-root}/{bmad_folder}/bmm/workflows/2-plan-workflows/prd`
 
-## YOUR TASK:
+## Sequence of Instructions (Do not deviate, skip, or optimize)
 
-Conduct comprehensive project discovery that leverages existing input documents while allowing user refinement, with data-driven classification and generate the first content section.
+### 1. Read Document State from Frontmatter
 
-## DISCOVERY SEQUENCE:
+**CRITICAL FIRST ACTION:** Read the frontmatter from `{outputFile}` to get document counts.
 
-### 1. Load Classification Data
+```
+Read documentCounts from prd.md frontmatter:
+- briefCount = documentCounts.briefs
+- researchCount = documentCounts.research
+- brainstormingCount = documentCounts.brainstorming
+- projectDocsCount = documentCounts.projectDocs
+```
+
+**ANNOUNCE your understanding:**
+
+"From step 1, I have loaded:
+
+- Product briefs: {{briefCount}} files
+- Research: {{researchCount}} files
+- Brainstorming: {{brainstormingCount}} files
+- Project docs: {{projectDocsCount}} files
+
+{if projectDocsCount > 0}This is a **brownfield project** - I'll focus on understanding what you want to add or change.{else}This is a **greenfield project** - I'll help you define the full product vision.{/if}"
+
+### 2. Load Classification Data
 
 Load and prepare CSV data for intelligent classification:
 
-- Load `{installed_path}/project-types.csv` completely
-- Load `{installed_path/domain-complexity.csv` completely
+- Load `{projectTypesCSV}` completely
+- Load `{domainComplexityCSV}` completely
 - Parse column structures and store in memory for this step only
 
-### 2. Leverage Input Documents for Head Start
+### 3. Begin Discovery Conversation
 
-Analyze available input documents to provide informed discovery:
+**SELECT EXACTLY ONE DISCOVERY PATH based on document state:**
 
-**Check Input Documents Available:**
+---
 
-- Product Briefs: {{number_of_briefs}} documents loaded
-- Research Documents: {{number_of_research}} documents loaded
-- Brainstorming Results: {{number_of_brainstorming}} documents loaded
-- Project Documentation: {{number_of_project_docs}} documents loaded
+#### PATH A: Has Product Brief (briefCount > 0)
 
-**If Input Documents Exist:**
-"As your PM peer, I've reviewed your existing project documentation and have a great starting point for our discovery. Let me share what I understand and you can refine or correct as needed.
+**Use this path when:** `briefCount > 0`
 
-**Based on your product brief and research:**
+"As your PM peer, I've reviewed your product brief and have a great starting point for our discovery. Let me share what I understand and you can refine or correct as needed.
+
+**Based on your product brief:**
 
 **What you're building:**
 {{extracted_vision_from_brief}}
@@ -87,9 +140,47 @@ Analyze available input documents to provide informed discovery:
 **What makes it special:**
 {{extracted_differentiator_from_brief}}
 
+{if projectDocsCount > 0}I also see you have existing project documentation. This PRD will define how new features integrate with your existing system architecture.{/if}
+
 **How does this align with your vision?** Should we refine any of these points or are there important aspects I'm missing?"
 
-**If No Input Documents:**
+**AFTER this message, SKIP to Section 4.**
+
+---
+
+#### PATH B: No Brief but Has Project Docs - Brownfield (briefCount == 0 AND projectDocsCount > 0)
+
+**Use this path when:** `briefCount == 0 AND projectDocsCount > 0`
+
+**NOTE:** Extract the following from loaded project documentation (index.md, architecture.md, project-overview.md, etc.):
+
+"As your PM peer, I've reviewed your existing project documentation from document-project.
+
+**Your existing system includes:**
+
+- **Tech Stack:** {analyze index.md and architecture.md for technologies used}
+- **Architecture:** {summarize architecture patterns from architecture.md}
+- **Key Components:** {list main components from source-tree-analysis.md or project-overview.md}
+
+This PRD will define **new features or changes** to add to this existing codebase.
+
+**Tell me about what you want to add or change:**
+
+- What new capability or feature do you want to build?
+- What problem will this solve for your users?
+- How should it integrate with the existing system?
+- Is this adding new functionality, improving existing features, or fixing issues?
+
+I'll help you create a PRD focused on these additions while respecting your existing patterns and architecture."
+
+**AFTER this message, SKIP to Section 4.**
+
+---
+
+#### PATH C: No Documents - Greenfield (briefCount == 0 AND projectDocsCount == 0)
+
+**Use this path when:** `briefCount == 0 AND projectDocsCount == 0`
+
 "As your PM peer, I'm excited to help you shape {{project_name}}. Let me start by understanding what you want to build.
 
 **Tell me about what you want to create:**
@@ -100,9 +191,13 @@ Analyze available input documents to provide informed discovery:
 
 I'll be listening for signals to help us classify the project and domain so we can ask the right questions throughout our process."
 
-### 3. Listen for Classification Signals
+**AFTER this message, continue to Section 4.**
 
-As the user describes their product, listen for and match against:
+---
+
+### 4. Listen for Classification Signals
+
+As the user describes their product/feature, listen for and match against:
 
 #### Project Type Signals
 
@@ -122,11 +217,14 @@ Compare user description against `signals` from `domain-complexity.csv`:
 - Examples: "payment,banking,trading" → fintech
 - Store the matched `domain` and `complexity_level`
 
-### 4. Enhanced Classification with Document Context
+### 5. Present Classification for Validation
 
-Leverage both user input and document analysis for classification:
+**SELECT EXACTLY ONE CLASSIFICATION PRESENTATION based on document state:**
 
-**If Input Documents Exist:**
+---
+
+#### IF PATH A was used (briefCount > 0):
+
 "Based on your product brief and our discussion, I'm classifying this as:
 
 - **Project Type:** {project_type_from_brief_or_conversation}
@@ -136,10 +234,33 @@ Leverage both user input and document analysis for classification:
 From your brief, I detected these classification signals:
 {{classification_signals_from_brief}}
 
+{if projectDocsCount > 0}Your existing project documentation also indicates:
+
+- **Existing Tech Stack:** {from architecture.md or index.md}
+- **Architecture Pattern:** {from architecture.md}
+
+I'll ensure the new features align with your existing system.{/if}
+
 Combined with our conversation, this suggests the above classification. Does this sound right?"
 
-**If No Input Documents:**
-Present your classifications for user validation:
+---
+
+#### IF PATH B was used (briefCount == 0 AND projectDocsCount > 0):
+
+"Based on your existing project documentation and our discussion about new features:
+
+- **Existing Project Type:** {detected from project docs - e.g., web_app, api_backend}
+- **Tech Stack:** {from architecture.md or index.md}
+- **New Feature Type:** {from user's description of what they want to add}
+- **Domain:** {detected_domain}
+- **Complexity:** {complexity_level}
+
+I'll ensure the PRD aligns with your existing architecture patterns. Does this classification sound right?"
+
+---
+
+#### IF PATH C was used (briefCount == 0 AND projectDocsCount == 0):
+
 "Based on our conversation, I'm hearing this as:
 
 - **Project Type:** {detected_project_type}
@@ -148,11 +269,16 @@ Present your classifications for user validation:
 
 Does this sound right to you? I want to make sure we're on the same page before diving deeper."
 
-### 5. Identify What Makes It Special
+---
 
-Leverage input documents for initial understanding, then refine:
+### 6. Identify What Makes It Special
 
-**If Input Documents Exist:**
+**SELECT EXACTLY ONE DIFFERENTIATOR DISCOVERY based on document state:**
+
+---
+
+#### IF PATH A was used (briefCount > 0):
+
 "From your product brief, I understand that what makes this special is:
 {{extracted_differentiator_from_brief}}
 
@@ -162,7 +288,21 @@ Let's explore this deeper:
 - **Missing aspects:** Are there other differentiators that aren't captured in your brief?
 - **Evolution:** How has your thinking on this evolved since you wrote the brief?"
 
-**If No Input Documents:**
+---
+
+#### IF PATH B was used (briefCount == 0 AND projectDocsCount > 0):
+
+"Your existing system already provides certain capabilities. Now let's define what makes these **new additions** special:
+
+- What gap in your current system will this fill?
+- How will this improve the experience for your existing users?
+- What's the key insight that led you to prioritize this addition?
+- What would make users say 'finally, this is what we needed'?"
+
+---
+
+#### IF PATH C was used (briefCount == 0 AND projectDocsCount == 0):
+
 Ask focused questions to capture the product's unique value:
 
 - "What would make users say 'this is exactly what I needed'?"
@@ -170,7 +310,9 @@ Ask focused questions to capture the product's unique value:
 - "What assumption about [problem space] are you challenging?"
 - "If this succeeds wildly, what changed for your users?"
 
-### 6. Generate Executive Summary Content
+---
+
+### 7. Generate Executive Summary Content
 
 Based on the conversation, prepare the content to append to the document:
 
@@ -190,75 +332,84 @@ Based on the conversation, prepare the content to append to the document:
 **Technical Type:** {project_type}
 **Domain:** {domain}
 **Complexity:** {complexity_level}
+{if projectDocsCount > 0}**Project Context:** Brownfield - extending existing system{else}**Project Context:** Greenfield - new project{/if}
 
 {project_classification_content}
 ```
 
-### 7. Present Content and Menu
+### 8. Present Content and Menu
 
 Show the generated content to the user and present:
+
 "I've drafted our Executive Summary based on our conversation. This will be the first section of your PRD.
 
 **Here's what I'll add to the document:**
 
-[Show the complete markdown content from step 6]
+[Show the complete markdown content from step 7]
 
-**What would you like to do?**
+**Select an Option:**
 [A] Advanced Elicitation - Let's dive deeper and refine this content
 [P] Party Mode - Bring in different perspectives to improve this
-[C] Continue - Save this and move to Success Criteria Definition (Step 3 of 10)"
+[C] Continue - Save this and move to Success Criteria Definition (Step 3 of 11)"
 
-### 8. Handle Menu Selection
+### 9. Handle Menu Selection
 
-#### If 'A' (Advanced Elicitation):
+#### IF A (Advanced Elicitation):
 
-- Execute {project-root}/{bmad_folder}/core/tasks/advanced-elicitation.xml with the current content
+- Execute {advancedElicitationTask} with the current content
 - Process the enhanced content that comes back
 - Ask user: "Accept these changes to the Executive Summary? (y/n)"
 - If yes: Update the content with improvements, then return to A/P/C menu
 - If no: Keep original content, then return to A/P/C menu
 
-#### If 'P' (Party Mode):
+#### IF P (Party Mode):
 
-- Execute {project-root}/{bmad_folder}/core/workflows/party-mode/workflow.md with the current content
+- Execute {partyModeWorkflow} with the current content
 - Process the collaborative improvements that come back
 - Ask user: "Accept these changes to the Executive Summary? (y/n)"
 - If yes: Update the content with improvements, then return to A/P/C menu
 - If no: Keep original content, then return to A/P/C menu
 
-#### If 'C' (Continue):
+#### IF C (Continue):
 
-- Append the final content to `{output_folder}/prd.md`
+- Append the final content to `{outputFile}`
 - Update frontmatter: `stepsCompleted: [1, 2]`
-- Load `./step-03-success.md`
+- Load `{nextStepFile}`
 
-## APPEND TO DOCUMENT:
+## CRITICAL STEP COMPLETION NOTE
 
-When user selects 'C', append the content directly to the document using the structure from step 6.
+ONLY WHEN [C continue option] is selected and [executive summary content finalized and saved to document with frontmatter updated], will you then load and read fully `{nextStepFile}` to execute and begin success criteria definition.
 
-## SUCCESS METRICS:
+---
 
-✅ Classification data loaded and used effectively
-✅ Input documents analyzed and leveraged for head start
-✅ User classifications validated and confirmed
-✅ Product differentiator clearly identified and refined
-✅ Executive summary content generated collaboratively with document context
-✅ A/P/C menu presented and handled correctly
-✅ Content properly appended to document when C selected
+## 🚨 SYSTEM SUCCESS/FAILURE METRICS
 
-## FAILURE MODES:
+### ✅ SUCCESS:
 
-❌ Skipping classification data loading and guessing classifications
-❌ Not leveraging existing input documents to accelerate discovery
-❌ Not validating classifications with user before proceeding
-❌ Generating executive summary without real user input
-❌ Missing the "what makes it special" discovery and refinement
-❌ Not presenting A/P/C menu after content generation
-❌ Appending content without user selecting 'C'
+- Document counts read from frontmatter and announced
+- Classification data loaded and used effectively
+- **Correct discovery path selected based on document counts**
+- Input documents analyzed and leveraged for head start
+- User classifications validated and confirmed
+- Product differentiator clearly identified and refined
+- Executive summary content generated collaboratively with document context
+- A/P/C menu presented and handled correctly
+- Content properly appended to document when C selected
+- Frontmatter updated with stepsCompleted: [1, 2]
 
-❌ **CRITICAL**: Reading only partial step file - leads to incomplete understanding and poor decisions
-❌ **CRITICAL**: Proceeding with 'C' without fully reading and understanding the next step file
-❌ **CRITICAL**: Making decisions without complete understanding of step requirements and protocols
+### ❌ SYSTEM FAILURE:
+
+- **Not reading documentCounts from frontmatter first**
+- **Executing multiple discovery paths instead of exactly one**
+- Skipping classification data loading and guessing classifications
+- Not leveraging existing input documents to accelerate discovery
+- Not validating classifications with user before proceeding
+- Generating executive summary without real user input
+- Missing the "what makes it special" discovery and refinement
+- Not presenting A/P/C menu after content generation
+- Appending content without user selecting 'C'
+
+**Master Rule:** Skipping steps, optimizing sequences, or not following exact instructions is FORBIDDEN and constitutes SYSTEM FAILURE.
 
 ## COMPLEXITY HANDLING:
 
@@ -267,9 +418,3 @@ If `complexity_level = "high"`:
 - Note the `suggested_workflow` and `web_searches` from domain CSV
 - Consider mentioning domain research needs in classification section
 - Document complexity implications in project classification
-
-## NEXT STEP:
-
-After user selects 'C' and content is saved to document, load `installed_path/steps/step-03-success.md` to define success criteria.
-
-Remember: Do NOT proceed to step-03 until user explicitly selects 'C' from the A/P/C menu and content is saved!

--- a/src/modules/bmm/workflows/2-plan-workflows/prd/steps/step-03-success.md
+++ b/src/modules/bmm/workflows/2-plan-workflows/prd/steps/step-03-success.md
@@ -1,6 +1,24 @@
+---
+name: 'step-03-success'
+description: 'Define comprehensive success criteria covering user, business, and technical success'
+
+# Path Definitions
+workflow_path: '{project-root}/{bmad_folder}/bmm/workflows/2-plan-workflows/prd'
+
+# File References
+thisStepFile: '{workflow_path}/steps/step-03-success.md'
+nextStepFile: '{workflow_path}/steps/step-04-journeys.md'
+workflowFile: '{workflow_path}/workflow.md'
+outputFile: '{output_folder}/prd.md'
+
+# Task References
+advancedElicitationTask: '{project-root}/{bmad_folder}/core/tasks/advanced-elicitation.xml'
+partyModeWorkflow: '{project-root}/{bmad_folder}/core/workflows/party-mode/workflow.md'
+---
+
 # Step 3: Success Criteria Definition
 
-**Progress: Step 3 of 10** - Next: User Journey Mapping
+**Progress: Step 3 of 11** - Next: User Journey Mapping
 
 ## MANDATORY EXECUTION RULES (READ FIRST):
 
@@ -204,7 +222,7 @@ Show the generated content and present choices:
 **What would you like to do?**
 [A] Advanced Elicitation - Let's dive deeper and refine these success metrics
 [P] Party Mode - Bring in different perspectives on success criteria
-[C] Continue - Save success criteria and move to User Journey Mapping (Step 4 of 10)"
+[C] Continue - Save success criteria and move to User Journey Mapping (Step 4 of 11)"
 
 ### 9. Handle Menu Selection
 

--- a/src/modules/bmm/workflows/2-plan-workflows/prd/steps/step-04-journeys.md
+++ b/src/modules/bmm/workflows/2-plan-workflows/prd/steps/step-04-journeys.md
@@ -1,3 +1,21 @@
+---
+name: 'step-04-journeys'
+description: 'Map ALL user types that interact with the system with narrative story-based journeys'
+
+# Path Definitions
+workflow_path: '{project-root}/{bmad_folder}/bmm/workflows/2-plan-workflows/prd'
+
+# File References
+thisStepFile: '{workflow_path}/steps/step-04-journeys.md'
+nextStepFile: '{workflow_path}/steps/step-05-domain.md'
+workflowFile: '{workflow_path}/workflow.md'
+outputFile: '{output_folder}/prd.md'
+
+# Task References
+advancedElicitationTask: '{project-root}/{bmad_folder}/core/tasks/advanced-elicitation.xml'
+partyModeWorkflow: '{project-root}/{bmad_folder}/core/workflows/party-mode/workflow.md'
+---
+
 # Step 4: User Journey Mapping
 
 **Progress: Step 4 of 11** - Next: Domain Requirements

--- a/src/modules/bmm/workflows/2-plan-workflows/prd/steps/step-05-domain.md
+++ b/src/modules/bmm/workflows/2-plan-workflows/prd/steps/step-05-domain.md
@@ -1,3 +1,24 @@
+---
+name: 'step-05-domain'
+description: 'Explore domain-specific requirements for complex domains (optional step)'
+
+# Path Definitions
+workflow_path: '{project-root}/{bmad_folder}/bmm/workflows/2-plan-workflows/prd'
+
+# File References
+thisStepFile: '{workflow_path}/steps/step-05-domain.md'
+nextStepFile: '{workflow_path}/steps/step-06-innovation.md'
+workflowFile: '{workflow_path}/workflow.md'
+outputFile: '{output_folder}/prd.md'
+
+# Data Files
+domainComplexityCSV: '{workflow_path}/domain-complexity.csv'
+
+# Task References
+advancedElicitationTask: '{project-root}/{bmad_folder}/core/tasks/advanced-elicitation.xml'
+partyModeWorkflow: '{project-root}/{bmad_folder}/core/workflows/party-mode/workflow.md'
+---
+
 # Step 5: Domain-Specific Exploration
 
 **Progress: Step 5 of 11** - Next: Innovation Focus

--- a/src/modules/bmm/workflows/2-plan-workflows/prd/steps/step-06-innovation.md
+++ b/src/modules/bmm/workflows/2-plan-workflows/prd/steps/step-06-innovation.md
@@ -1,3 +1,24 @@
+---
+name: 'step-06-innovation'
+description: 'Detect and explore innovative aspects of the product (optional step)'
+
+# Path Definitions
+workflow_path: '{project-root}/{bmad_folder}/bmm/workflows/2-plan-workflows/prd'
+
+# File References
+thisStepFile: '{workflow_path}/steps/step-06-innovation.md'
+nextStepFile: '{workflow_path}/steps/step-07-project-type.md'
+workflowFile: '{workflow_path}/workflow.md'
+outputFile: '{output_folder}/prd.md'
+
+# Data Files
+projectTypesCSV: '{workflow_path}/project-types.csv'
+
+# Task References
+advancedElicitationTask: '{project-root}/{bmad_folder}/core/tasks/advanced-elicitation.xml'
+partyModeWorkflow: '{project-root}/{bmad_folder}/core/workflows/party-mode/workflow.md'
+---
+
 # Step 6: Innovation Discovery
 
 **Progress: Step 6 of 11** - Next: Project Type Analysis

--- a/src/modules/bmm/workflows/2-plan-workflows/prd/steps/step-07-project-type.md
+++ b/src/modules/bmm/workflows/2-plan-workflows/prd/steps/step-07-project-type.md
@@ -1,3 +1,24 @@
+---
+name: 'step-07-project-type'
+description: 'Conduct project-type specific discovery using CSV-driven guidance'
+
+# Path Definitions
+workflow_path: '{project-root}/{bmad_folder}/bmm/workflows/2-plan-workflows/prd'
+
+# File References
+thisStepFile: '{workflow_path}/steps/step-07-project-type.md'
+nextStepFile: '{workflow_path}/steps/step-08-scoping.md'
+workflowFile: '{workflow_path}/workflow.md'
+outputFile: '{output_folder}/prd.md'
+
+# Data Files
+projectTypesCSV: '{workflow_path}/project-types.csv'
+
+# Task References
+advancedElicitationTask: '{project-root}/{bmad_folder}/core/tasks/advanced-elicitation.xml'
+partyModeWorkflow: '{project-root}/{bmad_folder}/core/workflows/party-mode/workflow.md'
+---
+
 # Step 7: Project-Type Deep Dive
 
 **Progress: Step 7 of 11** - Next: Scoping

--- a/src/modules/bmm/workflows/2-plan-workflows/prd/steps/step-08-scoping.md
+++ b/src/modules/bmm/workflows/2-plan-workflows/prd/steps/step-08-scoping.md
@@ -1,3 +1,21 @@
+---
+name: 'step-08-scoping'
+description: 'Define MVP boundaries and prioritize features across development phases'
+
+# Path Definitions
+workflow_path: '{project-root}/{bmad_folder}/bmm/workflows/2-plan-workflows/prd'
+
+# File References
+thisStepFile: '{workflow_path}/steps/step-08-scoping.md'
+nextStepFile: '{workflow_path}/steps/step-09-functional.md'
+workflowFile: '{workflow_path}/workflow.md'
+outputFile: '{output_folder}/prd.md'
+
+# Task References
+advancedElicitationTask: '{project-root}/{bmad_folder}/core/tasks/advanced-elicitation.xml'
+partyModeWorkflow: '{project-root}/{bmad_folder}/core/workflows/party-mode/workflow.md'
+---
+
 # Step 8: Scoping Exercise - MVP & Future Features
 
 **Progress: Step 8 of 11** - Next: Functional Requirements

--- a/src/modules/bmm/workflows/2-plan-workflows/prd/steps/step-09-functional.md
+++ b/src/modules/bmm/workflows/2-plan-workflows/prd/steps/step-09-functional.md
@@ -1,3 +1,21 @@
+---
+name: 'step-09-functional'
+description: 'Synthesize all discovery into comprehensive functional requirements'
+
+# Path Definitions
+workflow_path: '{project-root}/{bmad_folder}/bmm/workflows/2-plan-workflows/prd'
+
+# File References
+thisStepFile: '{workflow_path}/steps/step-09-functional.md'
+nextStepFile: '{workflow_path}/steps/step-10-nonfunctional.md'
+workflowFile: '{workflow_path}/workflow.md'
+outputFile: '{output_folder}/prd.md'
+
+# Task References
+advancedElicitationTask: '{project-root}/{bmad_folder}/core/tasks/advanced-elicitation.xml'
+partyModeWorkflow: '{project-root}/{bmad_folder}/core/workflows/party-mode/workflow.md'
+---
+
 # Step 9: Functional Requirements Synthesis
 
 **Progress: Step 9 of 11** - Next: Non-Functional Requirements

--- a/src/modules/bmm/workflows/2-plan-workflows/prd/steps/step-10-nonfunctional.md
+++ b/src/modules/bmm/workflows/2-plan-workflows/prd/steps/step-10-nonfunctional.md
@@ -1,3 +1,21 @@
+---
+name: 'step-10-nonfunctional'
+description: 'Define quality attributes that matter for this specific product'
+
+# Path Definitions
+workflow_path: '{project-root}/{bmad_folder}/bmm/workflows/2-plan-workflows/prd'
+
+# File References
+thisStepFile: '{workflow_path}/steps/step-10-nonfunctional.md'
+nextStepFile: '{workflow_path}/steps/step-11-complete.md'
+workflowFile: '{workflow_path}/workflow.md'
+outputFile: '{output_folder}/prd.md'
+
+# Task References
+advancedElicitationTask: '{project-root}/{bmad_folder}/core/tasks/advanced-elicitation.xml'
+partyModeWorkflow: '{project-root}/{bmad_folder}/core/workflows/party-mode/workflow.md'
+---
+
 # Step 10: Non-Functional Requirements
 
 **Progress: Step 10 of 11** - Next: Complete PRD

--- a/src/modules/bmm/workflows/2-plan-workflows/prd/steps/step-11-complete.md
+++ b/src/modules/bmm/workflows/2-plan-workflows/prd/steps/step-11-complete.md
@@ -1,3 +1,16 @@
+---
+name: 'step-11-complete'
+description: 'Complete the PRD workflow, update status files, and suggest next steps'
+
+# Path Definitions
+workflow_path: '{project-root}/{bmad_folder}/bmm/workflows/2-plan-workflows/prd'
+
+# File References
+thisStepFile: '{workflow_path}/steps/step-11-complete.md'
+workflowFile: '{workflow_path}/workflow.md'
+outputFile: '{output_folder}/prd.md'
+---
+
 # Step 11: Workflow Completion
 
 **Final Step - Complete the PRD**

--- a/src/modules/bmm/workflows/document-project/instructions.md
+++ b/src/modules/bmm/workflows/document-project/instructions.md
@@ -196,7 +196,7 @@ Your choice [1/2/3]:
 
 - Mode: {{workflow_mode}}
 - Scan Level: {{scan_level}}
-- Output: {output_folder}/bmm-index.md and related files
+- Output: {output_folder}/index.md and related files
 
 {{#if status_file_found}}
 **Status Updated:**


### PR DESCRIPTION
## Summary

This PR improves the PRD workflow to better handle brownfield projects and standardizes the step file format.

## Changes

### Fix: PRD Workflow Step Count and Documentation
- Fix step files to show correct total (11 steps, not 10)
- Fix path typo in step-01-init.md (step → steps)
- Fix step-01b-continue.md completion condition (10 → 11)
- Remove non-existent workflow references (story-context, validate-architecture)
- Update workflow chains and glossary definitions
- Fix document-project output filename (bmm-index.md → index.md)

### Feature: Brownfield Project Support
Add proper three-branch conditional logic for document-based discovery:
- **PATH A**: Has Product Brief (any project type) - standard flow
- **PATH B**: No Brief + Has Project Docs (brownfield) - asks about NEW features
- **PATH C**: No Documents (greenfield) - from scratch

Additional improvements:
- Add documentCounts to frontmatter for state tracking
- Add YAML frontmatter to all 12 PRD step files
- Standardize step file structure across the workflow

**Key insight**: Branch based on DOCUMENT TYPE, not PROJECT TYPE.

## Files Changed
- 13 PRD step/template files
- 6 documentation files

## Testing
- [x] Manually tested PRD workflow initialization
- [x] Verified brownfield detection logic
- [x] Confirmed step navigation works correctly