### PR TITLE
fix(opencode): remove incorrect mode: primary and restore name field in templates

### DIFF
--- a/tools/cli/installers/lib/ide/templates/combined/opencode-agent.md
+++ b/tools/cli/installers/lib/ide/templates/combined/opencode-agent.md
@@ -1,5 +1,5 @@
 ---
-mode: primary
+name: '{{name}}'
 description: '{{description}}'
 ---
 

--- a/tools/cli/installers/lib/ide/templates/combined/opencode-task.md
+++ b/tools/cli/installers/lib/ide/templates/combined/opencode-task.md
@@ -1,10 +1,12 @@
 ---
+name: '{{name}}'
 description: '{{description}}'
 ---
 
 Execute the BMAD '{{name}}' task.
 
 TASK INSTRUCTIONS:
+
 1. LOAD the task file from {project-root}/{{bmadFolderName}}/{{path}}
 2. READ its entire contents
 3. FOLLOW every instruction precisely as specified

--- a/tools/cli/installers/lib/ide/templates/combined/opencode-tool.md
+++ b/tools/cli/installers/lib/ide/templates/combined/opencode-tool.md
@@ -1,10 +1,12 @@
 ---
+name: '{{name}}'
 description: '{{description}}'
 ---
 
 Execute the BMAD '{{name}}' tool.
 
 TOOL INSTRUCTIONS:
+
 1. LOAD the tool file from {project-root}/{{bmadFolderName}}/{{path}}
 2. READ its entire contents
 3. FOLLOW every instruction precisely as specified

--- a/tools/cli/installers/lib/ide/templates/combined/opencode-workflow-yaml.md
+++ b/tools/cli/installers/lib/ide/templates/combined/opencode-workflow-yaml.md
@@ -1,4 +1,5 @@
 ---
+name: '{{name}}'
 description: '{{description}}'
 ---
 
@@ -7,6 +8,7 @@ Execute the BMAD '{{name}}' workflow.
 CRITICAL: You must load and follow the workflow definition exactly.
 
 WORKFLOW INSTRUCTIONS:
+
 1. LOAD the workflow file from {project-root}/{{bmadFolderName}}/{{path}}
 2. READ its entire contents
 3. FOLLOW every step precisely as specified

--- a/tools/cli/installers/lib/ide/templates/combined/opencode-workflow.md
+++ b/tools/cli/installers/lib/ide/templates/combined/opencode-workflow.md
@@ -1,4 +1,5 @@
 ---
+name: '{{name}}'
 description: '{{description}}'
 ---
 
@@ -7,6 +8,7 @@ Execute the BMAD '{{name}}' workflow.
 CRITICAL: You must load and follow the workflow definition exactly.
 
 WORKFLOW INSTRUCTIONS:
+
 1. LOAD the workflow file from {project-root}/{{bmadFolderName}}/{{path}}
 2. READ its entire contents
 3. FOLLOW every step precisely as specified


### PR DESCRIPTION
## What

Remove incorrect `mode: primary` from the OpenCode agent template and restore the `name` frontmatter field across all OpenCode templates.

## Why

PR #1556 added `mode: primary` based on a misunderstanding of what this field does in OpenCode. This restricts BMAD agents to primary-only use, preventing them from being invoked as subagents via the `@` syntax. OpenCode defaults to `mode: all`, which is the correct behavior.

Fixes #1643

## How

- Replaced `mode: primary` with `name: '{{name}}'` in `opencode-agent.md`
- Added missing `name: '{{name}}'` field to `opencode-task.md`, `opencode-tool.md`, `opencode-workflow.md`, and `opencode-workflow-yaml.md`

## Testing

All pre-commit checks pass (schemas, refs, install, lint, format).