### PR TITLE
fix: correct markdown formatting in product-brief next steps

### DIFF
--- a/src/modules/bmm/workflows/1-analysis/product-brief/steps/step-06-complete.md
+++ b/src/modules/bmm/workflows/1-analysis/product-brief/steps/step-06-complete.md
@@ -119,7 +119,10 @@ Provide guidance on logical next workflows:
    - Success metrics become specific acceptance criteria
    - MVP scope becomes detailed feature specifications
 
-**Other Potential Next Steps:** 2. `workflow create-ux-design` - UX research and design 3. `workflow create-architecture` - Technical architecture planning 4. `workflow domain-research` - Deep market or domain research (if needed)
+**Other Potential Next Steps:**
+
+2. `workflow create-ux-design` - UX research and design (can run parallel with PRD)
+3. `workflow domain-research` - Deep market or domain research (if needed)
 
 **Strategic Considerations:**
 
@@ -145,7 +148,6 @@ The brief captures everything needed to guide subsequent product development:
 
 - PRD workflow for detailed requirements?
 - UX design workflow for user experience planning?
-- Architecture workflow for technical design?
 
 **Product Brief Complete**"
 


### PR DESCRIPTION
## Summary

- Fixed malformed markdown where multiple list items were crammed on one line
- Removed Architecture from suggested next steps (it requires PRD first)

## Details

The product-brief completion step had a formatting issue where Other Potential Next Steps was a single line with items 2, 3, 4 concatenated. This made Architecture appear as an equal option when it actually requires PRD to be completed first (enforced by architecture step-01-init.md).

Fixes #1080

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Documentation
* Updated Product Brief workflow documentation to clarify next steps following initial analysis
* Removed Architecture workflow from potential subsequent steps
* Clarified that UX design can proceed in parallel with PRD development
* Improved formatting for better readability

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->