### PR TITLE
ci: trigger CodeRabbit review on PR un-draft

### DIFF
--- a/.github/workflows/coderabbit-review.yaml
+++ b/.github/workflows/coderabbit-review.yaml
@@ -1,0 +1,22 @@
+name: Trigger CodeRabbit on Ready for Review
+
+on:
+  pull_request:
+    types: [ready_for_review]
+
+jobs:
+  trigger-review:
+    runs-on: ubuntu-latest
+    permissions:
+      pull-requests: write
+    steps:
+      - name: Request CodeRabbit review
+        uses: actions/github-script@v7
+        with:
+          script: |
+            await github.rest.issues.createComment({
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              issue_number: context.payload.pull_request.number,
+              body: '@coderabbitai review'
+            });


### PR DESCRIPTION
## Summary

- Adds a GitHub Actions workflow that automatically triggers CodeRabbit review when a draft PR is marked as ready for review
- Works around a known CodeRabbit limitation where the `ready_for_review` webhook event is not reliably handled

## Context

CodeRabbit auto-review triggers on PR creation (`opened` event) but often misses the `ready_for_review` event fired when a draft PR is un-drafted. This workflow listens for that event and posts `@coderabbitai review` as a comment, ensuring the review happens automatically.

## Test plan

- [ ] Create a draft PR, then mark it as ready for review
- [ ] Verify the workflow runs and posts the `@coderabbitai review` comment
- [ ] Verify CodeRabbit then performs the review automatically