### PR TITLE
feat: make workflow diagram iframe full-width

### DIFF
--- a/docs/reference/workflow-map.md
+++ b/docs/reference/workflow-map.md
@@ -11,7 +11,7 @@ If at anytime you are unsure what to do, the `/bmad-help` command will help you 
 
 Final important note: Every workflow below can be run directly with your tool of choice via slash command or by loading an agent first and using the entry from the agents menu.
 
-<iframe src="/workflow-map-diagram.html" width="100%" height="900" frameborder="0" style="border-radius: 8px; border: 1px solid #334155;"></iframe>
+<iframe src="/workflow-map-diagram.html" width="100%" height="700" frameborder="0" style="border-radius: 0; border: none;"></iframe>
 
 *[Interactive diagram - hover over outputs to see artifact flows]*
 

--- a/website/src/styles/custom.css
+++ b/website/src/styles/custom.css
@@ -181,6 +181,15 @@
   margin: 0 auto;
 }
 
+/* Full-width workflow diagram iframe */
+.sl-markdown-content > iframe:first-child {
+  width: 100vw !important;
+  margin-left: calc(50% - 50vw);
+  border-radius: 0 !important;
+  border-left: none !important;
+  border-right: none !important;
+}
+
 /* Main content area */
 main {
   min-width: 0;


### PR DESCRIPTION
## What
Makes the embedded workflow diagram iframe span the full viewport width instead of being constrained by the content container.

## Why
The horizontal layout of the workflow diagram needs more width to display properly. The current max-width constraint (1400px) causes the diagram to be cramped and leaves unused space on wider screens.

## Changes
- Added CSS rule to make the first iframe in markdown content break out to full viewport width
- Uses `width: 100vw` and negative margin technique to escape the container
- Removes border and border-radius for seamless full-width appearance
- Adjusts iframe height from 900px to 700px for better fit

## Files
- `website/src/styles/custom.css` - added full-width iframe rule
- `docs/reference/workflow-map.md` - updated iframe styling