### PR TITLE
fix: remove --prefer-offline flag to prevent stale cache errors

### DIFF
--- a/tools/cli/installers/lib/modules/manager.js
+++ b/tools/cli/installers/lib/modules/manager.js
@@ -416,7 +416,7 @@ class ModuleManager {
       if (needsDependencyInstall || wasNewClone || nodeModulesMissing) {
         const installSpinner = ora(`Installing dependencies for ${moduleInfo.name}...`).start();
         try {
-          execSync('npm install --production --no-audit --no-fund --prefer-offline --no-progress', {
+          execSync('npm install --omit=dev --no-audit --no-fund --no-progress', {
             cwd: moduleCacheDir,
             stdio: 'pipe',
             timeout: 120_000, // 2 minute timeout
@@ -441,7 +441,7 @@ class ModuleManager {
         if (packageJsonNewer) {
           const installSpinner = ora(`Installing dependencies for ${moduleInfo.name}...`).start();
           try {
-            execSync('npm install --production --no-audit --no-fund --prefer-offline --no-progress', {
+            execSync('npm install --omit=dev --no-audit --no-fund --no-progress', {
               cwd: moduleCacheDir,
               stdio: 'pipe',
               timeout: 120_000, // 2 minute timeout


### PR DESCRIPTION
## What
Removes the `--prefer-offline` flag from npm install commands in the module installer.

## Why
The `--prefer-offline` flag causes npm to use cached package metadata, which can be stale and fail to resolve recently published package versions (e.g., `diff@8.0.3`). This results in `ETARGET` errors during fresh installations.

Fixes #1438

## How
- Removed `--prefer-offline` from both npm install calls in `manager.js`
- Updated deprecated `--production` flag to `--omit=dev`

## Testing
Verified that `npm install --omit=dev --no-audit --no-fund --no-progress` correctly installs dependencies without the stale cache issue.