### PR TITLE
docs: update README links to new documentation site

### DIFF
--- a/README.md
+++ b/README.md
@@ -24,8 +24,8 @@ The completely revamped **BMAD V6 installer** now includes built-in support for 
 
 **📚 Learn More:**
 
-- [**Custom Content Overview**](docs/modules/bmb-bmad-builder/custom-content.md) - Discover all supported content types
-- [**Installation Guide**](docs/modules/bmb-bmad-builder/custom-content-installation.md) - Learn to create and install custom content
+- [**Custom Content Overview**](http://docs.bmad-method.org/explanation/bmad-builder/custom-content-types/) - Discover all supported content types
+- [**Installation Guide**](http://docs.bmad-method.org/how-to/installation/install-custom-modules/) - Learn to create and install custom content
 - [**2 Very simple Custom Modules of questionable quality**](./samples/sample-custom-modules/README.md) - if you want to download and try to install a custom shared module, get an idea of how to bundle and share your own, or create your own personal agents, workflows and modules.
 
 </div>
@@ -67,7 +67,7 @@ With **BMad Builder**, you can architect both simple agents and vastly complex d
 ## 📊 See It In Action
 
 <p align="center">
-  <img src="./docs/modules/bmm-bmad-method/images/workflow-method-greenfield.svg" alt="BMad Method Workflow" width="100%">
+  <img src="./docs/tutorials/getting-started/images/workflow-method-greenfield.svg" alt="BMad Method Workflow" width="100%">
 </p>
 
 <p align="center">
@@ -146,17 +146,17 @@ Each agent brings deep expertise and can be customized to match your team's styl
   - 12 specialized agents
   - 34 workflows across 4 phases
   - Stand Along Quick Spec Flow for a streamlined simple implementation process
-  - [→ Documentation Hub](./docs/modules/bmm-bmad-method/index.md)
+  - [→ Documentation Hub](http://docs.bmad-method.org/explanation/bmm/)
 
 - **BMad Builder (BMB)** - Create custom agents and workflows
   - Build anything from simple agents to complex modules
   - Create domain-specific solutions (legal, medical, finance, education)
-  - [→ Builder Guide](./docs/modules/bmb-bmad-builder/index.md)
+  - [→ Builder Guide](http://docs.bmad-method.org/explanation/bmad-builder/)
 
 - **Creative Intelligence Suite (CIS)** - Innovation & problem-solving
   - Brainstorming, design thinking, storytelling
   - 5 creative facilitation workflows
-  - [→ Creative Workflows](./docs/modules/cis-creative-intelligence-suite/index.md)
+  - [→ Creative Workflows](http://docs.bmad-method.org/explanation/creative-intelligence/)
 
 ### Key Features
 
@@ -170,15 +170,15 @@ Each agent brings deep expertise and can be customized to match your team's styl
 
 ### Quick Links
 
-- **[Quick Start Guide](./docs/modules/bmm-bmad-method/quick-start.md)** - 15-minute introduction
-- **[Complete BMM Documentation](./docs/modules/bmm-bmad-method/index.md)** - All guides and references
-- **[Agent Customization](docs/bmad-customization/agent-customization-guide.md)** - Personalize your agents
-- **[All Documentation](./docs/index.md)** - Complete documentation index
+- **[Quick Start Guide](http://docs.bmad-method.org/tutorials/getting-started/getting-started-bmadv6/)** - 15-minute introduction
+- **[Complete BMM Documentation](http://docs.bmad-method.org/explanation/bmm/)** - All guides and references
+- **[Agent Customization](http://docs.bmad-method.org/how-to/customization/customize-agents/)** - Personalize your agents
+- **[All Documentation](http://docs.bmad-method.org/)** - Complete documentation index
 
 ### For v4 Users
 
 - **[v4 Documentation](https://github.com/bmad-code-org/BMAD-METHOD/tree/V4/docs)**
-- **[v4 to v6 Upgrade Guide](./docs/v4-to-v6-upgrade.md)**
+- **[v4 to v6 Upgrade Guide](http://docs.bmad-method.org/how-to/installation/upgrade-to-v6/)**
 
 ## 💬 Community & Support
 
@@ -211,7 +211,7 @@ If you would like to contribute, first check the [CONTRIBUTING.md](CONTRIBUTING.
 
 ### 🔄 For v4 Users
 
-- **[Comprehensive Upgrade Guide](./docs/v4-to-v6-upgrade.md)** - Step-by-step migration
+- **[Comprehensive Upgrade Guide](http://docs.bmad-method.org/how-to/installation/upgrade-to-v6/)** - Step-by-step migration
 - **[v4 Documentation Archive](https://github.com/bmad-code-org/BMAD-METHOD/tree/V4)** - Legacy reference
 - Backwards compatibility where possible
 - Smooth migration path with installer detection


### PR DESCRIPTION
## Summary
- Updates documentation site links in README.md to use HTTP instead of HTTPS
- Changes all `https://docs.bmad-method.org/` links to `http://docs.bmad-method.org/`

## Test plan
- [ ] Verify all documentation links resolve correctly