### PR TITLE
fix: add sprint-status.yaml sync to correct-course workflow

### DIFF
--- a/src/bmm/workflows/4-implementation/correct-course/checklist.md
+++ b/src/bmm/workflows/4-implementation/correct-course/checklist.md
@@ -253,6 +253,15 @@
 </check-item>
 
 <check-item id="6.4">
+<prompt>Update sprint-status.yaml to reflect approved epic changes</prompt>
+<action>If epics were added: Add new epic entries with status 'backlog'</action>
+<action>If epics were removed: Remove corresponding entries</action>
+<action>If epics were renumbered: Update epic IDs and story references</action>
+<action>If stories were added/removed: Update story entries within affected epics</action>
+<status>[ ] Done / [ ] N/A / [ ] Action-needed</status>
+</check-item>
+
+<check-item id="6.5">
 <prompt>Confirm next steps and handoff plan</prompt>
 <action>Review handoff responsibilities with user</action>
 <action>Ensure all stakeholders understand their roles</action>


### PR DESCRIPTION
## Summary

- The correct-course workflow restructures epics (add, remove, renumber) but did not update `sprint-status.yaml`, leaving tracking out of sync
- Added check-item 6.4 to Section 6 of `checklist.md` (after user approval gate) to update sprint-status.yaml when epic structure changes

## Changes

New check-item handles:
- Adding new epic entries with status 'backlog'
- Removing epic entries when descoped
- Renumbering epic IDs and story references
- Adding/removing story entries within affected epics

## Test plan

- [x] Verified diagnosis by reading workflow files
- [x] Ran 5 parallel test scenarios in `/tmp/correct-course-test/`:
  - Add new epic (Epic 4 + stories)
  - Remove epic (Epic 3 descoped)
  - Renumber epics (swap Epic 2 ↔ Epic 3)
  - Add stories to existing epic
  - Remove story from epic
- [x] All tests passed

🤖 Generated with [Claude Code](https://claude.com/claude-code)