### PR TITLE
fix: remove --prefer-offline flag and update deprecated --production to --omit=dev

### DIFF
--- a/tools/cli/installers/lib/modules/manager.js
+++ b/tools/cli/installers/lib/modules/manager.js
@@ -417,7 +417,7 @@ class ModuleManager {
       if (needsDependencyInstall || wasNewClone || nodeModulesMissing) {
         const installSpinner = ora(`Installing dependencies for ${moduleInfo.name}...`).start();
         try {
-          execSync('npm install --production --no-audit --no-fund --prefer-offline --no-progress --legacy-peer-deps', {
+          execSync('npm install --omit=dev --no-audit --no-fund --no-progress --legacy-peer-deps', {
             cwd: moduleCacheDir,
             stdio: 'pipe',
             timeout: 120_000, // 2 minute timeout
@@ -442,7 +442,7 @@ class ModuleManager {
         if (packageJsonNewer) {
           const installSpinner = ora(`Installing dependencies for ${moduleInfo.name}...`).start();
           try {
-            execSync('npm install --production --no-audit --no-fund --prefer-offline --no-progress --legacy-peer-deps', {
+            execSync('npm install --omit=dev --no-audit --no-fund --no-progress --legacy-peer-deps', {
               cwd: moduleCacheDir,
               stdio: 'pipe',
               timeout: 120_000, // 2 minute timeout


### PR DESCRIPTION
## What
Removes the `--prefer-offline` flag and replaces deprecated `--production` with `--omit=dev` in npm install commands in the module installer.

## Why
- **`--prefer-offline`** causes npm to use cached package metadata, which can be stale and fail to resolve recently published package versions (e.g., `diff@8.0.3`). This results in `ETARGET` errors during fresh installations.
- **`--production`** is deprecated by npm in favor of `--omit=dev`.

Fixes #1438

Replaces #1440 (closed due to merge conflicts from force-push; conflicts now resolved against current main).

## How
- Removed `--prefer-offline` from both npm install calls in `manager.js`
- Updated deprecated `--production` flag to `--omit=dev`
- Preserved `--legacy-peer-deps` from #1476

## Note on #1479
Issue #1479 consolidates multiple installer failures, but the `--prefer-offline` and `--production` flag fixes **have not yet been applied** to main. This PR provides the targeted fix for these specific npm flag issues.

## Testing
Verified that `npm install --omit=dev --no-audit --no-fund --no-progress --legacy-peer-deps` correctly installs dependencies without the stale cache issue.