### PR TITLE
fix: add missing review menu and HALT to quick-spec step 4

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -47,7 +47,7 @@
         "jest": "^30.0.4",
         "lint-staged": "^16.1.1",
         "markdownlint-cli2": "^0.19.1",
-        "prettier": "^3.5.3",
+        "prettier": "^3.7.4",
         "prettier-plugin-packagejson": "^2.5.19",
         "sharp": "^0.33.5",
         "yaml-eslint-parser": "^1.2.3",
@@ -244,6 +244,7 @@
       "integrity": "sha512-e7jT4DxYvIDLk1ZHmU/m/mB19rex9sv0c2ftBtjSBv+kVM/902eh0fINUzD7UwLLNR+jU585GxUJ8/EBfAM5fw==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@babel/code-frame": "^7.27.1",
         "@babel/generator": "^7.28.5",
@@ -3642,6 +3643,7 @@
       "integrity": "sha512-W609buLVRVmeW693xKfzHeIV6nJGGz98uCPfeXI1ELMLXVeKYZ9m15fAMSaUPBHYLGFsVRcMmSCksQOrZV9BYA==",
       "devOptional": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "undici-types": "~7.16.0"
       }
@@ -3981,6 +3983,7 @@
       "integrity": "sha512-NZyJarBfL7nWwIq+FDL6Zp/yHEhePMNnnJ0y3qfieCrmNvYct8uvtiV41UvlSe6apAfk0fY1FbWx+NwfmpvtTg==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "bin": {
         "acorn": "bin/acorn"
       },
@@ -4287,6 +4290,7 @@
       "integrity": "sha512-6mF/YrvwwRxLTu+aMEa5pwzKUNl5ZetWbTyZCs9Um0F12HUmxUiF5UHiZPy4rifzU3gtpM3xP2DfdmkNX9eZRg==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@astrojs/compiler": "^2.13.0",
         "@astrojs/internal-helpers": "0.7.5",
@@ -5354,6 +5358,7 @@
         }
       ],
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "baseline-browser-mapping": "^2.9.0",
         "caniuse-lite": "^1.0.30001759",
@@ -6684,6 +6689,7 @@
       "integrity": "sha512-LEyamqS7W5HB3ujJyvi0HQK/dtVINZvd5mAAp9eT5S/ujByGjiZLCzPcHVzuXbpJDJF/cxwHlfceVUDZ2lnSTw==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@eslint-community/eslint-utils": "^4.8.0",
         "@eslint-community/regexpp": "^4.12.1",
@@ -10298,6 +10304,7 @@
       "integrity": "sha512-p3JTemJJbkiMjXEMiFwgm0v6ym5g8K+b2oDny+6xdl300tUKySxvilJQLSea48C6OaYNmO30kH9KxpiAg5bWJw==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "globby": "15.0.0",
         "js-yaml": "4.1.1",
@@ -12371,6 +12378,7 @@
         }
       ],
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "nanoid": "^3.3.11",
         "picocolors": "^1.1.1",
@@ -12436,6 +12444,7 @@
       "integrity": "sha512-v6UNi1+3hSlVvv8fSaoUbggEM5VErKmmpGA7Pl3HF8V6uKY7rvClBOJlH6yNwQtfTueNkGVpOv/mtWL9L4bgRA==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "bin": {
         "prettier": "bin/prettier.cjs"
       },
@@ -13264,6 +13273,7 @@
       "integrity": "sha512-3nk8Y3a9Ea8szgKhinMlGMhGMw89mqule3KWczxhIzqudyHdCIOHw8WJlj/r329fACjKLEh13ZSk7oE22kyeIw==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@types/estree": "1.0.8"
       },
@@ -14827,6 +14837,7 @@
       "integrity": "sha512-+Oxm7q9hDoLMyJOYfUYBuHQo+dkAloi33apOPP56pzj+vsdJDzr+j1NISE5pyaAuKL4A3UD34qd0lx5+kfKp2g==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "esbuild": "^0.25.0",
         "fdir": "^6.4.4",
@@ -15100,6 +15111,7 @@
       "resolved": "https://registry.npmjs.org/yaml/-/yaml-2.8.2.tgz",
       "integrity": "sha512-mplynKqc1C2hTVYxd0PU2xQAc22TI1vShAYGksCCfxbn/dFwnHTNi1bvYsBTkhdUNtGIf5xNOg938rrSSYvS9A==",
       "license": "ISC",
+      "peer": true,
       "bin": {
         "yaml": "bin.mjs"
       },
@@ -15291,6 +15303,7 @@
       "integrity": "sha512-gzUt/qt81nXsFGKIFcC3YnfEAx5NkunCfnDlvuBSSFS02bcXu4Lmea0AFIUwbLWxWPx3d9p8S5QoaujKcNQxcQ==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "funding": {
         "url": "https://github.com/sponsors/colinhacks"
       }

--- a/package.json
+++ b/package.json
@@ -101,7 +101,7 @@
     "jest": "^30.0.4",
     "lint-staged": "^16.1.1",
     "markdownlint-cli2": "^0.19.1",
-    "prettier": "^3.5.3",
+    "prettier": "^3.7.4",
     "prettier-plugin-packagejson": "^2.5.19",
     "sharp": "^0.33.5",
     "yaml-eslint-parser": "^1.2.3",

--- a/src/modules/bmm/workflows/bmad-quick-flow/quick-spec/steps/step-04-review.md
+++ b/src/modules/bmm/workflows/bmad-quick-flow/quick-spec/steps/step-04-review.md
@@ -39,9 +39,27 @@ wipFile: '{implementation_artifacts}/tech-spec-wip.md'
 
 - {task_count} tasks to implement
 - {ac_count} acceptance criteria to verify
-- {files_count} files to modify
+- {files_count} files to modify"
 
-Does this capture your intent? Any changes needed?"
+**Present review menu:**
+
+```
+[y] Approve - finalize the spec
+[c] Changes - request modifications
+[q] Questions - ask about any section
+[a] Advanced Elicitation - dig deeper before approving
+[p] Party Mode - get expert feedback before approving
+```
+
+**HALT and wait for user selection.**
+
+#### Menu Handling:
+
+- **[y]**: Proceed to Section 3 (Finalize the Spec)
+- **[c]**: Proceed to Section 2 (Handle Review Feedback), then return here and redisplay menu
+- **[q]**: Answer questions, then redisplay this menu
+- **[a]**: Load and execute `{advanced_elicitation}`, then return here and redisplay menu
+- **[p]**: Load and execute `{party_mode_exec}`, then return here and redisplay menu
 
 ### 2. Handle Review Feedback
 

--- a/src/modules/cis/module.yaml
+++ b/src/modules/cis/module.yaml
@@ -4,6 +4,7 @@ header: "Creative Innovation Suite (CIS) Module"
 subheader: "No custom configuration required - uses Core settings only"
 default_selected: false # This module will not be selected by default for new installations
 
+
 # Variables from Core Config inserted:
 ## user_name
 ## communication_language


### PR DESCRIPTION
## Summary

- Adds structured review menu with explicit HALT to quick-spec step 4
- Replaces confusing open-ended question with clear options
- Aligns step 4 with the menu-driven pattern used in steps 1-3
- Bumps prettier from ^3.5.3 to ^3.7.4 to match lockfile (fixes CI mismatch)

Fixes #1304

## Test plan

- [ ] Run quick-spec workflow through step 4
- [ ] Verify menu is displayed after spec presentation
- [ ] Verify workflow halts and waits for user selection

🤖 Generated with [Claude Code](https://claude.ai/claude-code)