### PR TITLE
fix: use pull_request_target for CodeRabbit review trigger

### DIFF
--- a/.github/workflows/coderabbit-review.yaml
+++ b/.github/workflows/coderabbit-review.yaml
@@ -1,7 +1,7 @@
 name: Trigger CodeRabbit on Ready for Review
 
 on:
-  pull_request:
+  pull_request_target:
     types: [ready_for_review]
 
 jobs:


### PR DESCRIPTION
## Summary

- Fixes 403 "Resource not accessible by integration" error on the CodeRabbit review trigger workflow
- Changes `pull_request` to `pull_request_target` so the workflow runs in the base repo context with write permissions, which is required for fork PRs
- Safe because the workflow only posts a comment and does not check out or execute any PR code

## Context

The workflow triggers when a draft PR is marked "ready for review" to request a CodeRabbit review via comment. For cross-repository (fork) PRs, GitHub restricts `GITHUB_TOKEN` to read-only on `pull_request` events regardless of declared permissions. `pull_request_target` resolves this by running in the base repo context.

Failed run: https://github.com/bmad-code-org/BMAD-METHOD/actions/runs/21776395455

## Test plan

- [ ] Merge this PR
- [ ] Mark PR #1511 (or another fork draft PR) as "ready for review"
- [ ] Verify the workflow posts the `@coderabbitai review` comment successfully

🤖 Generated with [Claude Code](https://claude.com/claude-code)