### PR TITLE
chore: disable CodeRabbit review status comments

### DIFF
--- a/.coderabbit.yaml
+++ b/.coderabbit.yaml
@@ -6,7 +6,7 @@ reviews:
   profile: chill
   high_level_summary: true
   request_changes_workflow: false
-  review_status: true
+  review_status: false
   collapse_walkthrough: false
   poem: false
   auto_review:


### PR DESCRIPTION
## Summary
- Disable the useless automatic "Review skipped" comments on PRs
- CodeRabbit remains available on-demand via `@coderabbitai review`
- Until someone invokes CodeRabbit with a `@coderabbit review` comment, it shouldn't appear in the comments on a PR

## Test plan
- [x] Verified `chat.auto_reply: true` still enables on-demand reviews
- [x] Confirm no "Review skipped" comment appears on this PR

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Disabled automatic code review trigger in configuration.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->