### PR TITLE
fix: remove tracked .claude/commands file from version control

### DIFF
--- a/.claude/commands/bmad-bmm-generate-project-context.md
+++ b/.claude/commands/bmad-bmm-generate-project-context.md
@@ -1,7 +1,0 @@
----
-name: 'generate-project-context'
-description: 'Creates a concise project-context.md file with critical rules and patterns that AI agents must follow when implementing code. Optimized for LLM context efficiency.'
-disable-model-invocation: true
----
-
-IT IS CRITICAL THAT YOU FOLLOW THIS COMMAND: LOAD the FULL @{project-root}/_bmad/bmm/workflows/generate-project-context/workflow.md, READ its entire contents and follow its directions exactly!


### PR DESCRIPTION
## Summary
- Removes `.claude/commands/bmad-bmm-generate-project-context.md` from git tracking
- This file was accidentally tracked despite `.claude/commands` being in `.gitignore`
- The installer generates this file at install time from source templates — it should not be tracked

## Test plan
- [x] All tests pass (npm run test)
- [x] File is untracked but still exists locally (gitignore covers it)

🤖 Generated with [Claude Code](https://claude.com/claude-code)