### PR TITLE
Mixed line endings (Windows CRLF problem)

### DIFF
--- a/tools/cli/commands/install.js
+++ b/tools/cli/commands/install.js
@@ -10,9 +10,15 @@ const ui = new UI();
 module.exports = {
   command: 'install',
   description: 'Install BMAD Core agents and tools',
-  options: [],
+  options: [['-d, --debug', 'Enable debug output for manifest generation']],
   action: async (options) => {
     try {
+      // Set debug flag as environment variable for all components
+      if (options.debug) {
+        process.env.BMAD_DEBUG_MANIFEST = 'true';
+        console.log(chalk.cyan('Debug mode enabled\n'));
+      }
+
       const config = await ui.promptInstall();
 
       // Handle cancel


### PR DESCRIPTION
# Pull Request: Fix Windows CRLF Line Ending Issues

## What

Added line ending normalization in manifest generator to fix YAML parsing failures on Windows.

## Why

Windows line endings (CRLF) were causing YAML parsing errors during installation: "Implicit map keys need to be followed by map values". This prevented workflow files from being properly registered in the manifest.

Fixes #1223

## How

- Added line ending normalization (`\r\n` → `\n`) in `manifest-generator.js` before YAML parsing
- Added `--debug` CLI flag for troubleshooting manifest generation issues

## Testing

Tested `bmad install --debug` on Windows. All 51 workflow files now parse correctly without YAML errors.

### before
<img width="288" height="374" alt="image" src="https://github.com/user-attachments/assets/40c26823-bf4b-4ac6-a1e9-a0ce89fd3575" />

### after fix
<img width="294" height="898" alt="image" src="https://github.com/user-attachments/assets/2be3486f-e6ec-4012-9886-f9eedb14715a" />
<img width="1294" height="858" alt="image" src="https://github.com/user-attachments/assets/ceecb1c8-0dbe-4dde-a485-31e3afe22d60" />

---

## Files Changed

| File | Change |
|------|--------|
| `tools/cli/installers/lib/core/manifest-generator.js` | Added line ending normalization and debug logging |
| `tools/cli/commands/install.js` | Added `--debug` CLI option |







