### PR TITLE
fix(quick-spec): reorder final menu to D-B-A-P-R

### DIFF
--- a/src/bmm/workflows/bmad-quick-flow/quick-spec/steps/step-04-review.md
+++ b/src/bmm/workflows/bmad-quick-flow/quick-spec/steps/step-04-review.md
@@ -115,11 +115,11 @@ Saved to: {finalFile}
 
 **Next Steps:**
 
-[A] Advanced Elicitation - refine further
-[R] Adversarial Review - critique of the spec (highly recommended)
-[B] Begin Development - start implementing now (not recommended)
 [D] Done - exit workflow
+[B] Begin Development - start implementing now (not recommended)
+[A] Advanced Elicitation - refine further
 [P] Party Mode - get expert feedback before dev
+[R] Adversarial Review again - critique of the spec (highly recommended)
 
 ---
 
@@ -138,9 +138,9 @@ b) **HALT and wait for user selection.**
 
 #### Menu Handling Logic:
 
-- IF A: Read fully and follow: `{advanced_elicitation}` with current spec content, process enhanced insights, ask user "Accept improvements? (y/n)", if yes update spec then redisplay menu, if no keep original then redisplay menu
-- IF B: Load and execute `{quick_dev_workflow}` with the final spec file (warn: fresh context is better)
 - IF D: Exit workflow - display final confirmation and path to spec
+- IF B: Load and execute `{quick_dev_workflow}` with the final spec file (warn: fresh context is better)
+- IF A: Read fully and follow: `{advanced_elicitation}` with current spec content, process enhanced insights, ask user "Accept improvements? (y/n)", if yes update spec then redisplay menu, if no keep original then redisplay menu
 - IF P: Read fully and follow: `{party_mode_exec}` with current spec content, process collaborative insights, ask user "Accept changes? (y/n)", if yes update spec then redisplay menu, if no keep original then redisplay menu
 - IF R: Execute Adversarial Review (see below)
 - IF Any other comments or queries: respond helpfully then redisplay menu


### PR DESCRIPTION
## Summary

Reorders the final menu in quick-spec step-04-review to group related options:

**Before:** `[A] [R] [B] [D] [P]` — scattered, no logic

**After:** `[D] [B] [A] [P] [R]` — grouped by purpose:
- "Go-on" options first: Done, Begin Development
- "Reasoning" options last: Advanced Elicitation, Party Mode, Adversarial Review

Also adds "again" to Adversarial Review option for clarity.

Follows established pattern: most common action first, related options grouped together.

## Test plan

- [ ] Complete a quick-spec workflow to the final menu
- [ ] Verify menu displays in D-B-A-P-R order
- [ ] Verify R option says "Adversarial Review again"

🤖 Generated with [Claude Code](https://claude.com/claude-code)