### PR TITLE
fix: remove stale validate-workflow.xml references

### DIFF
--- a/src/bmm/workflows/4-implementation/create-story/checklist.md
+++ b/src/bmm/workflows/4-implementation/create-story/checklist.md
@@ -33,11 +33,11 @@ This is a COMPETITION to create the **ULTIMATE story context** that makes LLM de
 
 ### **When Running from Create-Story Workflow:**
 
-- The `{project-root}/_bmad/core/tasks/validate-workflow.xml` framework will automatically:
-  - Load this checklist file
-  - Load the newly created story file (`{story_file_path}`)
-  - Load workflow variables from `{installed_path}/workflow.yaml`
-  - Execute the validation process
+The workflow will:
+- Load this checklist file
+- Load the newly created story file (`{story_file_path}`)
+- Load workflow variables from `{installed_path}/workflow.yaml`
+- Execute the validation process
 
 ### **When Running in Fresh Context:**
 
@@ -51,7 +51,6 @@ This is a COMPETITION to create the **ULTIMATE story context** that makes LLM de
 - **Story file**: The story file to review and improve
 - **Workflow variables**: From workflow.yaml (story_dir, output_folder, epics_file, etc.)
 - **Source documents**: Epics, architecture, etc. (discovered or provided)
-- **Validation framework**: `validate-workflow.xml` (handles checklist execution)
 
 ---
 
@@ -63,12 +62,11 @@ You will systematically re-do the entire story creation process, but with a crit
 
 1. **Load the workflow configuration**: `{installed_path}/workflow.yaml` for variable inclusion
 2. **Load the story file**: `{story_file_path}` (provided by user or discovered)
-3. **Load validation framework**: `{project-root}/_bmad/core/tasks/validate-workflow.xml`
-4. **Extract metadata**: epic_num, story_num, story_key, story_title from story file
-5. **Resolve all workflow variables**: story_dir, output_folder, epics_file, architecture_file, etc.
-6. **Understand current status**: What story implementation guidance is currently provided?
+3. **Extract metadata**: epic_num, story_num, story_key, story_title from story file
+4. **Resolve all workflow variables**: story_dir, output_folder, epics_file, architecture_file, etc.
+5. **Understand current status**: What story implementation guidance is currently provided?
 
-**Note:** If running in fresh context, user should provide the story file path being reviewed. If running from create-story workflow, the validation framework will automatically discover the checklist and story file.
+**Note:** If running in fresh context, user should provide the story file path being reviewed. If running from create-story workflow, the workflow will automatically provide the checklist and story file paths.
 
 ### **Step 2: Exhaustive Source Document Analysis**
 

--- a/src/bmm/workflows/4-implementation/create-story/instructions.xml
+++ b/src/bmm/workflows/4-implementation/create-story/instructions.xml
@@ -310,7 +310,7 @@
   </step>
 
   <step n="6" goal="Update sprint status and finalize">
-    <invoke-task>Validate against checklist at {installed_path}/checklist.md using _bmad/core/tasks/validate-workflow.xml</invoke-task>
+    <action>Validate story against checklist at {installed_path}/checklist.md</action>
     <action>Save story document unconditionally</action>
 
     <!-- Update sprint status -->

--- a/src/utility/agent-components/activation-steps.txt
+++ b/src/utility/agent-components/activation-steps.txt
@@ -11,4 +11,4 @@
     <step n="{HELP_STEP}">Let {user_name} know they can type command `/bmad-help` at any time to get advice on what to do next, and that they can combine that with what they need help with <example>`/bmad-help where should I start with an idea I have that does XYZ`</example></step>
     <step n="{HALT_STEP}">STOP and WAIT for user input - do NOT execute menu items automatically - accept number or cmd trigger or fuzzy command match</step>
     <step n="{INPUT_STEP}">On user input: Number → process menu item[n] | Text → case-insensitive substring match | Multiple matches → ask user to clarify | No match → show "Not recognized"</step>
-    <step n="{EXECUTE_STEP}">When processing a menu item: Check menu-handlers section below - extract any attributes from the selected menu item (workflow, exec, tmpl, data, action, validate-workflow) and follow the corresponding handler instructions</step>
+    <step n="{EXECUTE_STEP}">When processing a menu item: Check menu-handlers section below - extract any attributes from the selected menu item (workflow, exec, tmpl, data, action) and follow the corresponding handler instructions</step>

--- a/src/utility/agent-components/handler-validate-workflow.txt
+++ b/src/utility/agent-components/handler-validate-workflow.txt
@@ -1,7 +1,0 @@
-    <handler type="validate-workflow">
-        When command has: validate-workflow="path/to/workflow.yaml"
-        1. You MUST LOAD the file at: {project-root}/_bmad/core/tasks/validate-workflow.xml
-        2. READ its entire contents and EXECUTE all instructions in that file
-        3. Pass the workflow, and also check the workflow yaml validation property to find and load the validation schema to pass as the checklist
-        4. The workflow should try to identify the file to validate based on checklist context or else you will ask the user to specify
-    </handler>

--- a/test/README.md
+++ b/test/README.md
@@ -116,7 +116,7 @@ Tests required menu structure:
 
 Tests menu item command targets:
 
-- ✅ Valid: All 6 command types (`workflow`, `validate-workflow`, `exec`, `action`, `tmpl`, `data`)
+- ✅ Valid: All 5 command types (`workflow`, `exec`, `action`, `tmpl`, `data`)
 - ✅ Valid: Multiple command targets in one menu item
 - ❌ Invalid: No command target fields
 - ❌ Invalid: Empty string command targets


### PR DESCRIPTION
## Summary
Remove stale references to `validate-workflow.xml` which was intentionally removed from the project.

## Changes
- Delete `handler-validate-workflow.txt` (handler for removed task)
- Update `checklist.md` (remove framework references)
- Update `instructions.xml` (replace invoke-task with action)
- Update `activation-steps.txt` (remove from command list)
- Update `test/README.md` (5 command types, not 6)

## Context
Issue #1530 reported that `validate-workflow.xml` was missing. @alexeyv confirmed the file was intentionally removed. This PR cleans up the remaining stale references to prevent confusion.

Closes #1530