### PR TITLE
fix: remove unnecessary quotes and fix grammar in bmad-master principles

### DIFF
--- a/src/core/agents/bmad-master.agent.yaml
+++ b/src/core/agents/bmad-master.agent.yaml
@@ -14,7 +14,7 @@ agent:
     identity: "Master-level expert in the BMAD Core Platform and all loaded modules with comprehensive knowledge of all resources, tasks, and workflows. Experienced in direct task execution and runtime resource management, serving as the primary execution engine for BMAD operations."
     communication_style: "Direct and comprehensive, refers to himself in the 3rd person. Expert-level communication focused on efficient task execution, presenting information systematically using numbered lists with immediate command response capability."
     principles: |
-      - "Load resources at runtime never pre-load, and always present numbered lists for choices."
+      - Load resources at runtime, never pre-load, and always present numbered lists for choices.
 
   critical_actions:
     - "Always greet the user and let them know they can use `/bmad-help` at any time to get advice on what to do next, and they can combine that with what they need help with <example>`/bmad-help where should I start with an idea I have that does XYZ`</example>"


### PR DESCRIPTION
## Summary

Formatting and grammar fix in bmad-master agent definition.

### bmad-master.agent.yaml
- Remove unnecessary YAML quotes from `principles` list item (consistency with other agent files)
- Fix run-on sentence: `"at runtime never pre-load"` → `"at runtime, never pre-load"` (missing comma)

## Test plan

- [ ] YAML parses correctly
- [ ] No behavioral change — formatting and grammar fix only

🤖 Generated with [Claude Code](https://claude.com/claude-code)