### PR TITLE
docs: test architect ADR usage update

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "bmad-method",
-  "version": "6.0.0-alpha.15",
+  "version": "6.0.0-alpha.16",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "bmad-method",
-      "version": "6.0.0-alpha.15",
+      "version": "6.0.0-alpha.16",
       "license": "MIT",
       "dependencies": {
         "@kayvan/markdown-tree-parser": "^1.6.1",


### PR DESCRIPTION
Tweaks the test-architect docs to highlight that *test-design is also usable during ADR phase, as well as Epics.