### PR TITLE
fix: correct relative path to prd-purpose.md in step-11-polish

### DIFF
--- a/src/bmm/workflows/2-plan-workflows/create-prd/steps-c/step-11-polish.md
+++ b/src/bmm/workflows/2-plan-workflows/create-prd/steps-c/step-11-polish.md
@@ -5,7 +5,7 @@ description: 'Optimize and polish the complete PRD document for flow, coherence,
 # File References
 nextStepFile: './step-12-complete.md'
 outputFile: '{planning_artifacts}/prd.md'
-purposeFile: './data/prd-purpose.md'
+purposeFile: '../data/prd-purpose.md'
 
 # Task References
 advancedElicitationTask: '{project-root}/_bmad/core/workflows/advanced-elicitation/workflow.xml'


### PR DESCRIPTION
## Summary

The `purposeFile` reference in `step-11-polish.md` uses `./data/prd-purpose.md` but the `data/` directory is a sibling of the `steps-c/` directory, not inside it. The correct relative path from `steps-c/` is `../data/prd-purpose.md`.

**File:** `src/bmm/workflows/2-plan-workflows/create-prd/steps-c/step-11-polish.md` (line 8)

```diff
- purposeFile: './data/prd-purpose.md'
+ purposeFile: '../data/prd-purpose.md'
```

**Directory structure:**
```
create-prd/
├── data/
│   └── prd-purpose.md    ← target file
├── steps-c/
│   └── step-11-polish.md ← referencing file (./data/ is wrong, ../data/ is correct)
└── ...
```

Fixes #1495

> 🔍 This broken reference was detected by the cross-file reference validator proposed in #1494. With that validator in CI, this class of bug would be caught automatically at PR time.

## Test plan

- [x] `npm test` passes (all linting, schema validation, formatting checks)
- [x] Verified `../data/prd-purpose.md` resolves to the correct file