### PR TITLE
Look in the local cache for module installer

### DIFF
--- a/tools/cli/installers/lib/modules/manager.js
+++ b/tools/cli/installers/lib/modules/manager.js
@@ -1122,7 +1122,13 @@ class ModuleManager {
     if (moduleName === 'core') {
       sourcePath = getSourcePath('core');
     } else {
-      sourcePath = await this.findModuleSource(moduleName);
+      // First check if module is in cache (for custom modules installed from external directories)
+      const cachePath = path.join(bmadDir, '_cfg', 'custom', moduleName);
+      if (await fs.pathExists(cachePath)) {
+        sourcePath = cachePath;
+      } else {
+        sourcePath = await this.findModuleSource(moduleName);
+      }
       if (!sourcePath) {
         // No source found, skip module installer
         return;


### PR DESCRIPTION
Looks in the local _cfg custom module cache location for the module, in case the module is one that was sourced from an external location.

Without this, the `installer.js` for custom modules is not executed.