### PR TITLE
feat(prd): enforce FR number immutability in edit workflows

### DIFF
--- a/src/modules/bmm/workflows/2-plan-workflows/prd/steps-c/step-09-functional.md
+++ b/src/modules/bmm/workflows/2-plan-workflows/prd/steps-c/step-09-functional.md
@@ -224,6 +224,10 @@ When user selects 'C', append the content directly to the document using the str
 
 Emphasize to user: "This FR list is now binding. Any feature not listed here will not exist in the final product unless we explicitly add it. This is why it's critical to ensure completeness now."
 
+## ⚠️ FR IMMUTABILITY:
+
+Before saving, warn user: "FR numbers become **immutable IDs** after this step. New FRs always get next sequential ID (no inserting/reordering). Can mark `[DEPRECATED]` or add `[Supersedes FRx]`. Review carefully."
+
 ## NEXT STEP:
 
 After user selects 'C' and content is saved to document, load {nextStepFile} to define non-functional requirements.

--- a/src/modules/bmm/workflows/2-plan-workflows/prd/steps-e/step-e-01-discovery.md
+++ b/src/modules/bmm/workflows/2-plan-workflows/prd/steps-e/step-e-01-discovery.md
@@ -158,6 +158,8 @@ Please describe the changes you want to make. For example:
 
 **Wait for user to describe their requirements.**
 
+**IF user wants to modify/reorder existing FRs:** FR numbers are IDs - redirect to allowed operations (add new sequential FRs, mark `[DEPRECATED]`, or `[Supersedes]`).
+
 ### 7. Detect PRD Format
 
 Analyze the loaded PRD:

--- a/src/modules/bmm/workflows/2-plan-workflows/prd/steps-e/step-e-02-review.md
+++ b/src/modules/bmm/workflows/2-plan-workflows/prd/steps-e/step-e-02-review.md
@@ -123,6 +123,14 @@ Return detailed change plan with section breakdown."
 - Content to remove (if incorrect/leakage)
 - Structure changes (if reformatting needed)
 
+### 2.1 FR Immutability Check
+
+FR numbers are **IDs**, not logical order. IF plan includes FR modifications, block and redirect:
+- ✅ New FRs get next ID (FR1-10 exists → FR11, even if extending FR6)
+- ✅ Add `[DEPRECATED]` prefix to obsolete FRs
+- ✅ Add `[Supersedes FRx]` to replacement FRs
+- ❌ Never modify/delete/reorder/renumber existing FRs
+
 ### 3. Prepare Change Plan Summary
 
 **Summary sections:**
@@ -245,5 +253,6 @@ Load and execute {nextStepFile} (step-e-03-edit.md)
 - Missing section-by-section breakdown
 - Not prioritizing changes
 - Proceeding without user approval
+- Approving FR modifications (immutability violation)
 
 **Master Rule:** Plan before editing. Thorough analysis ensures we make the right changes in the right order. User approval prevents misalignment.

--- a/src/modules/bmm/workflows/2-plan-workflows/prd/steps-e/step-e-03-edit.md
+++ b/src/modules/bmm/workflows/2-plan-workflows/prd/steps-e/step-e-03-edit.md
@@ -124,6 +124,16 @@ Apply changes and return updated section."
 Changes: {brief summary}
 {More sections remaining...}"
 
+### 3.1 FR Immutability Enforcement
+
+FR numbers are **IDs**, not logical order:
+- ✅ New FRs get next sequential ID (FR1-10 → FR11, regardless of conceptual grouping)
+- ✅ Add `[DEPRECATED]` prefix (preserve original text)
+- ✅ Add `[Supersedes FRx]` to replacement FRs
+- ❌ Never modify/delete/reorder/renumber existing FRs
+
+**IF violation detected:** STOP, return to step-e-02-review.md
+
 ### 4. Handle Restructuring (If Needed)
 
 **If conversion mode is "Full restructuring" or "Both":**
@@ -249,5 +259,6 @@ Display:
 - Not updating frontmatter
 - No final verification
 - Not saving updated PRD
+- Modifying/deleting/renumbering existing FRs (immutability violation)
 
 **Master Rule:** Execute the plan exactly as approved. PRD is now ready for validation or downstream use. Validation integration ensures quality.


### PR DESCRIPTION
## What

Enforce FR numbers as immutable IDs in PRD edit workflows. New FRs must use next sequential ID regardless of conceptual grouping.

## Why

FR numbers are referenced by downstream artifacts (Epics, Stories, Tests, Architecture). Modifying/reordering them breaks traceability across the entire development chain.

Fixes #N/A - proactive improvement

## How

- Added immutability warning in `step-09-functional.md` before saving FRs
- Added early redirect in `step-e-01-discovery.md` when user requests FR modifications
- Added immutability check in `step-e-02-review.md` to block plans with FR modifications
- Added enforcement in `step-e-03-edit.md` with violation detection

Allowed operations:
- ✅ Add new FRs with next sequential ID (FR1-10 → FR11)
- ✅ Mark obsolete: `[DEPRECATED]`
- ✅ Supersede: `[Supersedes FRx]`

Forbidden:
- ❌ Modify/delete/reorder/renumber existing FRs

## Testing

Manual review of workflow step files. Changes are additive (28 lines) and minimal.

🤖 Generated with [Claude Code](https://claude.com/claude-code)