### PR TITLE
docs: fix changelog URL in installer start message

### DIFF
--- a/tools/cli/installers/install-messages.yaml
+++ b/tools/cli/installers/install-messages.yaml
@@ -34,7 +34,7 @@ startMessage: |
     - Subscribe on YouTube: https://www.youtube.com/@BMadCode
     - Every star & sub helps us reach more developers!
 
-  Latest updates: https://github.com/bmad-code-org/BMAD-METHOD/CHANGELOG.md
+  Latest updates: https://github.com/bmad-code-org/BMAD-METHOD/blob/main/CHANGELOG.md
 
   ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
 


### PR DESCRIPTION
## What
Fix the "Latest updates" changelog link shown at install start so it uses the correct GitHub blob URL.

## Why
The current URL (without `/blob/main/`) does not resolve correctly on GitHub. Using the blob URL ensures users can open the changelog from the installer.
Fixes #1646 

## How
- Updated the changelog URL in `tools/cli/installers/install-messages.yaml` to include `/blob/main/`.

## Testing
Ran installer locally and confirmed the new URL opens CHANGELOG.md on GitHub.