### PR TITLE
refactor: replace 'execute' with 'Read fully and follow:' in workflow prompts

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,5 +1,5 @@
 # Dependencies
-node_modules/
+**/node_modules/
 pnpm-lock.yaml
 bun.lock
 deno.lock

--- a/.markdownlint-cli2.yaml
+++ b/.markdownlint-cli2.yaml
@@ -2,7 +2,7 @@
 # https://github.com/DavidAnson/markdownlint-cli2
 
 ignores:
-  - node_modules/**
+  - "**/node_modules/**"
   - test/fixtures/**
   - CODE_OF_CONDUCT.md
   - _bmad/**

--- a/src/bmm/workflows/1-analysis/create-product-brief/steps/step-01-init.md
+++ b/src/bmm/workflows/1-analysis/create-product-brief/steps/step-01-init.md
@@ -141,7 +141,7 @@ Display: "**Proceeding to product vision discovery...**"
 
 #### Menu Handling Logic:
 
-- After setup report is presented, immediately load, read entire file, then execute {nextStepFile}
+- After setup report is presented, without delay, read fully and follow: {nextStepFile}
 
 #### EXECUTION RULES:
 
@@ -150,7 +150,7 @@ Display: "**Proceeding to product vision discovery...**"
 
 ## CRITICAL STEP COMPLETION NOTE
 
-ONLY WHEN [setup completion is achieved and frontmatter properly updated], will you then load and read fully `{nextStepFile}` to execute and begin product vision discovery.
+ONLY WHEN [setup completion is achieved and frontmatter properly updated], will you then read fully and follow: `{nextStepFile}` to begin product vision discovery.
 
 ---
 

--- a/src/bmm/workflows/1-analysis/create-product-brief/steps/step-01b-continue.md
+++ b/src/bmm/workflows/1-analysis/create-product-brief/steps/step-01b-continue.md
@@ -125,7 +125,7 @@ Display: "Ready to continue with Step {nextStepNumber}: {nextStepTitle}?
 
 #### Menu Handling Logic:
 
-- IF C: Load, read entire file, then execute the appropriate next step file based on `lastStep`
+- IF C: Read fully and follow the appropriate next step file based on `lastStep`
 - IF Any other comments or queries: respond and redisplay menu
 
 #### EXECUTION RULES:
@@ -136,7 +136,7 @@ Display: "Ready to continue with Step {nextStepNumber}: {nextStepTitle}?
 
 ## CRITICAL STEP COMPLETION NOTE
 
-ONLY WHEN [C continue option] is selected and [current state confirmed], will you then load and read fully the appropriate next step file to resume the workflow.
+ONLY WHEN [C continue option] is selected and [current state confirmed], will you then read fully and follow the appropriate next step file to resume the workflow.
 
 ---
 

--- a/src/bmm/workflows/1-analysis/create-product-brief/steps/step-02-vision.md
+++ b/src/bmm/workflows/1-analysis/create-product-brief/steps/step-02-vision.md
@@ -156,9 +156,9 @@ Prepare the following structure for document append:
 
 #### Menu Handling Logic:
 
-- IF A: Execute {advancedElicitationTask} with current vision content to dive deeper and refine
-- IF P: Execute {partyModeWorkflow} to bring different perspectives to positioning and differentiation
-- IF C: Save content to {outputFile}, update frontmatter with stepsCompleted: [1, 2], then only then load, read entire file, then execute {nextStepFile}
+- IF A: Read fully and follow: {advancedElicitationTask} with current vision content to dive deeper and refine
+- IF P: Read fully and follow: {partyModeWorkflow} to bring different perspectives to positioning and differentiation
+- IF C: Save content to {outputFile}, update frontmatter with stepsCompleted: [1, 2], then read fully and follow: {nextStepFile}
 - IF Any other comments or queries: help user respond then [Redisplay Menu Options](#7-present-menu-options)
 
 #### EXECUTION RULES:
@@ -170,7 +170,7 @@ Prepare the following structure for document append:
 
 ## CRITICAL STEP COMPLETION NOTE
 
-ONLY WHEN [C continue option] is selected and [vision content finalized and saved to document with frontmatter updated], will you then load and read fully `{nextStepFile}` to execute and begin target user discovery.
+ONLY WHEN [C continue option] is selected and [vision content finalized and saved to document with frontmatter updated], will you then read fully and follow: `{nextStepFile}` to begin target user discovery.
 
 ---
 

--- a/src/bmm/workflows/1-analysis/create-product-brief/steps/step-03-users.md
+++ b/src/bmm/workflows/1-analysis/create-product-brief/steps/step-03-users.md
@@ -159,9 +159,9 @@ Prepare the following structure for document append:
 
 #### Menu Handling Logic:
 
-- IF A: Execute {advancedElicitationTask} with current user content to dive deeper into personas and journeys
-- IF P: Execute {partyModeWorkflow} to bring different perspectives to validate user understanding
-- IF C: Save content to {outputFile}, update frontmatter with stepsCompleted: [1, 2, 3], then only then load, read entire file, then execute {nextStepFile}
+- IF A: Read fully and follow: {advancedElicitationTask} with current user content to dive deeper into personas and journeys
+- IF P: Read fully and follow: {partyModeWorkflow} to bring different perspectives to validate user understanding
+- IF C: Save content to {outputFile}, update frontmatter with stepsCompleted: [1, 2, 3], then read fully and follow: {nextStepFile}
 - IF Any other comments or queries: help user respond then [Redisplay Menu Options](#6-present-menu-options)
 
 #### EXECUTION RULES:
@@ -173,7 +173,7 @@ Prepare the following structure for document append:
 
 ## CRITICAL STEP COMPLETION NOTE
 
-ONLY WHEN [C continue option] is selected and [user personas finalized and saved to document with frontmatter updated], will you then load and read fully `{nextStepFile}` to execute and begin success metrics definition.
+ONLY WHEN [C continue option] is selected and [user personas finalized and saved to document with frontmatter updated], will you then read fully and follow: `{nextStepFile}` to begin success metrics definition.
 
 ---
 

--- a/src/bmm/workflows/1-analysis/create-product-brief/steps/step-04-metrics.md
+++ b/src/bmm/workflows/1-analysis/create-product-brief/steps/step-04-metrics.md
@@ -162,9 +162,9 @@ Prepare the following structure for document append:
 
 #### Menu Handling Logic:
 
-- IF A: Execute {advancedElicitationTask} with current metrics content to dive deeper into success metric insights
-- IF P: Execute {partyModeWorkflow} to bring different perspectives to validate comprehensive metrics
-- IF C: Save content to {outputFile}, update frontmatter with stepsCompleted: [1, 2, 3, 4], then only then load, read entire file, then execute {nextStepFile}
+- IF A: Read fully and follow: {advancedElicitationTask} with current metrics content to dive deeper into success metric insights
+- IF P: Read fully and follow: {partyModeWorkflow} to bring different perspectives to validate comprehensive metrics
+- IF C: Save content to {outputFile}, update frontmatter with stepsCompleted: [1, 2, 3, 4], then read fully and follow: {nextStepFile}
 - IF Any other comments or queries: help user respond then [Redisplay Menu Options](#7-present-menu-options)
 
 #### EXECUTION RULES:
@@ -176,7 +176,7 @@ Prepare the following structure for document append:
 
 ## CRITICAL STEP COMPLETION NOTE
 
-ONLY WHEN [C continue option] is selected and [success metrics finalized and saved to document with frontmatter updated], will you then load and read fully `{nextStepFile}` to execute and begin MVP scope definition.
+ONLY WHEN [C continue option] is selected and [success metrics finalized and saved to document with frontmatter updated], will you then read fully and follow: `{nextStepFile}` to begin MVP scope definition.
 
 ---
 

--- a/src/bmm/workflows/1-analysis/create-product-brief/steps/step-05-scope.md
+++ b/src/bmm/workflows/1-analysis/create-product-brief/steps/step-05-scope.md
@@ -176,9 +176,9 @@ Prepare the following structure for document append:
 
 #### Menu Handling Logic:
 
-- IF A: Execute {advancedElicitationTask} with current scope content to optimize scope definition
-- IF P: Execute {partyModeWorkflow} to bring different perspectives to validate MVP scope
-- IF C: Save content to {outputFile}, update frontmatter with stepsCompleted: [1, 2, 3, 4, 5], then only then load, read entire file, then execute {nextStepFile}
+- IF A: Read fully and follow: {advancedElicitationTask} with current scope content to optimize scope definition
+- IF P: Read fully and follow: {partyModeWorkflow} to bring different perspectives to validate MVP scope
+- IF C: Save content to {outputFile}, update frontmatter with stepsCompleted: [1, 2, 3, 4, 5], then read fully and follow: {nextStepFile}
 - IF Any other comments or queries: help user respond then [Redisplay Menu Options](#7-present-menu-options)
 
 #### EXECUTION RULES:
@@ -190,7 +190,7 @@ Prepare the following structure for document append:
 
 ## CRITICAL STEP COMPLETION NOTE
 
-ONLY WHEN [C continue option] is selected and [MVP scope finalized and saved to document with frontmatter updated], will you then load and read fully `{nextStepFile}` to execute and complete the product brief workflow.
+ONLY WHEN [C continue option] is selected and [MVP scope finalized and saved to document with frontmatter updated], will you then read fully and follow: `{nextStepFile}` to complete the product brief workflow.
 
 ---
 

--- a/src/bmm/workflows/1-analysis/create-product-brief/steps/step-06-complete.md
+++ b/src/bmm/workflows/1-analysis/create-product-brief/steps/step-06-complete.md
@@ -128,7 +128,7 @@ Recap that the brief captures everything needed to guide subsequent product deve
 
 ### 5. Suggest next steps
 
-Execute task `_bmad/core/tasks/bmad-help.md` with argument `Validate PRD`.
+Product Brief complete. Read fully and follow: `_bmad/core/tasks/bmad-help.md` with argument `Validate PRD`.
 
 ---
 

--- a/src/bmm/workflows/1-analysis/create-product-brief/workflow.md
+++ b/src/bmm/workflows/1-analysis/create-product-brief/workflow.md
@@ -31,7 +31,7 @@ This uses **step-file architecture** for disciplined execution:
 3. **WAIT FOR INPUT**: If a menu is presented, halt and wait for user selection
 4. **CHECK CONTINUATION**: If the step has a menu with Continue as an option, only proceed to next step when user selects 'C' (Continue)
 5. **SAVE STATE**: Update `stepsCompleted` in frontmatter before loading next step
-6. **LOAD NEXT**: When directed, load, read entire file, then execute the next step file
+6. **LOAD NEXT**: When directed, read fully and follow the next step file
 
 ### Critical Rules (NO EXCEPTIONS)
 
@@ -55,4 +55,4 @@ Load and read full config from {project-root}/_bmad/bmm/config.yaml and resolve:
 
 ### 2. First Step EXECUTION
 
-Load, read the full file and then execute `{project-root}/_bmad/bmm/workflows/1-analysis/create-product-brief/steps/step-01-init.md` to begin the workflow.
+Read fully and follow: `{project-root}/_bmad/bmm/workflows/1-analysis/create-product-brief/steps/step-01-init.md` to begin the workflow.

--- a/src/bmm/workflows/2-plan-workflows/create-ux-design/steps/step-02-discovery.md
+++ b/src/bmm/workflows/2-plan-workflows/create-ux-design/steps/step-02-discovery.md
@@ -30,8 +30,8 @@ This step will generate content and present choices:
 
 ## PROTOCOL INTEGRATION:
 
-- When 'A' selected: Execute {project-root}/_bmad/core/workflows/advanced-elicitation/workflow.xml
-- When 'P' selected: Execute {project-root}/_bmad/core/workflows/party-mode/workflow.md
+- When 'A' selected: Read fully and follow: {project-root}/_bmad/core/workflows/advanced-elicitation/workflow.xml
+- When 'P' selected: Read fully and follow: {project-root}/_bmad/core/workflows/party-mode/workflow.md
 - PROTOCOLS always return to this step's A/P/C menu
 - User accepts/rejects protocol changes before proceeding
 
@@ -159,7 +159,7 @@ Show the generated project understanding content and present choices:
 
 ## APPEND TO DOCUMENT:
 
-When user selects 'C', append the content directly to the document. Only after the content is saved to document, load `./step-03-core-experience.md` and execute the instructions.
+When user selects 'C', append the content directly to the document. Only after the content is saved to document, read fully and follow: `./step-03-core-experience.md`.
 
 ## SUCCESS METRICS:
 

--- a/src/bmm/workflows/2-plan-workflows/create-ux-design/steps/step-03-core-experience.md
+++ b/src/bmm/workflows/2-plan-workflows/create-ux-design/steps/step-03-core-experience.md
@@ -30,8 +30,8 @@ This step will generate content and present choices:
 
 ## PROTOCOL INTEGRATION:
 
-- When 'A' selected: Execute {project-root}/_bmad/core/workflows/advanced-elicitation/workflow.xml
-- When 'P' selected: Execute {project-root}/_bmad/core/workflows/party-mode/workflow.md
+- When 'A' selected: Read fully and follow: {project-root}/_bmad/core/workflows/advanced-elicitation/workflow.xml
+- When 'P' selected: Read fully and follow: {project-root}/_bmad/core/workflows/party-mode/workflow.md
 - PROTOCOLS always return to this step's A/P/C menu
 - User accepts/rejects protocol changes before proceeding
 
@@ -161,7 +161,7 @@ Show the generated core experience content and present choices:
 
 #### If 'A' (Advanced Elicitation):
 
-- Execute {project-root}/_bmad/core/workflows/advanced-elicitation/workflow.xml with the current core experience content
+- Read fully and follow: {project-root}/_bmad/core/workflows/advanced-elicitation/workflow.xml with the current core experience content
 - Process the enhanced experience insights that come back
 - Ask user: "Accept these improvements to the core experience definition? (y/n)"
 - If yes: Update content with improvements, then return to A/P/C menu
@@ -169,7 +169,7 @@ Show the generated core experience content and present choices:
 
 #### If 'P' (Party Mode):
 
-- Execute {project-root}/_bmad/core/workflows/party-mode/workflow.md with the current core experience definition
+- Read fully and follow: {project-root}/_bmad/core/workflows/party-mode/workflow.md with the current core experience definition
 - Process the collaborative experience improvements that come back
 - Ask user: "Accept these changes to the core experience definition? (y/n)"
 - If yes: Update content with improvements, then return to A/P/C menu

--- a/src/bmm/workflows/2-plan-workflows/create-ux-design/steps/step-04-emotional-response.md
+++ b/src/bmm/workflows/2-plan-workflows/create-ux-design/steps/step-04-emotional-response.md
@@ -30,8 +30,8 @@ This step will generate content and present choices:
 
 ## PROTOCOL INTEGRATION:
 
-- When 'A' selected: Execute {project-root}/_bmad/core/workflows/advanced-elicitation/workflow.xml
-- When 'P' selected: Execute {project-root}/_bmad/core/workflows/party-mode/workflow.md
+- When 'A' selected: Read fully and follow: {project-root}/_bmad/core/workflows/advanced-elicitation/workflow.xml
+- When 'P' selected: Read fully and follow: {project-root}/_bmad/core/workflows/party-mode/workflow.md
 - PROTOCOLS always return to this step's A/P/C menu
 - User accepts/rejects protocol changes before proceeding
 
@@ -164,7 +164,7 @@ Show the generated emotional response content and present choices:
 
 #### If 'A' (Advanced Elicitation):
 
-- Execute {project-root}/_bmad/core/workflows/advanced-elicitation/workflow.xml with the current emotional response content
+- Read fully and follow: {project-root}/_bmad/core/workflows/advanced-elicitation/workflow.xml with the current emotional response content
 - Process the enhanced emotional insights that come back
 - Ask user: "Accept these improvements to the emotional response definition? (y/n)"
 - If yes: Update content with improvements, then return to A/P/C menu
@@ -172,7 +172,7 @@ Show the generated emotional response content and present choices:
 
 #### If 'P' (Party Mode):
 
-- Execute {project-root}/_bmad/core/workflows/party-mode/workflow.md with the current emotional response definition
+- Read fully and follow: {project-root}/_bmad/core/workflows/party-mode/workflow.md with the current emotional response definition
 - Process the collaborative emotional insights that come back
 - Ask user: "Accept these changes to the emotional response definition? (y/n)"
 - If yes: Update content with improvements, then return to A/P/C menu

--- a/src/bmm/workflows/2-plan-workflows/create-ux-design/steps/step-05-inspiration.md
+++ b/src/bmm/workflows/2-plan-workflows/create-ux-design/steps/step-05-inspiration.md
@@ -30,8 +30,8 @@ This step will generate content and present choices:
 
 ## PROTOCOL INTEGRATION:
 
-- When 'A' selected: Execute {project-root}/_bmad/core/workflows/advanced-elicitation/workflow.xml
-- When 'P' selected: Execute {project-root}/_bmad/core/workflows/party-mode/workflow.md
+- When 'A' selected: Read fully and follow: {project-root}/_bmad/core/workflows/advanced-elicitation/workflow.xml
+- When 'P' selected: Read fully and follow: {project-root}/_bmad/core/workflows/party-mode/workflow.md
 - PROTOCOLS always return to this step's A/P/C menu
 - User accepts/rejects protocol changes before proceeding
 
@@ -179,7 +179,7 @@ Show the generated inspiration analysis content and present choices:
 
 #### If 'A' (Advanced Elicitation):
 
-- Execute {project-root}/_bmad/core/workflows/advanced-elicitation/workflow.xml with the current inspiration analysis content
+- Read fully and follow: {project-root}/_bmad/core/workflows/advanced-elicitation/workflow.xml with the current inspiration analysis content
 - Process the enhanced pattern insights that come back
 - Ask user: "Accept these improvements to the inspiration analysis? (y/n)"
 - If yes: Update content with improvements, then return to A/P/C menu
@@ -187,7 +187,7 @@ Show the generated inspiration analysis content and present choices:
 
 #### If 'P' (Party Mode):
 
-- Execute {project-root}/_bmad/core/workflows/party-mode/workflow.md with the current inspiration analysis
+- Read fully and follow: {project-root}/_bmad/core/workflows/party-mode/workflow.md with the current inspiration analysis
 - Process the collaborative pattern insights that come back
 - Ask user: "Accept these changes to the inspiration analysis? (y/n)"
 - If yes: Update content with improvements, then return to A/P/C menu
@@ -197,7 +197,7 @@ Show the generated inspiration analysis content and present choices:
 
 - Append the final content to `{planning_artifacts}/ux-design-specification.md`
 - Update frontmatter: append step to end of stepsCompleted array
-- Load and execute`./step-06-design-system.md`
+- Read fully and follow: `./step-06-design-system.md`
 
 ## APPEND TO DOCUMENT:
 

--- a/src/bmm/workflows/2-plan-workflows/create-ux-design/steps/step-06-design-system.md
+++ b/src/bmm/workflows/2-plan-workflows/create-ux-design/steps/step-06-design-system.md
@@ -30,8 +30,8 @@ This step will generate content and present choices:
 
 ## PROTOCOL INTEGRATION:
 
-- When 'A' selected: Execute {project-root}/_bmad/core/workflows/advanced-elicitation/workflow.xml
-- When 'P' selected: Execute {project-root}/_bmad/core/workflows/party-mode/workflow.md
+- When 'A' selected: Read fully and follow: {project-root}/_bmad/core/workflows/advanced-elicitation/workflow.xml
+- When 'P' selected: Read fully and follow: {project-root}/_bmad/core/workflows/party-mode/workflow.md
 - PROTOCOLS always return to this step's A/P/C menu
 - User accepts/rejects protocol changes before proceeding
 
@@ -197,7 +197,7 @@ Show the generated design system content and present choices:
 
 #### If 'A' (Advanced Elicitation):
 
-- Execute {project-root}/_bmad/core/workflows/advanced-elicitation/workflow.xml with the current design system content
+- Read fully and follow: {project-root}/_bmad/core/workflows/advanced-elicitation/workflow.xml with the current design system content
 - Process the enhanced design system insights that come back
 - Ask user: "Accept these improvements to the design system decision? (y/n)"
 - If yes: Update content with improvements, then return to A/P/C menu
@@ -205,7 +205,7 @@ Show the generated design system content and present choices:
 
 #### If 'P' (Party Mode):
 
-- Execute {project-root}/_bmad/core/workflows/party-mode/workflow.md with the current design system choice
+- Read fully and follow: {project-root}/_bmad/core/workflows/party-mode/workflow.md with the current design system choice
 - Process the collaborative design system insights that come back
 - Ask user: "Accept these changes to the design system decision? (y/n)"
 - If yes: Update content with improvements, then return to A/P/C menu

--- a/src/bmm/workflows/2-plan-workflows/create-ux-design/steps/step-07-defining-experience.md
+++ b/src/bmm/workflows/2-plan-workflows/create-ux-design/steps/step-07-defining-experience.md
@@ -30,8 +30,8 @@ This step will generate content and present choices:
 
 ## PROTOCOL INTEGRATION:
 
-- When 'A' selected: Execute {project-root}/_bmad/core/workflows/advanced-elicitation/workflow.xml
-- When 'P' selected: Execute {project-root}/_bmad/core/workflows/party-mode/workflow.md
+- When 'A' selected: Read fully and follow: {project-root}/_bmad/core/workflows/advanced-elicitation/workflow.xml
+- When 'P' selected: Read fully and follow: {project-root}/_bmad/core/workflows/party-mode/workflow.md
 - PROTOCOLS always return to this step's A/P/C menu
 - User accepts/rejects protocol changes before proceeding
 
@@ -199,7 +199,7 @@ Show the generated defining experience content and present choices:
 
 #### If 'A' (Advanced Elicitation):
 
-- Execute {project-root}/_bmad/core/workflows/advanced-elicitation/workflow.xml with the current defining experience content
+- Read fully and follow: {project-root}/_bmad/core/workflows/advanced-elicitation/workflow.xml with the current defining experience content
 - Process the enhanced experience insights that come back
 - Ask user: "Accept these improvements to the defining experience? (y/n)"
 - If yes: Update content with improvements, then return to A/P/C menu
@@ -207,7 +207,7 @@ Show the generated defining experience content and present choices:
 
 #### If 'P' (Party Mode):
 
-- Execute {project-root}/_bmad/core/workflows/party-mode/workflow.md with the current defining experience
+- Read fully and follow: {project-root}/_bmad/core/workflows/party-mode/workflow.md with the current defining experience
 - Process the collaborative experience insights that come back
 - Ask user: "Accept these changes to the defining experience? (y/n)"
 - If yes: Update content with improvements, then return to A/P/C menu

--- a/src/bmm/workflows/2-plan-workflows/create-ux-design/steps/step-08-visual-foundation.md
+++ b/src/bmm/workflows/2-plan-workflows/create-ux-design/steps/step-08-visual-foundation.md
@@ -30,8 +30,8 @@ This step will generate content and present choices:
 
 ## PROTOCOL INTEGRATION:
 
-- When 'A' selected: Execute {project-root}/_bmad/core/workflows/advanced-elicitation/workflow.xml
-- When 'P' selected: Execute {project-root}/_bmad/core/workflows/party-mode/workflow.md
+- When 'A' selected: Read fully and follow: {project-root}/_bmad/core/workflows/advanced-elicitation/workflow.xml
+- When 'P' selected: Read fully and follow: {project-root}/_bmad/core/workflows/party-mode/workflow.md
 - PROTOCOLS always return to this step's A/P/C menu
 - User accepts/rejects protocol changes before proceeding
 
@@ -169,7 +169,7 @@ Show the generated visual foundation content and present choices:
 
 #### If 'A' (Advanced Elicitation):
 
-- Execute {project-root}/_bmad/core/workflows/advanced-elicitation/workflow.xml with the current visual foundation content
+- Read fully and follow: {project-root}/_bmad/core/workflows/advanced-elicitation/workflow.xml with the current visual foundation content
 - Process the enhanced visual insights that come back
 - Ask user: "Accept these improvements to the visual foundation? (y/n)"
 - If yes: Update content with improvements, then return to A/P/C menu
@@ -177,7 +177,7 @@ Show the generated visual foundation content and present choices:
 
 #### If 'P' (Party Mode):
 
-- Execute {project-root}/_bmad/core/workflows/party-mode/workflow.md with the current visual foundation
+- Read fully and follow: {project-root}/_bmad/core/workflows/party-mode/workflow.md with the current visual foundation
 - Process the collaborative visual insights that come back
 - Ask user: "Accept these changes to the visual foundation? (y/n)"
 - If yes: Update content with improvements, then return to A/P/C menu

--- a/src/bmm/workflows/2-plan-workflows/create-ux-design/steps/step-09-design-directions.md
+++ b/src/bmm/workflows/2-plan-workflows/create-ux-design/steps/step-09-design-directions.md
@@ -30,8 +30,8 @@ This step will generate content and present choices:
 
 ## PROTOCOL INTEGRATION:
 
-- When 'A' selected: Execute {project-root}/_bmad/core/workflows/advanced-elicitation/workflow.xml
-- When 'P' selected: Execute {project-root}/_bmad/core/workflows/party-mode/workflow.md
+- When 'A' selected: Read fully and follow: {project-root}/_bmad/core/workflows/advanced-elicitation/workflow.xml
+- When 'P' selected: Read fully and follow: {project-root}/_bmad/core/workflows/party-mode/workflow.md
 - PROTOCOLS always return to this step's A/P/C menu
 - User accepts/rejects protocol changes before proceeding
 
@@ -169,7 +169,7 @@ Show the generated design direction content and present choices:
 
 #### If 'A' (Advanced Elicitation):
 
-- Execute {project-root}/_bmad/core/workflows/advanced-elicitation/workflow.xml with the current design direction content
+- Read fully and follow: {project-root}/_bmad/core/workflows/advanced-elicitation/workflow.xml with the current design direction content
 - Process the enhanced design insights that come back
 - Ask user: "Accept these improvements to the design direction? (y/n)"
 - If yes: Update content with improvements, then return to A/P/C menu
@@ -177,7 +177,7 @@ Show the generated design direction content and present choices:
 
 #### If 'P' (Party Mode):
 
-- Execute {project-root}/_bmad/core/workflows/party-mode/workflow.md with the current design direction
+- Read fully and follow: {project-root}/_bmad/core/workflows/party-mode/workflow.md with the current design direction
 - Process the collaborative design insights that come back
 - Ask user: "Accept these changes to the design direction? (y/n)"
 - If yes: Update content with improvements, then return to A/P/C menu

--- a/src/bmm/workflows/2-plan-workflows/create-ux-design/steps/step-10-user-journeys.md
+++ b/src/bmm/workflows/2-plan-workflows/create-ux-design/steps/step-10-user-journeys.md
@@ -30,8 +30,8 @@ This step will generate content and present choices:
 
 ## PROTOCOL INTEGRATION:
 
-- When 'A' selected: Execute {project-root}/_bmad/core/workflows/advanced-elicitation/workflow.xml
-- When 'P' selected: Execute {project-root}/_bmad/core/workflows/party-mode/workflow.md
+- When 'A' selected: Read fully and follow: {project-root}/_bmad/core/workflows/advanced-elicitation/workflow.xml
+- When 'P' selected: Read fully and follow: {project-root}/_bmad/core/workflows/party-mode/workflow.md
 - PROTOCOLS always return to this step's A/P/C menu
 - User accepts/rejects protocol changes before proceeding
 
@@ -187,7 +187,7 @@ Show the generated user journey content and present choices:
 
 #### If 'A' (Advanced Elicitation):
 
-- Execute {project-root}/_bmad/core/workflows/advanced-elicitation/workflow.xml with the current user journey content
+- Read fully and follow: {project-root}/_bmad/core/workflows/advanced-elicitation/workflow.xml with the current user journey content
 - Process the enhanced journey insights that come back
 - Ask user: "Accept these improvements to the user journeys? (y/n)"
 - If yes: Update content with improvements, then return to A/P/C menu
@@ -195,7 +195,7 @@ Show the generated user journey content and present choices:
 
 #### If 'P' (Party Mode):
 
-- Execute {project-root}/_bmad/core/workflows/party-mode/workflow.md with the current user journeys
+- Read fully and follow: {project-root}/_bmad/core/workflows/party-mode/workflow.md with the current user journeys
 - Process the collaborative journey insights that come back
 - Ask user: "Accept these changes to the user journeys? (y/n)"
 - If yes: Update content with improvements, then return to A/P/C menu

--- a/src/bmm/workflows/2-plan-workflows/create-ux-design/steps/step-11-component-strategy.md
+++ b/src/bmm/workflows/2-plan-workflows/create-ux-design/steps/step-11-component-strategy.md
@@ -30,8 +30,8 @@ This step will generate content and present choices:
 
 ## PROTOCOL INTEGRATION:
 
-- When 'A' selected: Execute {project-root}/_bmad/core/workflows/advanced-elicitation/workflow.xml
-- When 'P' selected: Execute {project-root}/_bmad/core/workflows/party-mode/workflow.md
+- When 'A' selected: Read fully and follow: {project-root}/_bmad/core/workflows/advanced-elicitation/workflow.xml
+- When 'P' selected: Read fully and follow: {project-root}/_bmad/core/workflows/party-mode/workflow.md
 - PROTOCOLS always return to this step's A/P/C menu
 - User accepts/rejects protocol changes before proceeding
 
@@ -193,7 +193,7 @@ Show the generated component strategy content and present choices:
 
 #### If 'A' (Advanced Elicitation):
 
-- Execute {project-root}/_bmad/core/workflows/advanced-elicitation/workflow.xml with the current component strategy content
+- Read fully and follow: {project-root}/_bmad/core/workflows/advanced-elicitation/workflow.xml with the current component strategy content
 - Process the enhanced component insights that come back
 - Ask user: "Accept these improvements to the component strategy? (y/n)"
 - If yes: Update content with improvements, then return to A/P/C menu
@@ -201,7 +201,7 @@ Show the generated component strategy content and present choices:
 
 #### If 'P' (Party Mode):
 
-- Execute {project-root}/_bmad/core/workflows/party-mode/workflow.md with the current component strategy
+- Read fully and follow: {project-root}/_bmad/core/workflows/party-mode/workflow.md with the current component strategy
 - Process the collaborative component insights that come back
 - Ask user: "Accept these changes to the component strategy? (y/n)"
 - If yes: Update content with improvements, then return to A/P/C menu

--- a/src/bmm/workflows/2-plan-workflows/create-ux-design/steps/step-12-ux-patterns.md
+++ b/src/bmm/workflows/2-plan-workflows/create-ux-design/steps/step-12-ux-patterns.md
@@ -30,8 +30,8 @@ This step will generate content and present choices:
 
 ## PROTOCOL INTEGRATION:
 
-- When 'A' selected: Execute {project-root}/_bmad/core/workflows/advanced-elicitation/workflow.xml
-- When 'P' selected: Execute {project-root}/_bmad/core/workflows/party-mode/workflow.md
+- When 'A' selected: Read fully and follow: {project-root}/_bmad/core/workflows/advanced-elicitation/workflow.xml
+- When 'P' selected: Read fully and follow: {project-root}/_bmad/core/workflows/party-mode/workflow.md
 - PROTOCOLS always return to this step's A/P/C menu
 - User accepts/rejects protocol changes before proceeding
 
@@ -182,7 +182,7 @@ Show the generated UX patterns content and present choices:
 
 #### If 'A' (Advanced Elicitation):
 
-- Execute {project-root}/_bmad/core/workflows/advanced-elicitation/workflow.xml with the current UX patterns content
+- Read fully and follow: {project-root}/_bmad/core/workflows/advanced-elicitation/workflow.xml with the current UX patterns content
 - Process the enhanced pattern insights that come back
 - Ask user: "Accept these improvements to the UX patterns? (y/n)"
 - If yes: Update content with improvements, then return to A/P/C menu
@@ -190,7 +190,7 @@ Show the generated UX patterns content and present choices:
 
 #### If 'P' (Party Mode):
 
-- Execute {project-root}/_bmad/core/workflows/party-mode/workflow.md with the current UX patterns
+- Read fully and follow: {project-root}/_bmad/core/workflows/party-mode/workflow.md with the current UX patterns
 - Process the collaborative pattern insights that come back
 - Ask user: "Accept these changes to the UX patterns? (y/n)"
 - If yes: Update content with improvements, then return to A/P/C menu

--- a/src/bmm/workflows/2-plan-workflows/create-ux-design/steps/step-13-responsive-accessibility.md
+++ b/src/bmm/workflows/2-plan-workflows/create-ux-design/steps/step-13-responsive-accessibility.md
@@ -30,8 +30,8 @@ This step will generate content and present choices:
 
 ## PROTOCOL INTEGRATION:
 
-- When 'A' selected: Execute {project-root}/_bmad/core/workflows/advanced-elicitation/workflow.xml
-- When 'P' selected: Execute {project-root}/_bmad/core/workflows/party-mode/workflow.md
+- When 'A' selected: Read fully and follow: {project-root}/_bmad/core/workflows/advanced-elicitation/workflow.xml
+- When 'P' selected: Read fully and follow: {project-root}/_bmad/core/workflows/party-mode/workflow.md
 - PROTOCOLS always return to this step's A/P/C menu
 - User accepts/rejects protocol changes before proceeding
 
@@ -209,7 +209,7 @@ Show the generated responsive and accessibility content and present choices:
 
 #### If 'A' (Advanced Elicitation):
 
-- Execute {project-root}/_bmad/core/workflows/advanced-elicitation/workflow.xml with the current responsive/accessibility content
+- Read fully and follow: {project-root}/_bmad/core/workflows/advanced-elicitation/workflow.xml with the current responsive/accessibility content
 - Process the enhanced insights that come back
 - Ask user: "Accept these improvements to the responsive/accessibility strategy? (y/n)"
 - If yes: Update content with improvements, then return to A/P/C menu
@@ -217,7 +217,7 @@ Show the generated responsive and accessibility content and present choices:
 
 #### If 'P' (Party Mode):
 
-- Execute {project-root}/_bmad/core/workflows/party-mode/workflow.md with the current responsive/accessibility strategy
+- Read fully and follow: {project-root}/_bmad/core/workflows/party-mode/workflow.md with the current responsive/accessibility strategy
 - Process the collaborative insights that come back
 - Ask user: "Accept these changes to the responsive/accessibility strategy? (y/n)"
 - If yes: Update content with improvements, then return to A/P/C menu

--- a/src/bmm/workflows/2-plan-workflows/create-ux-design/steps/step-14-complete.md
+++ b/src/bmm/workflows/2-plan-workflows/create-ux-design/steps/step-14-complete.md
@@ -82,7 +82,7 @@ Update the main workflow status file:
 
 ### 3. Suggest Next Steps
 
-Execute task `_bmad/core/tasks/bmad-help.md` with argument `Create UX`.
+UX Design complete. Read fully and follow: `_bmad/core/tasks/bmad-help.md` with argument `Create UX`.
 
 ### 5. Final Completion Confirmation
 

--- a/src/bmm/workflows/2-plan-workflows/create-ux-design/workflow.md
+++ b/src/bmm/workflows/2-plan-workflows/create-ux-design/workflow.md
@@ -40,4 +40,4 @@ Load config from `{project-root}/_bmad/bmm/config.yaml` and resolve:
 ## EXECUTION
 
 - ✅ YOU MUST ALWAYS SPEAK OUTPUT In your Agent communication style with the config `{communication_language}`
-- Load and execute `steps/step-01-init.md` to begin the UX design workflow.
+- Read fully and follow: `steps/step-01-init.md` to begin the UX design workflow.

--- a/src/bmm/workflows/2-plan-workflows/prd/steps-c/step-01-init.md
+++ b/src/bmm/workflows/2-plan-workflows/prd/steps-c/step-01-init.md
@@ -151,7 +151,7 @@ Display menu after setup report:
 
 #### Menu Handling Logic:
 
-- IF C: Update output file frontmatter, adding this step name to the end of the list of stepsCompleted, then load, read entire {nextStepFile}, then execute {nextStepFile}
+- IF C: Update output file frontmatter, adding this step name to the end of the list of stepsCompleted, then read fully and follow: {nextStepFile}
 - IF user provides additional files: Load them, update inputDocuments and documentCounts, redisplay report
 - IF user asks questions: Answer and redisplay menu
 
@@ -162,7 +162,7 @@ Display menu after setup report:
 
 ## CRITICAL STEP COMPLETION NOTE
 
-ONLY WHEN [C continue option] is selected and [frontmatter properly updated with this step added to stepsCompleted and documentCounts], will you then load and read fully `{nextStepFile}` to execute and begin project discovery.
+ONLY WHEN [C continue option] is selected and [frontmatter properly updated with this step added to stepsCompleted and documentCounts], will you then read fully and follow: `{nextStepFile}` to begin project discovery.
 
 ---
 

--- a/src/bmm/workflows/2-plan-workflows/prd/steps-c/step-01b-continue.md
+++ b/src/bmm/workflows/2-plan-workflows/prd/steps-c/step-01b-continue.md
@@ -120,7 +120,7 @@ Display: "**Select an Option:** [C] Continue to {next step name}"
 
 #### Menu Handling Logic:
 
-- IF C: Load, read entire file, then execute the {nextStepFile} determined in step 3
+- IF C: Read fully and follow the {nextStepFile} determined in step 3
 - IF Any other comments or queries: respond and redisplay menu
 
 #### EXECUTION RULES:
@@ -130,7 +130,7 @@ Display: "**Select an Option:** [C] Continue to {next step name}"
 
 ## CRITICAL STEP COMPLETION NOTE
 
-ONLY WHEN [C continue option] is selected and [current state confirmed], will you then load and read fully the {nextStepFile} to resume the workflow.
+ONLY WHEN [C continue option] is selected and [current state confirmed], will you then read fully and follow: {nextStepFile} to resume the workflow.
 
 ---
 

--- a/src/bmm/workflows/2-plan-workflows/prd/steps-c/step-02-discovery.md
+++ b/src/bmm/workflows/2-plan-workflows/prd/steps-c/step-02-discovery.md
@@ -185,9 +185,9 @@ Present the project classification for review, then display menu:
 Display: "**Select:** [A] Advanced Elicitation [P] Party Mode [C] Continue to Product Vision (Step 2b of 13)"
 
 #### Menu Handling Logic:
-- IF A: Execute {advancedElicitationTask} with the current classification, process the enhanced insights that come back, ask user if they accept the improvements, if yes update classification then redisplay menu, if no keep original classification then redisplay menu
-- IF P: Execute {partyModeWorkflow} with the current classification, process the collaborative insights, ask user if they accept the changes, if yes update classification then redisplay menu, if no keep original classification then redisplay menu
-- IF C: Save classification to {outputFile} frontmatter, add this step name to the end of stepsCompleted array, then load, read entire file, then execute {nextStepFile}
+- IF A: Read fully and follow: {advancedElicitationTask} with the current classification, process the enhanced insights that come back, ask user if they accept the improvements, if yes update classification then redisplay menu, if no keep original classification then redisplay menu
+- IF P: Read fully and follow: {partyModeWorkflow} with the current classification, process the collaborative insights, ask user if they accept the changes, if yes update classification then redisplay menu, if no keep original classification then redisplay menu
+- IF C: Save classification to {outputFile} frontmatter, add this step name to the end of stepsCompleted array, then read fully and follow: {nextStepFile}
 - IF Any other: help user respond, then redisplay menu
 
 #### EXECUTION RULES:
@@ -197,7 +197,7 @@ Display: "**Select:** [A] Advanced Elicitation [P] Party Mode [C] Continue to Pr
 
 ## CRITICAL STEP COMPLETION NOTE
 
-ONLY WHEN [C continue option] is selected and [classification saved to frontmatter], will you then load and read fully `{nextStepFile}` to explore product vision.
+ONLY WHEN [C continue option] is selected and [classification saved to frontmatter], will you then read fully and follow: `{nextStepFile}` to explore product vision.
 
 ---
 

--- a/src/bmm/workflows/2-plan-workflows/prd/steps-c/step-03-success.md
+++ b/src/bmm/workflows/2-plan-workflows/prd/steps-c/step-03-success.md
@@ -175,9 +175,9 @@ Present the success criteria content for user review, then display menu:
 Display: "**Select:** [A] Advanced Elicitation [P] Party Mode [C] Continue to User Journey Mapping (Step 4 of 11)"
 
 #### Menu Handling Logic:
-- IF A: Execute {advancedElicitationTask} with the current success criteria content, process the enhanced success metrics that come back, ask user "Accept these improvements to the success criteria? (y/n)", if yes update content with improvements then redisplay menu, if no keep original content then redisplay menu
-- IF P: Execute {partyModeWorkflow} with the current success criteria, process the collaborative improvements to metrics and scope, ask user "Accept these changes to the success criteria? (y/n)", if yes update content with improvements then redisplay menu, if no keep original content then redisplay menu
-- IF C: Append the final content to {outputFile}, update frontmatter by adding this step name to the end of the stepsCompleted array, then load, read entire file, then execute {nextStepFile}
+- IF A: Read fully and follow: {advancedElicitationTask} with the current success criteria content, process the enhanced success metrics that come back, ask user "Accept these improvements to the success criteria? (y/n)", if yes update content with improvements then redisplay menu, if no keep original content then redisplay menu
+- IF P: Read fully and follow: {partyModeWorkflow} with the current success criteria, process the collaborative improvements to metrics and scope, ask user "Accept these changes to the success criteria? (y/n)", if yes update content with improvements then redisplay menu, if no keep original content then redisplay menu
+- IF C: Append the final content to {outputFile}, update frontmatter by adding this step name to the end of the stepsCompleted array, then read fully and follow: {nextStepFile}
 - IF Any other: help user respond, then redisplay menu
 
 #### EXECUTION RULES:

--- a/src/bmm/workflows/2-plan-workflows/prd/steps-c/step-04-journeys.md
+++ b/src/bmm/workflows/2-plan-workflows/prd/steps-c/step-04-journeys.md
@@ -155,9 +155,9 @@ Present the user journey content for review, then display menu:
 Display: "**Select:** [A] Advanced Elicitation [P] Party Mode [C] Continue to Domain Requirements (Step 5 of 11)"
 
 #### Menu Handling Logic:
-- IF A: Execute {advancedElicitationTask} with the current journey content, process the enhanced journey insights that come back, ask user "Accept these improvements to the user journeys? (y/n)", if yes update content with improvements then redisplay menu, if no keep original content then redisplay menu
-- IF P: Execute {partyModeWorkflow} with the current journeys, process the collaborative journey improvements and additions, ask user "Accept these changes to the user journeys? (y/n)", if yes update content with improvements then redisplay menu, if no keep original content then redisplay menu
-- IF C: Append the final content to {outputFile}, update frontmatter by adding this step name to the end of the stepsCompleted array, then load, read entire file, then execute {nextStepFile}
+- IF A: Read fully and follow: {advancedElicitationTask} with the current journey content, process the enhanced journey insights that come back, ask user "Accept these improvements to the user journeys? (y/n)", if yes update content with improvements then redisplay menu, if no keep original content then redisplay menu
+- IF P: Read fully and follow: {partyModeWorkflow} with the current journeys, process the collaborative journey improvements and additions, ask user "Accept these changes to the user journeys? (y/n)", if yes update content with improvements then redisplay menu, if no keep original content then redisplay menu
+- IF C: Append the final content to {outputFile}, update frontmatter by adding this step name to the end of the stepsCompleted array, then read fully and follow: {nextStepFile}
 - IF Any other: help user respond, then redisplay menu
 
 #### EXECUTION RULES:

--- a/src/bmm/workflows/2-plan-workflows/prd/steps-c/step-05-domain.md
+++ b/src/bmm/workflows/2-plan-workflows/prd/steps-c/step-05-domain.md
@@ -154,9 +154,9 @@ Acknowledge the domain and explore what makes it complex:
 Display: "**Select:** [A] Advanced Elicitation [P] Party Mode [C] Continue - Save and Proceed to Innovation (Step 6 of 13)"
 
 #### Menu Handling Logic:
-- IF A: Execute {advancedElicitationTask}, and when finished redisplay the menu
-- IF P: Execute {partyModeWorkflow}, and when finished redisplay the menu
-- IF C: Save content to {outputFile}, update frontmatter, then load, read entire file, then execute {nextStepFile}
+- IF A: Read fully and follow: {advancedElicitationTask}, and when finished redisplay the menu
+- IF P: Read fully and follow: {partyModeWorkflow}, and when finished redisplay the menu
+- IF C: Save content to {outputFile}, update frontmatter, then read fully and follow: {nextStepFile}
 - IF Any other comments or queries: help user respond then [Redisplay Menu Options](#n-present-menu-options)
 
 #### EXECUTION RULES:
@@ -178,7 +178,7 @@ If step was skipped, append nothing and proceed.
 
 ## CRITICAL STEP COMPLETION NOTE
 
-ONLY WHEN [C continue option] is selected and [content saved or skipped], will you then load and read fully `{nextStepFile}` to explore innovation.
+ONLY WHEN [C continue option] is selected and [content saved or skipped], will you then read fully and follow: `{nextStepFile}` to explore innovation.
 
 ---
 

--- a/src/bmm/workflows/2-plan-workflows/prd/steps-c/step-06-innovation.md
+++ b/src/bmm/workflows/2-plan-workflows/prd/steps-c/step-06-innovation.md
@@ -155,9 +155,9 @@ Present the innovation content for review, then display menu:
 Display: "**Select:** [A] Advanced Elicitation [P] Party Mode [C] Continue to Project Type Analysis (Step 7 of 11)"
 
 #### Menu Handling Logic:
-- IF A: Execute {advancedElicitationTask} with the current innovation content, process the enhanced innovation insights that come back, ask user "Accept these improvements to the innovation analysis? (y/n)", if yes update content with improvements then redisplay menu, if no keep original content then redisplay menu
-- IF P: Execute {partyModeWorkflow} with the current innovation content, process the collaborative innovation exploration and ideation, ask user "Accept these changes to the innovation analysis? (y/n)", if yes update content with improvements then redisplay menu, if no keep original content then redisplay menu
-- IF C: Append the final content to {outputFile}, update frontmatter by adding this step name to the end of the stepsCompleted array, then load, read entire file, then execute {nextStepFile}
+- IF A: Read fully and follow: {advancedElicitationTask} with the current innovation content, process the enhanced innovation insights that come back, ask user "Accept these improvements to the innovation analysis? (y/n)", if yes update content with improvements then redisplay menu, if no keep original content then redisplay menu
+- IF P: Read fully and follow: {partyModeWorkflow} with the current innovation content, process the collaborative innovation exploration and ideation, ask user "Accept these changes to the innovation analysis? (y/n)", if yes update content with improvements then redisplay menu, if no keep original content then redisplay menu
+- IF C: Append the final content to {outputFile}, update frontmatter by adding this step name to the end of the stepsCompleted array, then read fully and follow: {nextStepFile}
 - IF Any other: help user respond, then redisplay menu
 
 #### EXECUTION RULES:
@@ -176,7 +176,7 @@ Display: "**Select:** [A] Advanced Elicitation - Let's try to find innovative an
 
 ### Menu Handling Logic:
 - IF A: Proceed with content generation anyway, then return to menu
-- IF C: Skip this step, then load, read entire file, then execute {nextStepFile}
+- IF C: Skip this step, then read fully and follow: {nextStepFile}
 
 ### EXECUTION RULES:
 - ALWAYS halt and wait for user input after presenting menu

--- a/src/bmm/workflows/2-plan-workflows/prd/steps-c/step-07-project-type.md
+++ b/src/bmm/workflows/2-plan-workflows/prd/steps-c/step-07-project-type.md
@@ -172,9 +172,9 @@ Present the project-type content for review, then display menu:
 Display: "**Select:** [A] Advanced Elicitation [P] Party Mode [C] Continue to Scoping (Step 8 of 11)"
 
 #### Menu Handling Logic:
-- IF A: Execute {advancedElicitationTask} with the current project-type content, process the enhanced technical insights that come back, ask user "Accept these improvements to the technical requirements? (y/n)", if yes update content with improvements then redisplay menu, if no keep original content then redisplay menu
-- IF P: Execute {partyModeWorkflow} with the current project-type requirements, process the collaborative technical expertise and validation, ask user "Accept these changes to the technical requirements? (y/n)", if yes update content with improvements then redisplay menu, if no keep original content then redisplay menu
-- IF C: Append the final content to {outputFile}, update frontmatter by adding this step name to the end of the stepsCompleted array, then load, read entire file, then execute {nextStepFile}
+- IF A: Read fully and follow: {advancedElicitationTask} with the current project-type content, process the enhanced technical insights that come back, ask user "Accept these improvements to the technical requirements? (y/n)", if yes update content with improvements then redisplay menu, if no keep original content then redisplay menu
+- IF P: Read fully and follow: {partyModeWorkflow} with the current project-type requirements, process the collaborative technical expertise and validation, ask user "Accept these changes to the technical requirements? (y/n)", if yes update content with improvements then redisplay menu, if no keep original content then redisplay menu
+- IF C: Append the final content to {outputFile}, update frontmatter by adding this step name to the end of the stepsCompleted array, then read fully and follow: {nextStepFile}
 - IF Any other: help user respond, then redisplay menu
 
 #### EXECUTION RULES:

--- a/src/bmm/workflows/2-plan-workflows/prd/steps-c/step-08-scoping.md
+++ b/src/bmm/workflows/2-plan-workflows/prd/steps-c/step-08-scoping.md
@@ -183,9 +183,9 @@ Present the scoping decisions for review, then display menu:
 Display: "**Select:** [A] Advanced Elicitation [P] Party Mode [C] Continue to Functional Requirements (Step 9 of 11)"
 
 #### Menu Handling Logic:
-- IF A: Execute {advancedElicitationTask} with the current scoping analysis, process the enhanced insights that come back, ask user if they accept the improvements, if yes update content then redisplay menu, if no keep original content then redisplay menu
-- IF P: Execute {partyModeWorkflow} with the scoping context, process the collaborative insights on MVP and roadmap decisions, ask user if they accept the changes, if yes update content then redisplay menu, if no keep original content then redisplay menu
-- IF C: Append the final content to {outputFile}, update frontmatter by adding this step name to the end of the stepsCompleted array, then load, read entire file, then execute {nextStepFile}
+- IF A: Read fully and follow: {advancedElicitationTask} with the current scoping analysis, process the enhanced insights that come back, ask user if they accept the improvements, if yes update content then redisplay menu, if no keep original content then redisplay menu
+- IF P: Read fully and follow: {partyModeWorkflow} with the scoping context, process the collaborative insights on MVP and roadmap decisions, ask user if they accept the changes, if yes update content then redisplay menu, if no keep original content then redisplay menu
+- IF C: Append the final content to {outputFile}, update frontmatter by adding this step name to the end of the stepsCompleted array, then read fully and follow: {nextStepFile}
 - IF Any other: help user respond, then redisplay menu
 
 #### EXECUTION RULES:

--- a/src/bmm/workflows/2-plan-workflows/prd/steps-c/step-09-functional.md
+++ b/src/bmm/workflows/2-plan-workflows/prd/steps-c/step-09-functional.md
@@ -181,9 +181,9 @@ Present the functional requirements for review, then display menu:
 Display: "**Select:** [A] Advanced Elicitation [P] Party Mode [C] Continue to Non-Functional Requirements (Step 10 of 11)"
 
 #### Menu Handling Logic:
-- IF A: Execute {advancedElicitationTask} with the current FR list, process the enhanced capability coverage that comes back, ask user if they accept the additions, if yes update content then redisplay menu, if no keep original content then redisplay menu
-- IF P: Execute {partyModeWorkflow} with the current FR list, process the collaborative capability validation and additions, ask user if they accept the changes, if yes update content then redisplay menu, if no keep original content then redisplay menu
-- IF C: Append the final content to {outputFile}, update frontmatter by adding this step name to the end of the stepsCompleted array, then load, read entire file, then execute {nextStepFile}
+- IF A: Read fully and follow: {advancedElicitationTask} with the current FR list, process the enhanced capability coverage that comes back, ask user if they accept the additions, if yes update content then redisplay menu, if no keep original content then redisplay menu
+- IF P: Read fully and follow: {partyModeWorkflow} with the current FR list, process the collaborative capability validation and additions, ask user if they accept the changes, if yes update content then redisplay menu, if no keep original content then redisplay menu
+- IF C: Append the final content to {outputFile}, update frontmatter by adding this step name to the end of the stepsCompleted array, then read fully and follow: {nextStepFile}
 - IF Any other: help user respond, then redisplay menu
 
 #### EXECUTION RULES:

--- a/src/bmm/workflows/2-plan-workflows/prd/steps-c/step-10-nonfunctional.md
+++ b/src/bmm/workflows/2-plan-workflows/prd/steps-c/step-10-nonfunctional.md
@@ -168,9 +168,9 @@ Present the non-functional requirements for review, then display menu:
 Display: "**Select:** [A] Advanced Elicitation [P] Party Mode [C] Continue to Polish Document (Step 11 of 12)"
 
 #### Menu Handling Logic:
-- IF A: Execute {advancedElicitationTask} with the current NFR content, process the enhanced quality attribute insights that come back, ask user if they accept the improvements, if yes update content then redisplay menu, if no keep original content then redisplay menu
-- IF P: Execute {partyModeWorkflow} with the current NFR list, process the collaborative technical validation and additions, ask user if they accept the changes, if yes update content then redisplay menu, if no keep original content then redisplay menu
-- IF C: Append the final content to {outputFile}, update frontmatter by adding this step name to the end of the stepsCompleted array, then load, read entire file, then execute {nextStepFile}
+- IF A: Read fully and follow: {advancedElicitationTask} with the current NFR content, process the enhanced quality attribute insights that come back, ask user if they accept the improvements, if yes update content then redisplay menu, if no keep original content then redisplay menu
+- IF P: Read fully and follow: {partyModeWorkflow} with the current NFR list, process the collaborative technical validation and additions, ask user if they accept the changes, if yes update content then redisplay menu, if no keep original content then redisplay menu
+- IF C: Append the final content to {outputFile}, update frontmatter by adding this step name to the end of the stepsCompleted array, then read fully and follow: {nextStepFile}
 - IF Any other: help user respond, then redisplay menu
 
 #### EXECUTION RULES:

--- a/src/bmm/workflows/2-plan-workflows/prd/steps-c/step-11-polish.md
+++ b/src/bmm/workflows/2-plan-workflows/prd/steps-c/step-11-polish.md
@@ -169,9 +169,9 @@ Present the polished document for review, then display menu:
 Display: "**Select:** [A] Advanced Elicitation [P] Party Mode [C] Continue to Complete PRD (Step 12 of 12)"
 
 #### Menu Handling Logic:
-- IF A: Execute {advancedElicitationTask} with the polished document, process the enhanced refinements that come back, ask user "Accept these polish improvements? (y/n)", if yes update content with improvements then redisplay menu, if no keep original polish then redisplay menu
-- IF P: Execute {partyModeWorkflow} with the polished document, process the collaborative refinements to flow and coherence, ask user "Accept these polish changes? (y/n)", if yes update content with improvements then redisplay menu, if no keep original polish then redisplay menu
-- IF C: Save the polished document to {outputFile}, update frontmatter by adding this step name to the end of the stepsCompleted array, then load, read entire file, then execute {nextStepFile}
+- IF A: Read fully and follow: {advancedElicitationTask} with the polished document, process the enhanced refinements that come back, ask user "Accept these polish improvements? (y/n)", if yes update content with improvements then redisplay menu, if no keep original polish then redisplay menu
+- IF P: Read fully and follow: {partyModeWorkflow} with the polished document, process the collaborative refinements to flow and coherence, ask user "Accept these polish changes? (y/n)", if yes update content with improvements then redisplay menu, if no keep original polish then redisplay menu
+- IF C: Save the polished document to {outputFile}, update frontmatter by adding this step name to the end of the stepsCompleted array, then read fully and follow: {nextStepFile}
 - IF Any other: help user respond, then redisplay menu
 
 #### EXECUTION RULES:

--- a/src/bmm/workflows/2-plan-workflows/prd/steps-c/step-12-complete.md
+++ b/src/bmm/workflows/2-plan-workflows/prd/steps-c/step-12-complete.md
@@ -87,7 +87,7 @@ Offer validation workflows to ensure PRD is ready for implementation:
 
 ### 4. Suggest Next Workflows
 
-Execute task `_bmad/core/tasks/bmad-help.md` with argument `Create PRD`.
+PRD complete. Read fully and follow: `_bmad/core/tasks/bmad-help.md` with argument `Create PRD`.
 
 ### 5. Final Completion Confirmation
 

--- a/src/bmm/workflows/2-plan-workflows/prd/steps-e/step-e-01-discovery.md
+++ b/src/bmm/workflows/2-plan-workflows/prd/steps-e/step-e-01-discovery.md
@@ -189,7 +189,7 @@ Display: "**Edit Requirements Understood**
 
 **Proceeding to deep review and analysis...**"
 
-Load and execute next step (step-e-02-review.md)
+Read fully and follow: next step (step-e-02-review.md)
 
 **IF PRD is Legacy (Non-Standard) AND no validation report:**
 
@@ -216,7 +216,7 @@ Present MENU OPTIONS below for user selection
 
 #### Menu Handling Logic:
 
-- IF C (Convert): Load, read entire file, then execute {altStepFile} (step-e-01b-legacy-conversion.md)
+- IF C (Convert): Read fully and follow: {altStepFile} (step-e-01b-legacy-conversion.md)
 - IF E (Edit As-Is): Display "Proceeding with edits..." then load next step
 - IF X (Exit): Display summary and exit
 - IF Any other: help user, then redisplay menu

--- a/src/bmm/workflows/2-plan-workflows/prd/steps-e/step-e-01b-legacy-conversion.md
+++ b/src/bmm/workflows/2-plan-workflows/prd/steps-e/step-e-01b-legacy-conversion.md
@@ -182,7 +182,7 @@ Edit goals: {summary}
 
 **Proceeding to deep review...**"
 
-Load and execute {nextStepFile} (step-e-02-review.md)
+Read fully and follow: {nextStepFile} (step-e-02-review.md)
 
 ---
 

--- a/src/bmm/workflows/2-plan-workflows/prd/steps-e/step-e-02-review.md
+++ b/src/bmm/workflows/2-plan-workflows/prd/steps-e/step-e-02-review.md
@@ -204,7 +204,7 @@ Display: "**Change Plan Approved**
 
 **Proceeding to edit step...**"
 
-Load and execute {nextStepFile} (step-e-03-edit.md)
+Read fully and follow: {nextStepFile} (step-e-03-edit.md)
 
 ### 7. Present MENU OPTIONS (If User Wants Discussion)
 
@@ -219,8 +219,8 @@ Load and execute {nextStepFile} (step-e-03-edit.md)
 
 #### Menu Handling Logic:
 
-- IF A: Execute {advancedElicitationTask}, then return to discussion
-- IF P: Execute {partyModeWorkflow}, then return to discussion
+- IF A: Read fully and follow: {advancedElicitationTask}, then return to discussion
+- IF P: Read fully and follow: {partyModeWorkflow}, then return to discussion
 - IF C: Document approval, then load {nextStepFile}
 - IF Any other: discuss, then redisplay menu
 

--- a/src/bmm/workflows/2-plan-workflows/prd/steps-e/step-e-03-edit.md
+++ b/src/bmm/workflows/2-plan-workflows/prd/steps-e/step-e-03-edit.md
@@ -222,7 +222,7 @@ Display:
 
 #### Menu Handling Logic:
 
-- IF V (Validate): Display "Starting validation workflow..." then load and execute steps-v/step-v-01-discovery.md
+- IF V (Validate): Display "Starting validation workflow..." then read fully and follow: steps-v/step-v-01-discovery.md
 - IF S (Summary): Present edit summary and exit
 - IF A (Adjust): Accept additional requirements, loop back to editing
 - IF X (Exit): Display summary and exit

--- a/src/bmm/workflows/2-plan-workflows/prd/steps-e/step-e-04-complete.md
+++ b/src/bmm/workflows/2-plan-workflows/prd/steps-e/step-e-04-complete.md
@@ -120,14 +120,14 @@ Display:
   - Display: "This will run all 13 validation checks on the updated PRD."
   - Display: "Preparing to validate: {prd_file_path}"
   - Display: "**Proceeding to validation...**"
-  - Load, read entire file, then execute {validationWorkflow} (steps-v/step-v-01-discovery.md)
+  - Read fully and follow: {validationWorkflow} (steps-v/step-v-01-discovery.md)
   - Note: This hands off to the validation workflow which will run its complete 13-step process
 
 - **IF E (Edit More):**
   - Display: "**Additional Edits**"
   - Ask: "What additional edits would you like to make?"
   - Accept input, then display: "**Returning to edit step...**"
-  - Load and execute step-e-03-edit.md again
+  - Read fully and follow: step-e-03-edit.md again
 
 - **IF S (Summary):**
   - Display detailed summary including:

--- a/src/bmm/workflows/2-plan-workflows/prd/steps-v/step-v-01-discovery.md
+++ b/src/bmm/workflows/2-plan-workflows/prd/steps-v/step-v-01-discovery.md
@@ -187,9 +187,9 @@ Display: **Select an Option:** [A] Advanced Elicitation [P] Party Mode [C] Conti
 
 #### Menu Handling Logic:
 
-- IF A: Execute {advancedElicitationTask}, and when finished redisplay the menu
-- IF P: Execute {partyModeWorkflow}, and when finished redisplay the menu
-- IF C: Load, read entire file, then execute {nextStepFile} to begin format detection
+- IF A: Read fully and follow: {advancedElicitationTask}, and when finished redisplay the menu
+- IF P: Read fully and follow: {partyModeWorkflow}, and when finished redisplay the menu
+- IF C: Read fully and follow: {nextStepFile} to begin format detection
 - IF user provides additional document: Load it, update report, redisplay summary
 - IF Any other: help user, then redisplay menu
 

--- a/src/bmm/workflows/2-plan-workflows/prd/steps-v/step-v-02-format-detection.md
+++ b/src/bmm/workflows/2-plan-workflows/prd/steps-v/step-v-02-format-detection.md
@@ -136,7 +136,7 @@ Display: "**Format Detected:** {classification}
 
 Proceeding to systematic validation checks..."
 
-Immediately load and execute {nextStepFile} (step-v-03-density-validation.md)
+Without delay, read fully and follow: {nextStepFile} (step-v-03-density-validation.md)
 
 **IF format is Non-Standard (< 3 core sections):**
 
@@ -161,8 +161,8 @@ Present MENU OPTIONS below for user selection
 
 #### Menu Handling Logic:
 
-- IF A (Parity Check): Load, read entire file, then execute {altStepFile} (step-v-02b-parity-check.md)
-- IF B (Validate As-Is): Display "Proceeding with validation..." then load, read entire file, then execute {nextStepFile}
+- IF A (Parity Check): Read fully and follow: {altStepFile} (step-v-02b-parity-check.md)
+- IF B (Validate As-Is): Display "Proceeding with validation..." then read fully and follow: {nextStepFile}
 - IF C (Exit): Display format findings summary and exit validation
 - IF Any other: help user respond, then redisplay menu
 

--- a/src/bmm/workflows/2-plan-workflows/prd/steps-v/step-v-02b-parity-check.md
+++ b/src/bmm/workflows/2-plan-workflows/prd/steps-v/step-v-02b-parity-check.md
@@ -180,7 +180,7 @@ Your PRD is missing {count} of 6 core BMAD PRD sections. The overall effort to r
 
 #### Menu Handling Logic:
 
-- IF C (Continue): Display "Proceeding with validation..." then load, read entire file, then execute {nextStepFile}
+- IF C (Continue): Display "Proceeding with validation..." then read fully and follow: {nextStepFile}
 - IF E (Exit): Display parity summary and exit validation
 - IF S (Save): Confirm saved, display summary, exit
 - IF Any other: help user respond, then redisplay menu

--- a/src/bmm/workflows/2-plan-workflows/prd/steps-v/step-v-03-density-validation.md
+++ b/src/bmm/workflows/2-plan-workflows/prd/steps-v/step-v-03-density-validation.md
@@ -148,7 +148,7 @@ Severity: {Critical/Warning/Pass}
 
 **Proceeding to next validation check...**"
 
-Immediately load and execute {nextStepFile} (step-v-04-brief-coverage-validation.md)
+Without delay, read fully and follow: {nextStepFile} (step-v-04-brief-coverage-validation.md)
 
 ---
 

--- a/src/bmm/workflows/2-plan-workflows/prd/steps-v/step-v-04-brief-coverage-validation.md
+++ b/src/bmm/workflows/2-plan-workflows/prd/steps-v/step-v-04-brief-coverage-validation.md
@@ -76,7 +76,7 @@ Display: "**Product Brief Coverage: Skipped** (No Product Brief provided)
 
 **Proceeding to next validation check...**"
 
-Immediately load and execute {nextStepFile}
+Without delay, read fully and follow: {nextStepFile}
 
 **IF Product Brief exists:** Continue to step 2 below
 
@@ -186,7 +186,7 @@ Overall Coverage: {assessment}
 
 **Proceeding to next validation check...**"
 
-Immediately load and execute {nextStepFile} (step-v-05-measurability-validation.md)
+Without delay, read fully and follow: {nextStepFile} (step-v-05-measurability-validation.md)
 
 ---
 

--- a/src/bmm/workflows/2-plan-workflows/prd/steps-v/step-v-05-measurability-validation.md
+++ b/src/bmm/workflows/2-plan-workflows/prd/steps-v/step-v-05-measurability-validation.md
@@ -201,7 +201,7 @@ Total Violations: {count} ({severity})
 
 **Proceeding to next validation check...**"
 
-Immediately load and execute {nextStepFile} (step-v-06-traceability-validation.md)
+Without delay, read fully and follow: {nextStepFile} (step-v-06-traceability-validation.md)
 
 ---
 

--- a/src/bmm/workflows/2-plan-workflows/prd/steps-v/step-v-06-traceability-validation.md
+++ b/src/bmm/workflows/2-plan-workflows/prd/steps-v/step-v-06-traceability-validation.md
@@ -189,7 +189,7 @@ Total Issues: {count} ({severity})
 
 **Proceeding to next validation check...**"
 
-Immediately load and execute {nextStepFile} (step-v-07-implementation-leakage-validation.md)
+Without delay, read fully and follow: {nextStepFile} (step-v-07-implementation-leakage-validation.md)
 
 ---
 

--- a/src/bmm/workflows/2-plan-workflows/prd/steps-v/step-v-07-implementation-leakage-validation.md
+++ b/src/bmm/workflows/2-plan-workflows/prd/steps-v/step-v-07-implementation-leakage-validation.md
@@ -178,7 +178,7 @@ Total Violations: {count} ({severity})
 
 **Proceeding to next validation check...**"
 
-Immediately load and execute {nextStepFile} (step-v-08-domain-compliance-validation.md)
+Without delay, read fully and follow: {nextStepFile} (step-v-08-domain-compliance-validation.md)
 
 ---
 

--- a/src/bmm/workflows/2-plan-workflows/prd/steps-v/step-v-08-domain-compliance-validation.md
+++ b/src/bmm/workflows/2-plan-workflows/prd/steps-v/step-v-08-domain-compliance-validation.md
@@ -161,7 +161,7 @@ Domain: {domain} (low complexity)
 
 **Proceeding to next validation check...**"
 
-Immediately load and execute {nextStepFile}
+Without delay, read fully and follow: {nextStepFile}
 
 ### 6. Report Compliance Findings (High-Complexity Domains)
 
@@ -213,7 +213,7 @@ Compliance Status: {status}
 
 **Proceeding to next validation check...**"
 
-Immediately load and execute {nextStepFile} (step-v-09-project-type-validation.md)
+Without delay, read fully and follow: {nextStepFile} (step-v-09-project-type-validation.md)
 
 ---
 

--- a/src/bmm/workflows/2-plan-workflows/prd/steps-v/step-v-09-project-type-validation.md
+++ b/src/bmm/workflows/2-plan-workflows/prd/steps-v/step-v-09-project-type-validation.md
@@ -234,7 +234,7 @@ Compliance: {score}%
 
 **Proceeding to next validation check...**"
 
-Immediately load and execute {nextStepFile} (step-v-10-smart-validation.md)
+Without delay, read fully and follow: {nextStepFile} (step-v-10-smart-validation.md)
 
 ---
 

--- a/src/bmm/workflows/2-plan-workflows/prd/steps-v/step-v-10-smart-validation.md
+++ b/src/bmm/workflows/2-plan-workflows/prd/steps-v/step-v-10-smart-validation.md
@@ -179,7 +179,7 @@ FR Quality: {percentage}% with acceptable scores ({severity})
 
 **Proceeding to next validation check...**"
 
-Immediately load and execute {nextStepFile} (step-v-11-holistic-quality-validation.md)
+Without delay, read fully and follow: {nextStepFile} (step-v-11-holistic-quality-validation.md)
 
 ---
 

--- a/src/bmm/workflows/2-plan-workflows/prd/steps-v/step-v-11-holistic-quality-validation.md
+++ b/src/bmm/workflows/2-plan-workflows/prd/steps-v/step-v-11-holistic-quality-validation.md
@@ -66,7 +66,7 @@ Assess the PRD as a cohesive, compelling document - evaluating document flow, du
 
 "Perform holistic quality assessment on this PRD using multi-perspective evaluation:
 
-**Load and execute Advanced Elicitation workflow:**
+**Read fully and follow the Advanced Elicitation workflow:**
 {advancedElicitationTask}
 
 **Evaluate the PRD from these perspectives:**
@@ -232,7 +232,7 @@ Overall Rating: {rating}/5 - {label}
 
 **Proceeding to final validation checks...**"
 
-Immediately load and execute {nextStepFile} (step-v-12-completeness-validation.md)
+Without delay, read fully and follow: {nextStepFile} (step-v-12-completeness-validation.md)
 
 ---
 

--- a/src/bmm/workflows/2-plan-workflows/prd/steps-v/step-v-12-completeness-validation.md
+++ b/src/bmm/workflows/2-plan-workflows/prd/steps-v/step-v-12-completeness-validation.md
@@ -212,7 +212,7 @@ Overall Completeness: {percentage}% ({severity})
 
 **Proceeding to final step...**"
 
-Immediately load and execute {nextStepFile} (step-v-13-report-complete.md)
+Without delay, read fully and follow: {nextStepFile} (step-v-13-report-complete.md)
 
 ---
 

--- a/src/bmm/workflows/2-plan-workflows/prd/steps-v/step-v-13-report-complete.md
+++ b/src/bmm/workflows/2-plan-workflows/prd/steps-v/step-v-13-report-complete.md
@@ -181,7 +181,7 @@ Display:
 - **IF E (Use Edit Workflow):**
   - Explain: "The Edit workflow (steps-e/) can use this validation report to systematically address issues. Edit mode will guide you through discovering what to edit, reviewing the PRD, and applying targeted improvements."
   - Offer: "Would you like to launch Edit mode now? It will help you fix validation findings systematically."
-  - If yes: Load and execute steps-e/step-e-01-discovery.md
+  - If yes: Read fully and follow: steps-e/step-e-01-discovery.md
   - If no: Return to menu
 
 - **IF F (Fix Simpler Items):**
@@ -197,7 +197,7 @@ Display:
 - **IF X (Exit):**
   - Display: "**Validation Report Saved:** {validationReportPath}"
   - Display: "**Summary:** {overall status} - {recommendation}"
-  - Exit and Execute task `_bmad/core/tasks/bmad-help.md` with argument `Validate PRD`.
+  - PRD Validation complete. Read fully and follow: `_bmad/core/tasks/bmad-help.md` with argument `Validate PRD`.
 
 - **IF Any other:** Help user, then redisplay menu
 

--- a/src/bmm/workflows/2-plan-workflows/prd/workflow.md
+++ b/src/bmm/workflows/2-plan-workflows/prd/workflow.md
@@ -54,17 +54,17 @@ Wait for user selection.
 
 **IF Create Mode:**
 "**Create Mode: Creating a new PRD from scratch.**"
-Load, read entire file, then execute: `{nextStep}` (steps-c/step-01-init.md)
+Read fully and follow: `{nextStep}` (steps-c/step-01-init.md)
 
 **IF Validate Mode:**
 "**Validate Mode: Validating an existing PRD against BMAD standards.**"
 Prompt for PRD path: "Which PRD would you like to validate? Please provide the path to the PRD.md file."
-Then load, read entire file, and execute: `{validateWorkflow}` (steps-v/step-v-01-discovery.md)
+Then read fully and follow: `{validateWorkflow}` (steps-v/step-v-01-discovery.md)
 
 **IF Edit Mode:**
 "**Edit Mode: Improving an existing PRD.**"
 Prompt for PRD path: "Which PRD would you like to edit? Please provide the path to the PRD.md file."
-Then load, read entire file, and execute: `{editWorkflow}` (steps-e/step-e-01-discovery.md)
+Then read fully and follow: `{editWorkflow}` (steps-e/step-e-01-discovery.md)
 
 ---
 
@@ -87,7 +87,7 @@ This uses **step-file architecture** for disciplined execution:
 3. **WAIT FOR INPUT**: If a menu is presented, halt and wait for user selection
 4. **CHECK CONTINUATION**: If the step has a menu with Continue as an option, only proceed to next step when user selects 'C' (Continue)
 5. **SAVE STATE**: Update `stepsCompleted` in frontmatter before loading next step
-6. **LOAD NEXT**: When directed, load, read entire file, then execute the next step file
+6. **LOAD NEXT**: When directed, read fully and follow the next step file
 
 ### Critical Rules (NO EXCEPTIONS)
 
@@ -137,14 +137,14 @@ Load and read full config from {main_config} and resolve:
 
 **IF mode == create:**
 "**Create Mode: Creating a new PRD from scratch.**"
-Load, read entire file, then execute `{nextStep}` (steps-c/step-01-init.md)
+Read fully and follow: `{nextStep}` (steps-c/step-01-init.md)
 
 **IF mode == validate:**
 "**Validate Mode: Validating an existing PRD against BMAD standards.**"
 Prompt for PRD path: "Which PRD would you like to validate? Please provide the path to the PRD.md file."
-Then load, read entire file, and execute `{validateWorkflow}` (steps-v/step-v-01-discovery.md)
+Then read fully and follow: `{validateWorkflow}` (steps-v/step-v-01-discovery.md)
 
 **IF mode == edit:**
 "**Edit Mode: Improving an existing PRD.**"
 Prompt for PRD path: "Which PRD would you like to edit? Please provide the path to the PRD.md file."
-Then load, read entire file, and execute `{editWorkflow}` (steps-e/step-e-01-discovery.md)
+Then read fully and follow: `{editWorkflow}` (steps-e/step-e-01-discovery.md)

--- a/src/bmm/workflows/3-solutioning/check-implementation-readiness/steps/step-01-document-discovery.md
+++ b/src/bmm/workflows/3-solutioning/check-implementation-readiness/steps/step-01-document-discovery.md
@@ -162,7 +162,7 @@ Display: **Select an Option:** [C] Continue to File Validation
 
 #### Menu Handling Logic:
 
-- IF C: Save document inventory to {outputFile}, update frontmatter with completed step and files being included, and only then load read fully and execute {nextStepFile}
+- IF C: Save document inventory to {outputFile}, update frontmatter with completed step and files being included, and then read fully and follow: {nextStepFile}
 - IF Any other comments or queries: help user respond then redisplay menu
 
 ## CRITICAL STEP COMPLETION NOTE

--- a/src/bmm/workflows/3-solutioning/check-implementation-readiness/steps/step-06-final-assessment.md
+++ b/src/bmm/workflows/3-solutioning/check-implementation-readiness/steps/step-06-final-assessment.md
@@ -115,7 +115,7 @@ The assessment found [number] issues requiring attention. Review the detailed re
 
 The implementation readiness workflow is now complete. The report contains all findings and recommendations for the user to consider.
 
-Execute task `_bmad/core/tasks/bmad-help.md` with argument `implementation readiness`.
+Implementation Readiness complete. Read fully and follow: `_bmad/core/tasks/bmad-help.md` with argument `implementation readiness`.
 
 ---
 

--- a/src/bmm/workflows/3-solutioning/check-implementation-readiness/workflow.md
+++ b/src/bmm/workflows/3-solutioning/check-implementation-readiness/workflow.md
@@ -15,7 +15,7 @@ web_bundle: false
 ### Core Principles
 
 - **Micro-file Design**: Each step of the overall goal is a self contained instruction file that you will adhere too 1 file as directed at a time
-- **Just-In-Time Loading**: Only 1 current step file will be loaded, read, and executed to completion - never load future step files until told to do so
+- **Just-In-Time Loading**: Only 1 current step file will be loaded and followed to completion - never load future step files until told to do so
 - **Sequential Enforcement**: Sequence within the step files must be completed in order, no skipping or optimization allowed
 - **State Tracking**: Document progress in output file frontmatter using `stepsCompleted` array when a workflow produces a document
 - **Append-Only Building**: Build documents by appending content as directed to the output file
@@ -27,7 +27,7 @@ web_bundle: false
 3. **WAIT FOR INPUT**: If a menu is presented, halt and wait for user selection
 4. **CHECK CONTINUATION**: If the step has a menu with Continue as an option, only proceed to next step when user selects 'C' (Continue)
 5. **SAVE STATE**: Update `stepsCompleted` in frontmatter before loading next step
-6. **LOAD NEXT**: When directed, load, read entire file, then execute the next step file
+6. **LOAD NEXT**: When directed, read fully and follow the next step file
 
 ### Critical Rules (NO EXCEPTIONS)
 
@@ -52,4 +52,4 @@ Load and read full config from {project-root}/_bmad/bmm/config.yaml and resolve:
 
 ### 2. First Step EXECUTION
 
-Load, read the full file and then execute `./step-01-document-discovery.md` to begin the workflow.
+Read fully and follow: `./step-01-document-discovery.md` to begin the workflow.

--- a/src/bmm/workflows/3-solutioning/create-architecture/steps/step-02-context.md
+++ b/src/bmm/workflows/3-solutioning/create-architecture/steps/step-02-context.md
@@ -31,8 +31,8 @@ This step will generate content and present choices:
 
 ## PROTOCOL INTEGRATION:
 
-- When 'A' selected: Execute {project-root}/_bmad/core/workflows/advanced-elicitation/workflow.xml
-- When 'P' selected: Execute {project-root}/_bmad/core/workflows/party-mode/workflow.md
+- When 'A' selected: Read fully and follow: {project-root}/_bmad/core/workflows/advanced-elicitation/workflow.xml
+- When 'P' selected: Read fully and follow: {project-root}/_bmad/core/workflows/party-mode/workflow.md
 - PROTOCOLS always return to display this step's A/P/C menu after the A or P have completed
 - User accepts/rejects protocol changes before proceeding
 
@@ -170,7 +170,7 @@ Show the generated content and present choices:
 
 #### If 'A' (Advanced Elicitation):
 
-- Execute {project-root}/_bmad/core/workflows/advanced-elicitation/workflow.xml with the current context analysis
+- Read fully and follow: {project-root}/_bmad/core/workflows/advanced-elicitation/workflow.xml with the current context analysis
 - Process the enhanced architectural insights that come back
 - Ask user: "Accept these enhancements to the project context analysis? (y/n)"
 - If yes: Update content with improvements, then return to A/P/C menu
@@ -178,7 +178,7 @@ Show the generated content and present choices:
 
 #### If 'P' (Party Mode):
 
-- Execute {project-root}/_bmad/core/workflows/party-mode/workflow.md with the current project context
+- Read fully and follow: {project-root}/_bmad/core/workflows/party-mode/workflow.md with the current project context
 - Process the collaborative improvements to architectural understanding
 - Ask user: "Accept these changes to the project context analysis? (y/n)"
 - If yes: Update content with improvements, then return to A/P/C menu

--- a/src/bmm/workflows/3-solutioning/create-architecture/steps/step-03-starter.md
+++ b/src/bmm/workflows/3-solutioning/create-architecture/steps/step-03-starter.md
@@ -31,8 +31,8 @@ This step will generate content and present choices:
 
 ## PROTOCOL INTEGRATION:
 
-- When 'A' selected: Execute {project-root}/_bmad/core/workflows/advanced-elicitation/workflow.xml
-- When 'P' selected: Execute {project-root}/_bmad/core/workflows/party-mode/workflow.md
+- When 'A' selected: Read fully and follow: {project-root}/_bmad/core/workflows/advanced-elicitation/workflow.xml
+- When 'P' selected: Read fully and follow: {project-root}/_bmad/core/workflows/party-mode/workflow.md
 - PROTOCOLS always return to display this step's A/P/C menu after the A or P have completed
 - User accepts/rejects protocol changes before proceeding
 
@@ -277,7 +277,7 @@ Show the generated content and present choices:
 
 #### If 'A' (Advanced Elicitation):
 
-- Execute {project-root}/_bmad/core/workflows/advanced-elicitation/workflow.xml with current starter analysis
+- Read fully and follow: {project-root}/_bmad/core/workflows/advanced-elicitation/workflow.xml with current starter analysis
 - Process enhanced insights about starter options or custom approaches
 - Ask user: "Accept these changes to the starter template evaluation? (y/n)"
 - If yes: Update content, then return to A/P/C menu
@@ -285,7 +285,7 @@ Show the generated content and present choices:
 
 #### If 'P' (Party Mode):
 
-- Execute {project-root}/_bmad/core/workflows/party-mode/workflow.md with starter evaluation context
+- Read fully and follow: {project-root}/_bmad/core/workflows/party-mode/workflow.md with starter evaluation context
 - Process collaborative insights about starter trade-offs
 - Ask user: "Accept these changes to the starter template evaluation? (y/n)"
 - If yes: Update content, then return to A/P/C menu

--- a/src/bmm/workflows/3-solutioning/create-architecture/steps/step-04-decisions.md
+++ b/src/bmm/workflows/3-solutioning/create-architecture/steps/step-04-decisions.md
@@ -32,8 +32,8 @@ This step will generate content and present choices for each decision category:
 
 ## PROTOCOL INTEGRATION:
 
-- When 'A' selected: Execute {project-root}/_bmad/core/workflows/advanced-elicitation/workflow.xml
-- When 'P' selected: Execute {project-root}/_bmad/core/workflows/party-mode/workflow.md
+- When 'A' selected: Read fully and follow: {project-root}/_bmad/core/workflows/advanced-elicitation/workflow.xml
+- When 'P' selected: Read fully and follow: {project-root}/_bmad/core/workflows/party-mode/workflow.md
 - PROTOCOLS always return to display this step's A/P/C menu after the A or P have completed
 - User accepts/rejects protocol changes before proceeding
 
@@ -264,7 +264,7 @@ Show the generated decisions content and present choices:
 
 #### If 'A' (Advanced Elicitation):
 
-- Execute {project-root}/_bmad/core/workflows/advanced-elicitation/workflow.xml with specific decision categories
+- Read fully and follow: {project-root}/_bmad/core/workflows/advanced-elicitation/workflow.xml with specific decision categories
 - Process enhanced insights about particular decisions
 - Ask user: "Accept these enhancements to the architectural decisions? (y/n)"
 - If yes: Update content, then return to A/P/C menu
@@ -272,7 +272,7 @@ Show the generated decisions content and present choices:
 
 #### If 'P' (Party Mode):
 
-- Execute {project-root}/_bmad/core/workflows/party-mode/workflow.md with architectural decisions context
+- Read fully and follow: {project-root}/_bmad/core/workflows/party-mode/workflow.md with architectural decisions context
 - Process collaborative insights about decision trade-offs
 - Ask user: "Accept these changes to the architectural decisions? (y/n)"
 - If yes: Update content, then return to A/P/C menu

--- a/src/bmm/workflows/3-solutioning/create-architecture/steps/step-05-patterns.md
+++ b/src/bmm/workflows/3-solutioning/create-architecture/steps/step-05-patterns.md
@@ -32,8 +32,8 @@ This step will generate content and present choices:
 
 ## PROTOCOL INTEGRATION:
 
-- When 'A' selected: Execute {project-root}/_bmad/core/workflows/advanced-elicitation/workflow.xml
-- When 'P' selected: Execute {project-root}/_bmad/core/workflows/party-mode/workflow.md
+- When 'A' selected: Read fully and follow: {project-root}/_bmad/core/workflows/advanced-elicitation/workflow.xml
+- When 'P' selected: Read fully and follow: {project-root}/_bmad/core/workflows/party-mode/workflow.md
 - PROTOCOLS always return to display this step's A/P/C menu after the A or P have completed
 - User accepts/rejects protocol changes before proceeding
 
@@ -305,7 +305,7 @@ Show the generated patterns content and present choices:
 
 #### If 'A' (Advanced Elicitation):
 
-- Execute {project-root}/_bmad/core/workflows/advanced-elicitation/workflow.xml with current patterns
+- Read fully and follow: {project-root}/_bmad/core/workflows/advanced-elicitation/workflow.xml with current patterns
 - Process enhanced consistency rules that come back
 - Ask user: "Accept these additional pattern refinements? (y/n)"
 - If yes: Update content, then return to A/P/C menu
@@ -313,7 +313,7 @@ Show the generated patterns content and present choices:
 
 #### If 'P' (Party Mode):
 
-- Execute {project-root}/_bmad/core/workflows/party-mode/workflow.md with implementation patterns context
+- Read fully and follow: {project-root}/_bmad/core/workflows/party-mode/workflow.md with implementation patterns context
 - Process collaborative insights about potential conflicts
 - Ask user: "Accept these changes to the implementation patterns? (y/n)"
 - If yes: Update content, then return to A/P/C menu

--- a/src/bmm/workflows/3-solutioning/create-architecture/steps/step-06-structure.md
+++ b/src/bmm/workflows/3-solutioning/create-architecture/steps/step-06-structure.md
@@ -32,8 +32,8 @@ This step will generate content and present choices:
 
 ## PROTOCOL INTEGRATION:
 
-- When 'A' selected: Execute {project-root}/_bmad/core/workflows/advanced-elicitation/workflow.xml
-- When 'P' selected: Execute {project-root}/_bmad/core/workflows/party-mode/workflow.md
+- When 'A' selected: Read fully and follow: {project-root}/_bmad/core/workflows/advanced-elicitation/workflow.xml
+- When 'P' selected: Read fully and follow: {project-root}/_bmad/core/workflows/party-mode/workflow.md
 - PROTOCOLS always return to display this step's A/P/C menu after the A or P have completed
 - User accepts/rejects protocol changes before proceeding
 
@@ -325,7 +325,7 @@ Show the generated project structure content and present choices:
 
 #### If 'A' (Advanced Elicitation):
 
-- Execute {project-root}/_bmad/core/workflows/advanced-elicitation/workflow.xml with current project structure
+- Read fully and follow: {project-root}/_bmad/core/workflows/advanced-elicitation/workflow.xml with current project structure
 - Process enhanced organizational insights that come back
 - Ask user: "Accept these changes to the project structure? (y/n)"
 - If yes: Update content, then return to A/P/C menu
@@ -333,7 +333,7 @@ Show the generated project structure content and present choices:
 
 #### If 'P' (Party Mode):
 
-- Execute {project-root}/_bmad/core/workflows/party-mode/workflow.md with project structure context
+- Read fully and follow: {project-root}/_bmad/core/workflows/party-mode/workflow.md with project structure context
 - Process collaborative insights about organization trade-offs
 - Ask user: "Accept these changes to the project structure? (y/n)"
 - If yes: Update content, then return to A/P/C menu

--- a/src/bmm/workflows/3-solutioning/create-architecture/steps/step-07-validation.md
+++ b/src/bmm/workflows/3-solutioning/create-architecture/steps/step-07-validation.md
@@ -32,8 +32,8 @@ This step will generate content and present choices:
 
 ## PROTOCOL INTEGRATION:
 
-- When 'A' selected: Execute {project-root}/_bmad/core/workflows/advanced-elicitation/workflow.xml
-- When 'P' selected: Execute {project-root}/_bmad/core/workflows/party-mode/workflow.md
+- When 'A' selected: Read fully and follow: {project-root}/_bmad/core/workflows/advanced-elicitation/workflow.xml
+- When 'P' selected: Read fully and follow: {project-root}/_bmad/core/workflows/party-mode/workflow.md
 - PROTOCOLS always return to display this step's A/P/C menu after the A or P have completed
 - User accepts/rejects protocol changes before proceeding
 
@@ -305,7 +305,7 @@ Show the validation results and present choices:
 
 #### If 'A' (Advanced Elicitation):
 
-- Execute {project-root}/_bmad/core/workflows/advanced-elicitation/workflow.xml with validation issues
+- Read fully and follow: {project-root}/_bmad/core/workflows/advanced-elicitation/workflow.xml with validation issues
 - Process enhanced solutions for complex concerns
 - Ask user: "Accept these architectural improvements? (y/n)"
 - If yes: Update content, then return to A/P/C menu
@@ -313,7 +313,7 @@ Show the validation results and present choices:
 
 #### If 'P' (Party Mode):
 
-- Execute {project-root}/_bmad/core/workflows/party-mode/workflow.md with validation context
+- Read fully and follow: {project-root}/_bmad/core/workflows/party-mode/workflow.md with validation context
 - Process collaborative insights on implementation readiness
 - Ask user: "Accept these changes to the validation results? (y/n)"
 - If yes: Update content, then return to A/P/C menu

--- a/src/bmm/workflows/3-solutioning/create-architecture/steps/step-08-complete.md
+++ b/src/bmm/workflows/3-solutioning/create-architecture/steps/step-08-complete.md
@@ -41,7 +41,7 @@ completedAt: '{{current_date}}'
 
 ### 3. Next Steps Guidance
 
-Execute task `_bmad/core/tasks/bmad-help.md` with argument `Create Architecture`.
+Architecture complete. Read fully and follow: `_bmad/core/tasks/bmad-help.md` with argument `Create Architecture`.
 
 Upon Completion of task output: offer to answer any questions about the Architecture Document.
 

--- a/src/bmm/workflows/3-solutioning/create-architecture/workflow.md
+++ b/src/bmm/workflows/3-solutioning/create-architecture/workflow.md
@@ -45,6 +45,6 @@ Load config from `{project-root}/_bmad/bmm/config.yaml` and resolve:
 
 ## EXECUTION
 
-Load and execute `steps/step-01-init.md` to begin the workflow.
+Read fully and follow: `steps/step-01-init.md` to begin the workflow.
 
 **Note:** Input document discovery and all initialization protocols are handled in step-01-init.md.

--- a/src/bmm/workflows/3-solutioning/create-epics-and-stories/steps/step-01-validate-prerequisites.md
+++ b/src/bmm/workflows/3-solutioning/create-epics-and-stories/steps/step-01-validate-prerequisites.md
@@ -229,12 +229,12 @@ Display: `**Confirm the Requirements are complete and correct to [C] continue:**
 
 #### Menu Handling Logic:
 
-- IF C: Save all to {outputFile}, update frontmatter, only then load, read entire file, then execute {nextStepFile}
+- IF C: Save all to {outputFile}, update frontmatter, then read fully and follow: {nextStepFile}
 - IF Any other comments or queries: help user respond then [Redisplay Menu Options](#10-present-menu-options)
 
 ## CRITICAL STEP COMPLETION NOTE
 
-ONLY WHEN C is selected and all requirements are saved to document and frontmatter is updated, will you then load, read entire file, then execute {nextStepFile} to execute and begin epic design step.
+ONLY WHEN C is selected and all requirements are saved to document and frontmatter is updated, will you then read fully and follow: {nextStepFile} to begin epic design step.
 
 ---
 

--- a/src/bmm/workflows/3-solutioning/create-epics-and-stories/steps/step-02-design-epics.md
+++ b/src/bmm/workflows/3-solutioning/create-epics-and-stories/steps/step-02-design-epics.md
@@ -194,9 +194,9 @@ Display: "**Select an Option:** [A] Advanced Elicitation [P] Party Mode [C] Cont
 
 #### Menu Handling Logic:
 
-- IF A: Execute {advancedElicitationTask}
-- IF P: Execute {partyModeWorkflow}
-- IF C: Save approved epics_list to {outputFile}, update frontmatter, then only then load, read entire file, then execute {nextStepFile}
+- IF A: Read fully and follow: {advancedElicitationTask}
+- IF P: Read fully and follow: {partyModeWorkflow}
+- IF C: Save approved epics_list to {outputFile}, update frontmatter, then read fully and follow: {nextStepFile}
 - IF Any other comments or queries: help user respond then [Redisplay Menu Options](#8-present-menu-options)
 
 #### EXECUTION RULES:
@@ -208,7 +208,7 @@ Display: "**Select an Option:** [A] Advanced Elicitation [P] Party Mode [C] Cont
 
 ## CRITICAL STEP COMPLETION NOTE
 
-ONLY WHEN C is selected and the approved epics_list is saved to document, will you then load, read entire file, then execute {nextStepFile} to execute and begin story creation step.
+ONLY WHEN C is selected and the approved epics_list is saved to document, will you then read fully and follow: {nextStepFile} to begin story creation step.
 
 ---
 

--- a/src/bmm/workflows/3-solutioning/create-epics-and-stories/steps/step-03-create-stories.md
+++ b/src/bmm/workflows/3-solutioning/create-epics-and-stories/steps/step-03-create-stories.md
@@ -231,9 +231,9 @@ Display: "**Select an Option:** [A] Advanced Elicitation [P] Party Mode [C] Cont
 
 #### Menu Handling Logic:
 
-- IF A: Execute {advancedElicitationTask}
-- IF P: Execute {partyModeWorkflow}
-- IF C: Save content to {outputFile}, update frontmatter, then only then load, read entire file, then execute {nextStepFile}
+- IF A: Read fully and follow: {advancedElicitationTask}
+- IF P: Read fully and follow: {partyModeWorkflow}
+- IF C: Save content to {outputFile}, update frontmatter, then read fully and follow: {nextStepFile}
 - IF Any other comments or queries: help user respond then [Redisplay Menu Options](#7-present-final-menu-options)
 
 #### EXECUTION RULES:
@@ -245,7 +245,7 @@ Display: "**Select an Option:** [A] Advanced Elicitation [P] Party Mode [C] Cont
 
 ## CRITICAL STEP COMPLETION NOTE
 
-ONLY WHEN [C continue option] is selected and [all epics and stories saved to document following the template structure exactly], will you then load and read fully `{nextStepFile}` to execute and begin final validation phase.
+ONLY WHEN [C continue option] is selected and [all epics and stories saved to document following the template structure exactly], will you then read fully and follow: `{nextStepFile}` to begin final validation phase.
 
 ---
 

--- a/src/bmm/workflows/3-solutioning/create-epics-and-stories/steps/step-04-final-validation.md
+++ b/src/bmm/workflows/3-solutioning/create-epics-and-stories/steps/step-04-final-validation.md
@@ -144,6 +144,6 @@ If all validations pass:
 
 When C is selected, the workflow is complete and the epics.md is ready for development.
 
-Execute task `_bmad/core/tasks/bmad-help.md` with argument `Create Epics and Stories`.
+Epics and Stories complete. Read fully and follow: `_bmad/core/tasks/bmad-help.md` with argument `Create Epics and Stories`.
 
 Upon Completion of task output: offer to answer any questions about the Epics and Stories.

--- a/src/bmm/workflows/3-solutioning/create-epics-and-stories/workflow.md
+++ b/src/bmm/workflows/3-solutioning/create-epics-and-stories/workflow.md
@@ -19,7 +19,7 @@ This uses **step-file architecture** for disciplined execution:
 ### Core Principles
 
 - **Micro-file Design**: Each step of the overall goal is a self contained instruction file that you will adhere too 1 file as directed at a time
-- **Just-In-Time Loading**: Only 1 current step file will be loaded, read, and executed to completion - never load future step files until told to do so
+- **Just-In-Time Loading**: Only 1 current step file will be loaded and followed to completion - never load future step files until told to do so
 - **Sequential Enforcement**: Sequence within the step files must be completed in order, no skipping or optimization allowed
 - **State Tracking**: Document progress in output file frontmatter using `stepsCompleted` array when a workflow produces a document
 - **Append-Only Building**: Build documents by appending content as directed to the output file
@@ -31,7 +31,7 @@ This uses **step-file architecture** for disciplined execution:
 3. **WAIT FOR INPUT**: If a menu is presented, halt and wait for user selection
 4. **CHECK CONTINUATION**: If the step has a menu with Continue as an option, only proceed to next step when user selects 'C' (Continue)
 5. **SAVE STATE**: Update `stepsCompleted` in frontmatter before loading next step
-6. **LOAD NEXT**: When directed, load, read entire file, then execute the next step file
+6. **LOAD NEXT**: When directed, read fully and follow the next step file
 
 ### Critical Rules (NO EXCEPTIONS)
 
@@ -56,4 +56,4 @@ Load and read full config from {project-root}/_bmad/bmm/config.yaml and resolve:
 
 ### 2. First Step EXECUTION
 
-Load, read the full file and then execute `{project-root}/_bmad/bmm/workflows/3-solutioning/create-epics-and-stories/steps/step-01-validate-prerequisites.md` to begin the workflow.
+Read fully and follow: `{project-root}/_bmad/bmm/workflows/3-solutioning/create-epics-and-stories/steps/step-01-validate-prerequisites.md` to begin the workflow.

--- a/src/bmm/workflows/4-implementation/correct-course/instructions.md
+++ b/src/bmm/workflows/4-implementation/correct-course/instructions.md
@@ -33,7 +33,7 @@
 </step>
 
 <step n="2" goal="Execute Change Analysis Checklist">
-  <action>Load and execute the systematic analysis from: {checklist}</action>
+  <action>Read fully and follow the systematic analysis from: {checklist}</action>
   <action>Work through each checklist section interactively with the user</action>
   <action>Record status for each checklist item:</action>
     - [x] Done - Item completed successfully

--- a/src/bmm/workflows/bmad-quick-flow/quick-dev/steps/step-05-adversarial-review.md
+++ b/src/bmm/workflows/bmad-quick-flow/quick-dev/steps/step-05-adversarial-review.md
@@ -65,7 +65,7 @@ With `{diff_output}` constructed, invoke the review task. If possible, use infor
 <invoke-task>Review {diff_output} using {project-root}/_bmad/core/tasks/review-adversarial-general.xml</invoke-task>
 ```
 
-**Platform fallback:** If task invocation not available, load the task file and execute its instructions inline, passing `{diff_output}` as the content.
+**Platform fallback:** If task invocation not available, load the task file and follow its instructions inline, passing `{diff_output}` as the content.
 
 The task should: review `{diff_output}` and return a list of findings.
 

--- a/src/bmm/workflows/bmad-quick-flow/quick-dev/workflow.md
+++ b/src/bmm/workflows/bmad-quick-flow/quick-dev/workflow.md
@@ -47,4 +47,4 @@ Load config from `{project-root}/_bmad/bmm/config.yaml` and resolve:
 
 ## EXECUTION
 
-Load and execute `steps/step-01-mode-detection.md` to begin the workflow.
+Read fully and follow: `steps/step-01-mode-detection.md` to begin the workflow.

--- a/src/bmm/workflows/bmad-quick-flow/quick-spec/steps/step-01-understand.md
+++ b/src/bmm/workflows/bmad-quick-flow/quick-spec/steps/step-01-understand.md
@@ -172,9 +172,9 @@ b) **HALT and wait for user selection.**
 
 #### Menu Handling:
 
-- **[a]**: Load and execute `{advanced_elicitation}`, then return here and redisplay menu
-- **[c]**: Load and execute `{nextStepFile}` (Map Technical Constraints)
-- **[p]**: Load and execute `{party_mode_exec}`, then return here and redisplay menu
+- **[a]**: Read fully and follow: `{advanced_elicitation}`, then return here and redisplay menu
+- **[c]**: Read fully and follow: `{nextStepFile}` (Map Technical Constraints)
+- **[p]**: Read fully and follow: `{party_mode_exec}`, then return here and redisplay menu
 
 ---
 

--- a/src/bmm/workflows/bmad-quick-flow/quick-spec/steps/step-02-investigate.md
+++ b/src/bmm/workflows/bmad-quick-flow/quick-spec/steps/step-02-investigate.md
@@ -127,9 +127,9 @@ Fill in:
 
 #### Menu Handling:
 
-- **[a]**: Load and execute `{advanced_elicitation}`, then return here and redisplay menu
-- **[c]**: Verify frontmatter updated with `stepsCompleted: [1, 2]`, then load and execute `{nextStepFile}`
-- **[p]**: Load and execute `{party_mode_exec}`, then return here and redisplay menu
+- **[a]**: Read fully and follow: `{advanced_elicitation}`, then return here and redisplay menu
+- **[c]**: Verify frontmatter updated with `stepsCompleted: [1, 2]`, then read fully and follow: `{nextStepFile}`
+- **[p]**: Read fully and follow: `{party_mode_exec}`, then return here and redisplay menu
 
 ---
 

--- a/src/bmm/workflows/bmad-quick-flow/quick-spec/steps/step-03-generate.md
+++ b/src/bmm/workflows/bmad-quick-flow/quick-spec/steps/step-03-generate.md
@@ -114,7 +114,7 @@ stepsCompleted: [1, 2, 3]
 ---
 ```
 
-c) **Load and execute `{nextStepFile}` (Step 4)**
+c) **Read fully and follow: `{nextStepFile}` (Step 4)**
 
 ## REQUIRED OUTPUTS:
 

--- a/src/bmm/workflows/bmad-quick-flow/quick-spec/steps/step-04-review.md
+++ b/src/bmm/workflows/bmad-quick-flow/quick-spec/steps/step-04-review.md
@@ -58,8 +58,8 @@ wipFile: '{implementation_artifacts}/tech-spec-wip.md'
 - **[y]**: Proceed to Section 3 (Finalize the Spec)
 - **[c]**: Proceed to Section 2 (Handle Review Feedback), then return here and redisplay menu
 - **[q]**: Answer questions, then redisplay this menu
-- **[a]**: Load and execute `{advanced_elicitation}`, then return here and redisplay menu
-- **[p]**: Load and execute `{party_mode_exec}`, then return here and redisplay menu
+- **[a]**: Read fully and follow: `{advanced_elicitation}`, then return here and redisplay menu
+- **[p]**: Read fully and follow: `{party_mode_exec}`, then return here and redisplay menu
 
 ### 2. Handle Review Feedback
 
@@ -137,15 +137,15 @@ b) **HALT and wait for user selection.**
 
 #### Menu Handling:
 
-- **[a]**: Load and execute `{advanced_elicitation}`, then return here and redisplay menu
-- **[b]**: Load and execute `{quick_dev_workflow}` with the final spec file (warn: fresh context is better)
+- **[a]**: Read fully and follow: `{advanced_elicitation}`, then return here and redisplay menu
+- **[b]**: Read fully and follow: `{quick_dev_workflow}` with the final spec file (warn: fresh context is better)
 - **[d]**: Exit workflow - display final confirmation and path to spec
-- **[p]**: Load and execute `{party_mode_exec}`, then return here and redisplay menu
+- **[p]**: Read fully and follow: `{party_mode_exec}`, then return here and redisplay menu
 - **[r]**: Execute Adversarial Review:
     1. **Invoke Adversarial Review Task**:
        > With `{finalFile}` constructed, invoke the review task. If possible, use information asymmetry: run this task, and only it, in a separate subagent or process with read access to the project, but no context except the `{finalFile}`.
        <invoke-task>Review {finalFile} using {project-root}/_bmad/core/tasks/review-adversarial-general.xml</invoke-task>
-       > **Platform fallback:** If task invocation not available, load the task file and execute its instructions inline, passing `{finalFile}` as the content.
+       > **Platform fallback:** If task invocation not available, load the task file and follow its instructions inline, passing `{finalFile}` as the content.
        > The task should: review `{finalFile}` and return a list of findings.
 
     2. **Process Findings**:

--- a/src/bmm/workflows/bmad-quick-flow/quick-spec/workflow.md
+++ b/src/bmm/workflows/bmad-quick-flow/quick-spec/workflow.md
@@ -49,7 +49,7 @@ This uses **step-file architecture** for disciplined execution:
 3. **WAIT FOR INPUT**: If a menu is presented, halt and wait for user selection
 4. **CHECK CONTINUATION**: Only proceed to next step when user selects [c] (Continue)
 5. **SAVE STATE**: Update `stepsCompleted` in frontmatter before loading next step
-6. **LOAD NEXT**: When directed, load and read entire next step file, then execute
+6. **LOAD NEXT**: When directed, read fully and follow the next step file
 
 ### Critical Rules (NO EXCEPTIONS)
 
@@ -76,4 +76,4 @@ Load and read full config from `{main_config}` and resolve:
 
 ### 2. First Step Execution
 
-Load, read the full file, and then execute `steps/step-01-understand.md` to begin the workflow.
+Read fully and follow: `steps/step-01-understand.md` to begin the workflow.

--- a/src/bmm/workflows/document-project/instructions.md
+++ b/src/bmm/workflows/document-project/instructions.md
@@ -97,11 +97,11 @@ Your choice [1/2/3]:
     <action>Display: "Resuming {{workflow_mode}} from {{current_step}} with cached project type(s): {{cached_project_types}}"</action>
 
     <check if="workflow_mode == deep_dive">
-      <action>Load and execute: {installed_path}/workflows/deep-dive-instructions.md with resume context</action>
+      <action>Read fully and follow: {installed_path}/workflows/deep-dive-instructions.md with resume context</action>
     </check>
 
     <check if="workflow_mode == initial_scan OR workflow_mode == full_rescan">
-      <action>Load and execute: {installed_path}/workflows/full-scan-instructions.md with resume context</action>
+      <action>Read fully and follow: {installed_path}/workflows/full-scan-instructions.md with resume context</action>
     </check>
 
   </check>
@@ -148,7 +148,7 @@ Your choice [1/2/3]:
   <check if="user selects 1">
     <action>Set workflow_mode = "full_rescan"</action>
     <action>Display: "Starting full project rescan..."</action>
-    <action>Load and execute: {installed_path}/workflows/full-scan-instructions.md</action>
+    <action>Read fully and follow: {installed_path}/workflows/full-scan-instructions.md</action>
     <action>After sub-workflow completes, continue to Step 4</action>
   </check>
 
@@ -156,7 +156,7 @@ Your choice [1/2/3]:
     <action>Set workflow_mode = "deep_dive"</action>
     <action>Set scan_level = "exhaustive"</action>
     <action>Display: "Starting deep-dive documentation mode..."</action>
-    <action>Load and execute: {installed_path}/workflows/deep-dive-instructions.md</action>
+    <action>Read fully and follow: {installed_path}/workflows/deep-dive-instructions.md</action>
     <action>After sub-workflow completes, continue to Step 4</action>
   </check>
 
@@ -169,7 +169,7 @@ Your choice [1/2/3]:
 <check if="index.md does not exist">
   <action>Set workflow_mode = "initial_scan"</action>
   <action>Display: "No existing documentation found. Starting initial project scan..."</action>
-  <action>Load and execute: {installed_path}/workflows/full-scan-instructions.md</action>
+  <action>Read fully and follow: {installed_path}/workflows/full-scan-instructions.md</action>
   <action>After sub-workflow completes, continue to Step 4</action>
 </check>
 

--- a/src/core/workflows/brainstorming/workflow.md
+++ b/src/core/workflows/brainstorming/workflow.md
@@ -53,6 +53,6 @@ Load config from `{project-root}/_bmad/core/config.yaml` and resolve:
 
 ## EXECUTION
 
-Load and execute `steps/step-01-session-setup.md` to begin the workflow.
+Read fully and follow: `steps/step-01-session-setup.md` to begin the workflow.
 
 **Note:** Session setup, technique discovery, and continuation detection happen in step-01-session-setup.md.

--- a/src/core/workflows/party-mode/steps/step-02-discussion-orchestration.md
+++ b/src/core/workflows/party-mode/steps/step-02-discussion-orchestration.md
@@ -136,7 +136,7 @@ Check for exit conditions before continuing:
 
 #### If 'E' (Exit Party Mode):
 
-- Load read and execute: `./step-03-graceful-exit.md`
+- Read fully and follow: `./step-03-graceful-exit.md`
 
 ## SUCCESS METRICS:
 

--- a/src/utility/agent-components/activation-steps.txt
+++ b/src/utility/agent-components/activation-steps.txt
@@ -9,5 +9,5 @@
     {AGENT_SPECIFIC_STEPS}
     <step n="{MENU_STEP}">Show greeting using {user_name} from config, communicate in {communication_language}, then display numbered list of ALL menu items from menu section</step>
     <step n="{HALT_STEP}">STOP and WAIT for user input - do NOT execute menu items automatically - accept number or cmd trigger or fuzzy command match</step>
-    <step n="{INPUT_STEP}">On user input: Number → execute menu item[n] | Text → case-insensitive substring match | Multiple matches → ask user to clarify | No match → show "Not recognized"</step>
-    <step n="{EXECUTE_STEP}">When executing a menu item: Check menu-handlers section below - extract any attributes from the selected menu item (workflow, exec, tmpl, data, action, validate-workflow) and follow the corresponding handler instructions</step>
+    <step n="{INPUT_STEP}">On user input: Number → process menu item[n] | Text → case-insensitive substring match | Multiple matches → ask user to clarify | No match → show "Not recognized"</step>
+    <step n="{EXECUTE_STEP}">When processing a menu item: Check menu-handlers section below - extract any attributes from the selected menu item (workflow, exec, tmpl, data, action, validate-workflow) and follow the corresponding handler instructions</step>

--- a/src/utility/agent-components/handler-action.txt
+++ b/src/utility/agent-components/handler-action.txt
@@ -1,4 +1,4 @@
   <handler type="action">
-    When menu item has: action="#id" → Find prompt with id="id" in current agent XML, execute its content
-    When menu item has: action="text" → Execute the text directly as an inline instruction
+    When menu item has: action="#id" → Find prompt with id="id" in current agent XML, follow its content
+    When menu item has: action="text" → Follow the text directly as an inline instruction
   </handler>

--- a/src/utility/agent-components/handler-exec.txt
+++ b/src/utility/agent-components/handler-exec.txt
@@ -1,6 +1,6 @@
     <handler type="exec">
       When menu item or handler has: exec="path/to/file.md":
-      1. Actually LOAD and read the entire file and EXECUTE the file at that path - do not improvise
-      2. Read the complete file and follow all instructions within it
+      1. Read fully and follow the file at that path
+      2. Process the complete file and follow all instructions within it
       3. If there is data="some/path/data-foo.md" with the same item, pass that data path to the executed file as context.
     </handler>

--- a/src/utility/agent-components/handler-multi.txt
+++ b/src/utility/agent-components/handler-multi.txt
@@ -4,7 +4,7 @@
          2. Parse all nested handlers within the multi item
          3. For each nested handler:
             - Use the 'match' attribute for fuzzy matching user input (or Exact Match of character code in brackets [])
-            - Execute based on handler attributes (exec, workflow, action)
+            - Process based on handler attributes (exec, workflow, action)
          4. When user input matches a handler's 'match' pattern:
             - For exec="path/to/file.md": follow the `handler type="exec"` instructions
             - For workflow="path/to/workflow.yaml": follow the `handler type="workflow"` instructions

--- a/src/utility/agent-components/handler-workflow.txt
+++ b/src/utility/agent-components/handler-workflow.txt
@@ -1,10 +1,10 @@
     <handler type="workflow">
       When menu item has: workflow="path/to/workflow.yaml":
-      
+
       1. CRITICAL: Always LOAD {project-root}/_bmad/core/tasks/workflow.xml
-      2. Read the complete file - this is the CORE OS for executing BMAD workflows
+      2. Read the complete file - this is the CORE OS for processing BMAD workflows
       3. Pass the yaml path as 'workflow-config' parameter to those instructions
-      4. Execute workflow.xml instructions precisely following all steps
+      4. Follow workflow.xml instructions precisely following all steps
       5. Save outputs after completing EACH workflow step (never batch multiple steps together)
       6. If workflow.yaml path is "todo", inform user the workflow hasn't been implemented yet
     </handler>


### PR DESCRIPTION
## Summary

- Replace ambiguous "execute" terminology with explicit "Read fully and follow:" phrasing across all workflow files
- Prevents LLM goal-seeking behavior where models attempt to "achieve the end result" rather than following step-by-step instructions verbatim
- Add "[Workflow] complete." prefix to 7 workflow endpoints for clear completion signaling
- Fix gitignore and markdownlint to ignore all `**/node_modules/**` directories

## Changes

- Update 5 handler templates with canonical phrasing
- Replace ~150 INSTRUCTIONAL patterns across 87 workflow files
- Preserve BEHAVIORAL/STRUCTURAL patterns (agent descriptions, XML tags)

## Test plan

- [x] Schema validation passes
- [x] Installation tests pass (13/13)
- [x] Agent schema tests pass (52/52)
- [x] Markdown lint passes (0 errors)
- [x] Adversarial code review completed with findings addressed

Closes #1372

🤖 Generated with [Claude Code](https://claude.com/claude-code)