### PR TITLE
fix(bmm): add sprint_artifacts alias for workflow compatibility

### DIFF
--- a/src/modules/bmm/module.yaml
+++ b/src/modules/bmm/module.yaml
@@ -39,6 +39,10 @@ implementation_artifacts: # Phase 4 artifacts and quick-dev flow output
   default: "{output_folder}/implementation-artifacts"
   result: "{project-root}/{value}"
 
+# Alias for workflow compatibility
+sprint_artifacts:
+  inherit: "implementation_artifacts"
+
 project_knowledge: # Artifacts from research, document-project output, other long lived accurate knowledge
   prompt: "Where should non-ephemeral project knowledge be searched for and stored\n(docs, research, references)?"
   default: "docs"


### PR DESCRIPTION
## What

Add `sprint_artifacts` configuration alias to BMM module.yaml, matching the pattern already used in BMGD module.

## Why

Without this alias, stories are saved directly in `_bmad-output/` instead of `_bmad-output/implementation-artifacts/`. The `create-story` and `dev-story` workflows reference `{config_source}:sprint_artifacts`, but BMM's generated config.yaml defaults this to `output_folder` instead of inheriting from `implementation_artifacts`.

Fixes #1170

## How

- Added `sprint_artifacts: inherit: "implementation_artifacts"` after `implementation_artifacts` definition in `src/modules/bmm/module.yaml`
- This mirrors the existing pattern in BMGD module (lines 42-44)

## Testing

- Verified that BMGD module has this alias and works correctly
- Confirmed the fix resolves the path issue in a test project

🤖 Generated with [Claude Code](https://claude.com/claude-code)