### PR TITLE
Disable workflows and add upstream sync for fork

### DIFF
--- a/.github/workflows/coderabbit-review.yaml
+++ b/.github/workflows/coderabbit-review.yaml
@@ -6,6 +6,7 @@ on:
 
 jobs:
   trigger-review:
+    if: false # disabled – workflow disabled for fork
     runs-on: ubuntu-latest
     permissions:
       pull-requests: write

--- a/.github/workflows/discord.yaml
+++ b/.github/workflows/discord.yaml
@@ -12,7 +12,7 @@ env:
 
 jobs:
   pull_request:
-    if: github.event_name == 'pull_request'
+    if: false # disabled – workflow disabled for fork
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
@@ -54,7 +54,7 @@ jobs:
           jq -n --arg content "$MSG" '{content: $content}' | curl -sf --retry 2 -X POST "$WEBHOOK" -H "Content-Type: application/json" -d @-
 
   issues:
-    if: github.event_name == 'issues'
+    if: false # disabled – workflow disabled for fork
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4

--- a/.github/workflows/docs.yaml
+++ b/.github/workflows/docs.yaml
@@ -23,6 +23,7 @@ concurrency:
 
 jobs:
   build:
+    if: false # disabled – workflow disabled for fork
     runs-on: ubuntu-latest
     steps:
       - name: Checkout repository

--- a/.github/workflows/quality.yaml
+++ b/.github/workflows/quality.yaml
@@ -16,6 +16,7 @@ name: Quality & Validation
 
 jobs:
   prettier:
+    if: false # disabled – workflow disabled for fork
     runs-on: ubuntu-latest
     steps:
       - name: Checkout
@@ -34,6 +35,7 @@ jobs:
         run: npm run format:check
 
   eslint:
+    if: false # disabled – workflow disabled for fork
     runs-on: ubuntu-latest
     steps:
       - name: Checkout
@@ -52,6 +54,7 @@ jobs:
         run: npm run lint
 
   markdownlint:
+    if: false # disabled – workflow disabled for fork
     runs-on: ubuntu-latest
     steps:
       - name: Checkout
@@ -70,6 +73,7 @@ jobs:
         run: npm run lint:md
 
   docs:
+    if: false # disabled – workflow disabled for fork
     runs-on: ubuntu-latest
     steps:
       - name: Checkout
@@ -89,6 +93,7 @@ jobs:
         run: npm run docs:build
 
   validate:
+    if: false # disabled – workflow disabled for fork
     runs-on: ubuntu-latest
     steps:
       - name: Checkout

--- a/.github/workflows/upstream-sync.yaml
+++ b/.github/workflows/upstream-sync.yaml
@@ -1,0 +1,54 @@
+name: Upstream Sync
+
+permissions:
+  contents: write
+  issues: write
+  actions: write
+
+on:
+  schedule:
+    - cron: '0 */6 * * *' # every 6 hours
+  workflow_dispatch:
+
+jobs:
+  sync_latest_from_upstream:
+    name: Sync latest commits from upstream repo
+    runs-on: ubuntu-latest
+    if: ${{ github.event.repository.fork }}
+    steps:
+      - uses: actions/checkout@v6
+
+      - name: Clean issue notice
+        uses: actions-cool/issues-helper@v3
+        with:
+          actions: 'close-issues'
+          labels: '🚨 Sync Fail'
+
+      - name: Sync upstream changes
+        id: sync
+        uses: aormsby/Fork-Sync-With-Upstream-action@v3.4
+        with:
+          upstream_sync_repo: bmad-code-org/BMAD-METHOD
+          upstream_sync_branch: main
+          target_sync_branch: main
+          target_repo_token: ${{ secrets.GITHUB_TOKEN }}
+          test_mode: false
+
+      - name: Sync check
+        if: failure()
+        uses: actions-cool/issues-helper@v3
+        with:
+          actions: 'create-issue'
+          title: '🚨 Upstream Sync Failed'
+          labels: '🚨 Sync Fail'
+          body: |
+            Due to a change in the workflow file of the [BMAD-METHOD][upstream] upstream repository, GitHub has automatically suspended the scheduled automatic update. You need to manually sync your fork.
+
+            ### How to fix
+            1. Go to your fork on GitHub
+            2. Click **Sync fork** → **Update branch**
+            3. If there are conflicts, clone locally and resolve them
+
+            ![Sync fork button](https://docs.github.com/assets/cb-49937/mw-1440/images/help/repository/sync-fork-dropdown.webp)
+
+            [upstream]: https://github.com/bmad-code-org/BMAD-METHOD


### PR DESCRIPTION
## What
Added an upstream sync workflow to automatically synchronize changes from the BMAD-METHOD repository, and disabled several CI/CD workflows that are not applicable to forks.

## Why
Forks need a mechanism to stay synchronized with upstream changes. Additionally, certain quality checks and notification workflows are not relevant for fork repositories and should be disabled to reduce unnecessary workflow runs and potential permission issues.

## How
- Added `.github/workflows/upstream-sync.yaml` to automatically sync from `bmad-code-org/BMAD-METHOD` every 6 hours with manual trigger support
- Configured sync failure notifications via GitHub issues with instructions for manual resolution
- Disabled quality checks (prettier, eslint, markdownlint, docs, validate) in `quality.yaml` by adding `if: false` conditions
- Disabled Discord notifications in `discord.yaml` for pull requests and issues
- Disabled CodeRabbit review trigger in `coderabbit-review.yaml`
- Disabled docs deployment in `docs.yaml`

## Testing
Workflows are configured with appropriate conditions and will only execute when intended. The upstream sync workflow includes a test mode flag set to false and will create issues on sync failures for visibility.

https://claude.ai/code/session_01Mxvkj6F7iEbx5sG2jnH4Sm