### PR TITLE
fix: Clarify quick flow tech-spec plan wording

### DIFF
--- a/src/modules/bmm/workflows/bmad-quick-flow/create-tech-spec/steps/step-03-generate.md
+++ b/src/modules/bmm/workflows/bmad-quick-flow/create-tech-spec/steps/step-03-generate.md
@@ -10,7 +10,6 @@ wipFile: '{implementation_artifacts}/tech-spec-wip.md'
 # Step 3: Generate Implementation Plan
 
 **Progress: Step 3 of 4** - Next: Review & Finalize
-+**Note:** This step updates the existing tech-spec with the implementation plan; it does not create a new spec.
 
 ## RULES:
 


### PR DESCRIPTION
### What
* rename the Step 2 checkpoint menu option to say "Generate Plan" so it matches the next step

### Why
When going through the quick-dev workflow it was confusing to have the choice to "Generate Spec" when I already _have_ a tech spec.  The next step is actually to generate the implementation _plan_. 

```
[a] Advanced Elicitation - explore more context
[c] Continue - proceed to Generate Spec
[p] Party Mode - bring in other experts

c     #<---- user input 

Loading Step 3: Generate Plan.
```