### PR TITLE
Prevent deployment of docs on forked repositories

### DIFF
--- a/.github/workflows/docs.yaml
+++ b/.github/workflows/docs.yaml
@@ -52,6 +52,8 @@ jobs:
           path: build/site
 
   deploy:
+    # Don't run on forked repositories
+    if: github.event.repository.fork != true
     environment:
       name: github-pages
       url: ${{ steps.deployment.outputs.page_url }}


### PR DESCRIPTION
Whenever I sync my fork of BMAD-METHOD I notice that all the GitHub Actions (Workflows) try to run.
Example: https://github.com/wsmoak/BMAD-METHOD/actions/runs/20866029502

Let's try to prevent the docs deployment from running on forks, since that is never going to work.

Inspired by: https://beckysweger.com/2025/01/02/skip-a-job-in-a.html

In another repository we tried
if: ${{ github.repository == 'the-organization/the-repository' }}
which seems like it should have worked, but it did not.