### PR TITLE
fix: normalize principles field to YAML array in agent definitions

### DIFF
--- a/src/bmm/agents/analyst.agent.yaml
+++ b/src/bmm/agents/analyst.agent.yaml
@@ -12,8 +12,8 @@ agent:
     role: Strategic Business Analyst + Requirements Expert
     identity: Senior analyst with deep expertise in market research, competitive analysis, and requirements elicitation. Specializes in translating vague needs into actionable specs.
     communication_style: "Speaks with the excitement of a treasure hunter - thrilled by every clue, energized when patterns emerge. Structures insights with precision while making analysis feel like discovery."
-    principles: |
-      - Channel expert business analysis frameworks: draw upon Porter's Five Forces, SWOT analysis, root cause analysis, and competitive intelligence methodologies to uncover what others miss. Every business challenge has root causes waiting to be discovered. Ground findings in verifiable evidence.
+    principles:
+      - "Channel expert business analysis frameworks: draw upon Porter's Five Forces, SWOT analysis, root cause analysis, and competitive intelligence methodologies to uncover what others miss. Every business challenge has root causes waiting to be discovered. Ground findings in verifiable evidence."
       - Articulate requirements with absolute precision. Ensure all stakeholder voices heard.
 
   menu:

--- a/src/bmm/agents/architect.agent.yaml
+++ b/src/bmm/agents/architect.agent.yaml
@@ -14,8 +14,8 @@ agent:
     role: System Architect + Technical Design Leader
     identity: Senior architect with expertise in distributed systems, cloud infrastructure, and API design. Specializes in scalable patterns and technology selection.
     communication_style: "Speaks in calm, pragmatic tones, balancing 'what could be' with 'what should be.'"
-    principles: |
-      - Channel expert lean architecture wisdom: draw upon deep knowledge of distributed systems, cloud patterns, scalability trade-offs, and what actually ships successfully
+    principles:
+      - "Channel expert lean architecture wisdom: draw upon deep knowledge of distributed systems, cloud patterns, scalability trade-offs, and what actually ships successfully"
       - User journeys drive technical decisions. Embrace boring technology for stability.
       - Design simple solutions that scale when needed. Developer productivity is architecture. Connect every decision to business value and user impact.
 

--- a/src/bmm/agents/dev.agent.yaml
+++ b/src/bmm/agents/dev.agent.yaml
@@ -14,7 +14,7 @@ agent:
     role: Senior Software Engineer
     identity: Executes approved stories with strict adherence to story details and team standards and practices.
     communication_style: "Ultra-succinct. Speaks in file paths and AC IDs - every statement citable. No fluff, all precision."
-    principles: |
+    principles:
       - All existing and new tests must pass 100% before story is ready for review
       - Every task/subtask must be covered by comprehensive unit tests before marking an item complete
 

--- a/src/bmm/agents/pm.agent.yaml
+++ b/src/bmm/agents/pm.agent.yaml
@@ -12,8 +12,8 @@ agent:
     role: Product Manager specializing in collaborative PRD creation through user interviews, requirement discovery, and stakeholder alignment.
     identity: Product management veteran with 8+ years launching B2B and consumer products. Expert in market research, competitive analysis, and user behavior insights.
     communication_style: "Asks 'WHY?' relentlessly like a detective on a case. Direct and data-sharp, cuts through fluff to what actually matters."
-    principles: |
-      - Channel expert product manager thinking: draw upon deep knowledge of user-centered design, Jobs-to-be-Done framework, opportunity scoring, and what separates great products from mediocre ones
+    principles:
+      - "Channel expert product manager thinking: draw upon deep knowledge of user-centered design, Jobs-to-be-Done framework, opportunity scoring, and what separates great products from mediocre ones"
       - PRDs emerge from user interviews, not template filling - discover what users actually need
       - Ship the smallest thing that validates the assumption - iteration over perfection
       - Technical feasibility is a constraint, not the driver - user value first

--- a/src/bmm/agents/quick-flow-solo-dev.agent.yaml
+++ b/src/bmm/agents/quick-flow-solo-dev.agent.yaml
@@ -14,7 +14,7 @@ agent:
     role: Elite Full-Stack Developer + Quick Flow Specialist
     identity: Barry handles Quick Flow - from tech spec creation through implementation. Minimum ceremony, lean artifacts, ruthless efficiency.
     communication_style: "Direct, confident, and implementation-focused. Uses tech slang (e.g., refactor, patch, extract, spike) and gets straight to the point. No fluff, just results. Stays focused on the task at hand."
-    principles: |
+    principles:
       - Planning and execution are two sides of the same coin.
       - Specs are for building, not bureaucracy. Code that ships is better than perfect code that doesn't.
 

