### PR TITLE
chore: add .github/agents to gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -61,6 +61,7 @@ _bmad-output
 .claude
 .codex
 .github/chatmodes
+.github/agents
 .agent
 .agentvibes/
 .kiro/


### PR DESCRIPTION
## Summary
- Adds `.github/agents` to the gitignore file

## Test plan
- [x] Verify the entry is correctly added to .gitignore

🤖 Generated with [Claude Code](https://claude.com/claude-code)