### PR TITLE
fix: route OpenCode agents to correct .opencode/agent/ directory

### DIFF
--- a/tools/cli/installers/lib/ide/platform-codes.yaml
+++ b/tools/cli/installers/lib/ide/platform-codes.yaml
@@ -124,8 +124,13 @@ platforms:
     category: ide
     description: "OpenCode terminal coding assistant"
     installer:
-      target_dir: .opencode/command
-      template_type: opencode
+      targets:
+        - target_dir: .opencode/agent
+          template_type: opencode
+          artifact_types: [agents]
+        - target_dir: .opencode/command
+          template_type: opencode
+          artifact_types: [workflows, tasks, tools]
 
   qwen:
     name: "QwenCoder"


### PR DESCRIPTION
# What
Fixed OpenCode IDE installer to route agents to `.opencode/agent/` directory instead of `.opencode/command/`.

# Why
Since v6.0.0 beta, BMAD agents were being incorrectly installed to `.opencode/command/` instead of `.opencode/agent/`, causing agents to not be recognized by OpenCode. Workflows/tasks/tools still belong in `command/`.
Fixes #1548

# How
- Changed `opencode` platform config from single `target_dir` to multi-target `targets` array
- Agents now route to `.opencode/agent/` 
- Workflows/tasks/tools route to `.opencode/command/`
 Testing
Tested locally by running `bmad install` in a temp directory and verifying:
- `bmad-agent-*.md` files appear in `.opencode/agent/`
- Other artifacts appear in `.opencode/command/`