### PR TITLE
fix: *code-review is picking up non-application files

### DIFF
--- a/src/modules/bmgd/workflows/4-production/code-review/instructions.xml
+++ b/src/modules/bmgd/workflows/4-production/code-review/instructions.xml
@@ -12,6 +12,7 @@
   <critical>Read EVERY file in the File List - verify implementation against story requirements</critical>
   <critical>Tasks marked complete but not done = CRITICAL finding</critical>
   <critical>Acceptance Criteria not implemented = HIGH severity finding</critical>
+  <critical>Do not review files that are not part of the application's source code. Always exclude the _bmad/ and _bmad-output/ folders from the review. Always exclude IDE and CLI configuration folders like .cursor/ and .windsurf/ and .claude/</critical>
 
   <step n="1" goal="Load story and discover changes">
     <action>Use provided {{story_path}} or ask user which story file to review</action>

--- a/src/modules/bmm/workflows/4-implementation/code-review/instructions.xml
+++ b/src/modules/bmm/workflows/4-implementation/code-review/instructions.xml
@@ -12,6 +12,8 @@
   <critical>Read EVERY file in the File List - verify implementation against story requirements</critical>
   <critical>Tasks marked complete but not done = CRITICAL finding</critical>
   <critical>Acceptance Criteria not implemented = HIGH severity finding</critical>
+  <critical>Do not review files that are not part of the application's source code. Always exclude the _bmad/ and _bmad-output/ folders from the review. Always exclude IDE and CLI configuration folders like .cursor/ and .windsurf/ and .claude/</critical>
+
 
   <step n="1" goal="Load story and discover changes">
     <action>Use provided {{story_path}} or ask user which story file to review</action>


### PR DESCRIPTION
Fix for PR: [1230]


**Describe the bug**
When performing a *code-review, the dev agent is picking up changes in {project_root}/.claude and {project_root}/_bmad-output. It then adds comments in the current development story about modifications to those files. These are not application code files and should not be included in a code review. The dev agent (using Opus) does not include them in the change log, but the review (using Sonnet) detects them, then adds a "fix" to include them in the change log.

**Steps to Reproduce**
Run the following commands: 

```bash
/create-story
/dev-story
/code-review <- Agent reviews files in non-application related locations.
```

**PR**
Modify: _bmad\bmm\workflows\4-implementation\code-review\instructions.xml

```xml
<check if="git repository exists">
           ....
          <action>EXCLUDE from review: Files in .claude/, _bmad/ and _bmad-output/ directories (framework/tooling files, not application code)</action>
    </check>
```

**Expected behavior**
Only application files should be included in the code review.

**Please be Specific if relevant**
Model(s) Used: Claude Sonnet 4.5
Agentic IDE Used: Claude-Code
WebSite Used: N/A
Project Language: TypeScript
BMad Method version: 6.0.0-alpha.21

**Screenshots or Links**
If applicable, add screenshots or links (if web sharable record) to help explain your problem.

**Additional context**
Add any other context about the problem here. The more information you can provide, the easier it will be to suggest a fix or resolve
