### PR TITLE
fix: Link to Gemini Gem manager for creating Gem with web bundle

### DIFF
--- a/docs/web-bundles-gemini-gpt-guide.md
+++ b/docs/web-bundles-gemini-gpt-guide.md
@@ -73,7 +73,7 @@ web-bundles/
 
 **Create a Gem:**
 
-1. Go to [Google AI Studio](https://aistudio.google.com/)
+1. Go to [Gemini Gem manager](https://gemini.google.com/gems/view)
 2. Click "New Gem" or "Create Gem"
 3. Give your Gem a name (e.g., "BMad PM Agent")
 4. **Enable "Code execution" for best results with document generation**


### PR DESCRIPTION
Updated the link for creating a Gem.  

There is no option to create a Gem at https://aistudio.google.com/ .  This page has a "New app" option.

Instead, this option is in the Gemini Gem manager at https://gemini.google.com/gems/view .
