### PR TITLE
fix: Fix IDE Selector Spacebar Behavior

### DIFF
--- a/tools/cli/lib/prompts.js
+++ b/tools/cli/lib/prompts.js
@@ -322,6 +322,25 @@ async function autocompleteMultiselect(options) {
     },
   });
 
+  // === FIX: Make SPACE always act as selection key (not search input) ===
+  // Override _isActionKey to treat SPACE like TAB - always an action key
+  // This prevents SPACE from being added to the search input
+  const originalIsActionKey = prompt._isActionKey.bind(prompt);
+  prompt._isActionKey = function (char, key) {
+    if (key && key.name === 'space') {
+      return true;
+    }
+    return originalIsActionKey(char, key);
+  };
+
+  // Handle SPACE toggle when NOT navigating (internal code only handles it when isNavigating=true)
+  prompt.on('key', (char, key) => {
+    if (key && key.name === 'space' && !prompt.isNavigating && prompt.focusedValue !== undefined) {
+      prompt.toggleSelected(prompt.focusedValue);
+    }
+  });
+  // === END FIX ===
+
   const result = await prompt.prompt();
   await handleCancel(result);
   return result;

--- a/tools/cli/lib/ui.js
+++ b/tools/cli/lib/ui.js
@@ -634,7 +634,7 @@ class UI {
 
     // Interactive mode
     const interactiveSelectedIdes = await prompts.autocompleteMultiselect({
-      message: 'Select tools:',
+      message: 'Integrate with:',
       options: allToolOptions,
       initialValues: configuredIdes.length > 0 ? configuredIdes : undefined,
       required: false,


### PR DESCRIPTION
## Summary
- Fixed SPACE key not working as users are used to and expect in the IDE integration selector
- Changed prompt label from "Select tools:" to "Integrate with:" for consistency with upgrade flow

## Problem
In the autocomplete multiselect prompt, users expected SPACE to toggle selection (standard UX pattern), but:
- Pressing SPACE initially added a space character to the search input instead of selecting
- SPACE only worked for selection after first pressing UP/DOWN arrows

This was caused by `@clack/core`'s `AutocompletePrompt` only treating SPACE as an action key when `isNavigating=true` (set after arrow key navigation).

## Solution
Added a monkey-patch in `tools/cli/lib/prompts.js` that:
1. Overrides `_isActionKey` to always return `true` for SPACE (prevents it from being added to search input)
2. Adds a key event handler that calls `toggleSelected` when NOT navigating (since internal code only handles it when navigating)

## Why This Is Safe

**Public/Semi-public APIs used:**
- `prompt.on('key', ...)` - Standard EventEmitter pattern, documented in clack
- `prompt.toggleSelected(value)` - Public method for toggling selection
- `prompt.focusedValue` - Public property for current focused option
- `prompt.isNavigating` - Public state property

**`_isActionKey` override:**
- While prefixed with `_`, this method is designed for customization per TypeScript definitions
- Uses safe `bind(prompt)` pattern to preserve original context
- Calls through to original implementation for non-SPACE keys

**No breaking changes:**
- TAB still works as before (unchanged code path)
- Arrow navigation unchanged
- Search input works for all other characters
- ENTER submission unchanged

## Test Plan
- [ ] Fresh install: Press SPACE immediately at IDE selection → toggles first IDE
- [ ] Press DOWN then SPACE → toggles second IDE
- [ ] Type "cur" then SPACE → toggles Cursor (search still works)
- [ ] TAB still toggles selection
- [ ] ENTER submits selection
- [ ] Upgrade flow: Same behaviors work
- [ ] Label shows "Integrate with:" on both fresh install and upgrade