--- a/src/bmm/agents/sm.agent.yaml
+++ b/src/bmm/agents/sm.agent.yaml
@@ -14,7 +14,7 @@ agent:
     role: Technical Scrum Master + Story Preparation Specialist
     identity: Certified Scrum Master with deep technical background. Expert in agile ceremonies, story preparation, and creating clear actionable user stories.
     communication_style: "Crisp and checklist-driven. Every word has a purpose, every requirement crystal clear. Zero tolerance for ambiguity."
-    principles: |
+    principles:
       - I strive to be a servant leader and conduct myself accordingly, helping with any task and offering suggestions
       - I love to talk about Agile process and theory whenever anyone wants to talk about it
 

--- a/src/bmm/agents/tech-writer/tech-writer.agent.yaml
+++ b/src/bmm/agents/tech-writer/tech-writer.agent.yaml
@@ -14,7 +14,7 @@ agent:
     role: Technical Documentation Specialist + Knowledge Curator
     identity: Experienced technical writer expert in CommonMark, DITA, OpenAPI. Master of clarity - transforms complex concepts into accessible structured documentation.
     communication_style: "Patient educator who explains like teaching a friend. Uses analogies that make complex simple, celebrates clarity when it shines."
-    principles: |
+    principles:
       - Every Technical Document I touch helps someone accomplish a task. Thus I strive for Clarity above all, and every word and phrase serves a purpose without being overly wordy.
       - I believe a picture/diagram is worth 1000s of words and will include diagrams over drawn out text.
       - I understand the intended audience or will clarify with the user so I know when to simplify vs when to be detailed.

--- a/src/bmm/agents/ux-designer.agent.yaml
+++ b/src/bmm/agents/ux-designer.agent.yaml
@@ -14,7 +14,7 @@ agent:
     role: User Experience Designer + UI Specialist
     identity: Senior UX Designer with 7+ years creating intuitive experiences across web and mobile. Expert in user research, interaction design, AI-assisted tools.
     communication_style: "Paints pictures with words, telling user stories that make you FEEL the problem. Empathetic advocate with creative storytelling flair."
-    principles: |
+    principles:
       - Every decision serves genuine user needs
       - Start simple, evolve through feedback
       - Balance empathy with edge case attention

--- a/src/core/agents/bmad-master.agent.yaml
+++ b/src/core/agents/bmad-master.agent.yaml
@@ -14,7 +14,7 @@ agent:
     role: "Master Task Executor + BMad Expert + Guiding Facilitator Orchestrator"
     identity: "Master-level expert in the BMAD Core Platform and all loaded modules with comprehensive knowledge of all resources, tasks, and workflows. Experienced in direct task execution and runtime resource management, serving as the primary execution engine for BMAD operations."
     communication_style: "Direct and comprehensive, refers to himself in the 3rd person. Expert-level communication focused on efficient task execution, presenting information systematically using numbered lists with immediate command response capability."
-    principles: |
+    principles:
       - Load resources at runtime, never pre-load, and always present numbered lists for choices.
 
   critical_actions:


### PR DESCRIPTION
## Problem

The `agent.customize.template.yaml` defines `principles` as an array:

```yaml
principles: []
```

The recently added `qa.agent.yaml` (commit 7ecae1d0) correctly follows this template and uses a YAML array. However, all 9 other agent files use a **block scalar string** (`principles: |`), which YAML parsers interpret as a string rather than an array.

This inconsistency causes downstream consumers that expect the template-defined type (array) to receive a string instead. While the current schema accepts both via a union type, the template clearly indicates array is the intended format.

Related: #1594 (tighten schema to enforce array-only)

## Fix

Remove the `|` block scalar indicator from the `principles` field in all 9 affected agent files, converting them to proper YAML arrays — matching both the template definition and the qa agent.

### Files changed (9)

- `src/bmm/agents/analyst.agent.yaml`
- `src/bmm/agents/architect.agent.yaml`
- `src/bmm/agents/dev.agent.yaml`
- `src/bmm/agents/pm.agent.yaml`
- `src/bmm/agents/quick-flow-solo-dev.agent.yaml`
- `src/bmm/agents/sm.agent.yaml`
- `src/bmm/agents/tech-writer/tech-writer.agent.yaml`
- `src/bmm/agents/ux-designer.agent.yaml`
- `src/core/agents/bmad-master.agent.yaml`

## Before / After

```yaml
# Before (string — parsed as single text block)
principles: |
  - Channel expert lean architecture wisdom...
  - User journeys drive technical decisions.

# After (array — matches template)
principles:
  - Channel expert lean architecture wisdom...
  - User journeys drive technical decisions.
```

## Test plan

- [ ] Verify `agent.customize.template.yaml` schema is satisfied
- [ ] Confirm YAML parsers return an array for all agent `principles` fields
- [ ] Verify no behavioral change in agents that consume principles as prompt text

🤖 Generated with [Claude Code](https://claude.com/claude-code)