### PR TITLE
fix(bmm): improve code review completion message

### DIFF
--- a/src/modules/bmm/workflows/4-implementation/code-review/instructions.xml
+++ b/src/modules/bmm/workflows/4-implementation/code-review/instructions.xml
@@ -217,7 +217,7 @@
       **Issues Fixed:** {{fixed_count}}
       **Action Items Created:** {{action_count}}
 
-      {{#if new_status == "done"}}Story is ready for next work!{{else}}Address the action items and continue development.{{/if}}
+      {{#if new_status == "done"}}Code review complete!{{else}}Address the action items and continue development.{{/if}}
     </output>
   </step>
 


### PR DESCRIPTION
## Summary
- Changes the code review workflow completion message from "Story is ready for next work!" to "Code review complete!"
- The original phrasing was misleading - when a review finishes with status "done", it means the review itself is complete and the story is marked done in tracking
- The user may choose to do additional reviews or the story may genuinely be finished, so "Code review complete" more accurately describes the outcome without implying next steps

## Test plan
- [x] All existing tests pass
- [ ] Run code-review workflow and verify the new message displays correctly when review completes with "done" status