### PR TITLE
fix: fix typos in tech-writer and ux-designer agent definitions

### DIFF
--- a/src/bmm/agents/tech-writer/tech-writer.agent.yaml
+++ b/src/bmm/agents/tech-writer/tech-writer.agent.yaml
@@ -15,7 +15,7 @@ agent:
     communication_style: "Patient educator who explains like teaching a friend. Uses analogies that make complex simple, celebrates clarity when it shines."
     principles: |
       - Every Technical Document I touch helps someone accomplish a task. Thus I strive for Clarity above all, and every word and phrase serves a purpose without being overly wordy.
-      - I believe a picture/diagram is worth 1000s works and will include diagrams over drawn out text.
+      - I believe a picture/diagram is worth 1000s of words and will include diagrams over drawn out text.
       - I understand the intended audience or will clarify with the user so I know when to simplify vs when to be detailed.
       - I will always strive to follow `_bmad/_memory/tech-writer-sidecar/documentation-standards.md` best practices.
 

--- a/src/bmm/agents/ux-designer.agent.yaml
+++ b/src/bmm/agents/ux-designer.agent.yaml
@@ -23,4 +23,4 @@ agent:
   menu:
     - trigger: CU or fuzzy match on ux-design
       exec: "{project-root}/_bmad/bmm/workflows/2-plan-workflows/create-ux-design/workflow.md"
-      description: "[CU] Create UX: Guidance through realizing the plan for your UX to inform architecture and implementation. PRovides more details that what was discovered in the PRD"
+      description: "[CU] Create UX: Guidance through realizing the plan for your UX to inform architecture and implementation. Provides more details than what was discovered in the PRD"


### PR DESCRIPTION
## Summary

Fixes pre-existing typos in two agent definition files.

### tech-writer.agent.yaml
- `"1000s works"` → `"1000s of words"` — the idiom is "a picture is worth a thousand words"

### ux-designer.agent.yaml
- `"PRovides"` → `"Provides"` (capitalization typo)
- `"more details that what"` → `"more details than what"` (wrong word)

## Test plan

- [ ] YAML parses correctly
- [ ] No behavioral change — cosmetic text fixes only

🤖 Generated with [Claude Code](https://claude.com/claude-code)