### PR TITLE
docs: add description front matter to documentation pages

### DIFF
--- a/docs/_STYLE_GUIDE.md
+++ b/docs/_STYLE_GUIDE.md
@@ -1,5 +1,6 @@
 ---
 title: "Documentation Style Guide"
+description: Project-specific documentation conventions based on Google style and Diataxis structure
 ---
 
 This project adheres to the [Google Developer Documentation Style Guide](https://developers.google.com/style) and uses [Diataxis](https://diataxis.fr/) to structure content. Only project-specific conventions follow.

--- a/docs/bmgd/game-types.md
+++ b/docs/bmgd/game-types.md
@@ -1,5 +1,6 @@
 ---
 title: "Game Types Reference"
+description: 24 game type templates with genre-specific GDD sections for BMGD
 draft: true
 ---
 

--- a/docs/bmgd/quick-flow-workflows.md
+++ b/docs/bmgd/quick-flow-workflows.md
@@ -1,5 +1,6 @@
 ---
 title: "Quick Flow Workflows"
+description: Create tech specs and execute implementations with BMGD Quick Flow
 draft: true
 ---
 

--- a/docs/downloads.md
+++ b/docs/downloads.md
@@ -1,5 +1,6 @@
 ---
 title: Downloads
+description: Download BMad Method source bundles, prompts, and LLM-optimized documentation files
 ---
 
 Download BMad Method resources for offline use, AI training, or integration.

--- a/docs/how-to/customize-bmad.md
+++ b/docs/how-to/customize-bmad.md
@@ -1,5 +1,6 @@
 ---
 title: "BMad Method Customization Guide"
+description: Customize agents, workflows, and modules while preserving update compatibility
 ---
 
 The ability to customize the BMad Method and its core to your needs, while still being able to get updates and enhancements is a critical idea within the BMad Ecosystem.

--- a/docs/how-to/shard-large-documents.md
+++ b/docs/how-to/shard-large-documents.md
@@ -1,5 +1,6 @@
 ---
 title: "Document Sharding Guide"
+description: Split large markdown files into smaller organized files for better context management
 ---
 
 Use the `shard-doc` tool to split large markdown files into smaller, organized files for better context management.

--- a/docs/index.md
+++ b/docs/index.md
@@ -1,5 +1,6 @@
 ---
 title: Welcome to the BMad Method
+description: AI-driven development framework with specialized agents, guided workflows, and intelligent planning
 ---
 
 The BMad Method (**B**reakthrough **M**ethod of **A**gile AI **D**riven Development) is an AI-driven development framework that helps you build software faster and smarter. It provides specialized AI agents, guided workflows, and intelligent planning that adapts to your project's complexity—whether you're fixing a bug or building an enterprise platform.

--- a/docs/reference/agents.md
+++ b/docs/reference/agents.md
@@ -1,5 +1,6 @@
 ---
 title: Agents
+description: Default BMM agents with their menu triggers and primary workflows
 ---
 
 This page lists the default BMM (Agile suite) agents that install with BMAD Method, along with their menu triggers and primary workflows.

--- a/docs/reference/modules.md
+++ b/docs/reference/modules.md
@@ -1,5 +1,6 @@
 ---
 title: Official Modules
+description: Add-on modules for building custom agents, creative intelligence, game development, and testing
 ---
 
 BMad extends through official modules that you select during installation. These add-on modules provide specialized agents, workflows, and tasks for specific domains beyond the built-in core and BMM (Agile suite).

--- a/docs/reference/testing.md
+++ b/docs/reference/testing.md
@@ -1,5 +1,6 @@
 ---
 title: Testing Options
+description: Built-in QA agent and the standalone Test Architect module for advanced testing
 ---
 
 # Testing Options


### PR DESCRIPTION
## Summary
- Add `description` front matter to 10 documentation pages for improved SEO and metadata
- Descriptions are concise, page-relevant summaries under 160 characters
- Excluded 404 page as it is not indexed by search engines

## Test plan
- [x] All pre-commit hooks pass (lint, tests, build)
- [x] Site builds successfully with descriptions rendered