### PR TITLE
feat(prd): add missing steps 2b (vision) and 2c (executive summary)

### DIFF
--- a/src/bmm/workflows/2-plan-workflows/create-prd/steps-c/step-02-discovery.md
+++ b/src/bmm/workflows/2-plan-workflows/create-prd/steps-c/step-02-discovery.md
@@ -3,7 +3,7 @@ name: 'step-02-discovery'
 description: 'Discover project type, domain, and context through collaborative dialogue'
 
 # File References
-nextStepFile: './step-03-success.md'
+nextStepFile: './step-02b-vision.md'
 outputFile: '{planning_artifacts}/prd.md'
 
 # Data Files

--- a/src/bmm/workflows/2-plan-workflows/create-prd/steps-c/step-02b-vision.md
+++ b/src/bmm/workflows/2-plan-workflows/create-prd/steps-c/step-02b-vision.md
@@ -1,0 +1,154 @@
+---
+name: 'step-02b-vision'
+description: 'Discover the product vision and differentiator through collaborative dialogue'
+
+# File References
+nextStepFile: './step-02c-executive-summary.md'
+outputFile: '{planning_artifacts}/prd.md'
+
+# Task References
+advancedElicitationTask: '{project-root}/_bmad/core/workflows/advanced-elicitation/workflow.xml'
+partyModeWorkflow: '{project-root}/_bmad/core/workflows/party-mode/workflow.md'
+---
+
+# Step 2b: Product Vision Discovery
+
+**Progress: Step 2b of 13** - Next: Executive Summary
+
+## STEP GOAL:
+
+Discover what makes this product special and understand the product vision through collaborative conversation. No content generation — facilitation only.
+
+## MANDATORY EXECUTION RULES (READ FIRST):
+
+### Universal Rules:
+
+- 🛑 NEVER generate content without user input
+- 📖 CRITICAL: Read the complete step file before taking any action
+- 🔄 CRITICAL: When loading next step with 'C', ensure the entire file is read
+- ✅ ALWAYS treat this as collaborative discovery between PM peers
+- 📋 YOU ARE A FACILITATOR, not a content generator
+- ✅ YOU MUST ALWAYS SPEAK OUTPUT In your Agent communication style with the config `{communication_language}`
+
+### Role Reinforcement:
+
+- ✅ You are a product-focused PM facilitator collaborating with an expert peer
+- ✅ We engage in collaborative dialogue, not command-response
+- ✅ You bring structured thinking and facilitation skills, while the user brings domain expertise and product vision
+
+### Step-Specific Rules:
+
+- 🎯 Focus on discovering vision and differentiator — no content generation yet
+- 🚫 FORBIDDEN to generate executive summary content (that's the next step)
+- 🚫 FORBIDDEN to append anything to the document in this step
+- 💬 APPROACH: Natural conversation to understand what makes this product special
+- 🎯 BUILD ON classification insights from step 2
+
+## EXECUTION PROTOCOLS:
+
+- 🎯 Show your analysis before taking any action
+- ⚠️ Present A/P/C menu after vision discovery is complete
+- 📖 Update frontmatter, adding this step to the end of the list of stepsCompleted
+- 🚫 FORBIDDEN to load next step until C is selected
+
+## CONTEXT BOUNDARIES:
+
+- Current document and frontmatter from steps 1 and 2 are available
+- Project classification exists from step 2 (project type, domain, complexity, context)
+- Input documents already loaded are in memory (product briefs, research, brainstorming, project docs)
+- No executive summary content yet (that's step 2c)
+- This step ONLY discovers — it does NOT write to the document
+
+## YOUR TASK:
+
+Discover the product vision and differentiator through natural conversation. Understand what makes this product unique and valuable before any content is written.
+
+## VISION DISCOVERY SEQUENCE:
+
+### 1. Acknowledge Classification Context
+
+Reference the classification from step 2 and use it to frame the vision conversation:
+
+"We've established this is a {{projectType}} in the {{domain}} domain with {{complexityLevel}} complexity. Now let's explore what makes this product special."
+
+### 2. Explore What Makes It Special
+
+Guide the conversation to uncover the product's unique value:
+
+- **User delight:** "What would make users say 'this is exactly what I needed'?"
+- **Differentiation moment:** "What's the moment where users realize this is different or better than alternatives?"
+- **Core insight:** "What insight or approach makes this product possible or unique?"
+- **Value proposition:** "If you had one sentence to explain why someone should use this over anything else, what would it be?"
+
+### 3. Understand the Vision
+
+Dig deeper into the product vision:
+
+- **Problem framing:** "What's the real problem you're solving — not the surface symptom, but the deeper need?"
+- **Future state:** "When this product is successful, what does the world look like for your users?"
+- **Why now:** "Why is this the right time to build this?"
+
+### 4. Validate Understanding
+
+Reflect back what you've heard and confirm:
+
+"Here's what I'm hearing about your vision and differentiator:
+
+**Vision:** {{summarized_vision}}
+**What Makes It Special:** {{summarized_differentiator}}
+**Core Insight:** {{summarized_insight}}
+
+Does this capture it? Anything I'm missing?"
+
+Let the user confirm or refine your understanding.
+
+### N. Present MENU OPTIONS
+
+Present your understanding of the product vision for review, then display menu:
+
+"Based on our conversation, I have a clear picture of your product vision and what makes it special. I'll use these insights to draft the Executive Summary in the next step.
+
+**What would you like to do?**"
+
+Display: "**Select:** [A] Advanced Elicitation [P] Party Mode [C] Continue to Executive Summary (Step 2c of 13)"
+
+#### Menu Handling Logic:
+- IF A: Read fully and follow: {advancedElicitationTask} with the current vision insights, process the enhanced insights that come back, ask user if they accept the improvements, if yes update understanding then redisplay menu, if no keep original understanding then redisplay menu
+- IF P: Read fully and follow: {partyModeWorkflow} with the current vision insights, process the collaborative insights, ask user if they accept the changes, if yes update understanding then redisplay menu, if no keep original understanding then redisplay menu
+- IF C: Update {outputFile} frontmatter by adding this step name to the end of stepsCompleted array, then read fully and follow: {nextStepFile}
+- IF Any other: help user respond, then redisplay menu
+
+#### EXECUTION RULES:
+- ALWAYS halt and wait for user input after presenting menu
+- ONLY proceed to next step when user selects 'C'
+- After other menu items execution, return to this menu
+
+## CRITICAL STEP COMPLETION NOTE
+
+ONLY WHEN [C continue option] is selected and [stepsCompleted updated], will you then read fully and follow: `{nextStepFile}` to generate the Executive Summary.
+
+---
+
+## 🚨 SYSTEM SUCCESS/FAILURE METRICS
+
+### ✅ SUCCESS:
+
+- Classification context from step 2 acknowledged and built upon
+- Natural conversation to understand product vision and differentiator
+- User's existing documents (briefs, research, brainstorming) leveraged for vision insights
+- Vision and differentiator validated with user before proceeding
+- Clear understanding established that will inform Executive Summary generation
+- Frontmatter updated with stepsCompleted when C selected
+
+### ❌ SYSTEM FAILURE:
+
+- Generating executive summary or any document content (that's step 2c!)
+- Appending anything to the PRD document
+- Not building on classification from step 2
+- Being prescriptive instead of having natural conversation
+- Proceeding without user selecting 'C'
+
+❌ **CRITICAL**: Reading only partial step file - leads to incomplete understanding and poor decisions
+❌ **CRITICAL**: Proceeding with 'C' without fully reading and understanding the next step file
+
+**Master Rule:** This step is vision discovery only. No content generation, no document writing. Have natural conversations, build on what you know from classification, and establish the vision that will feed into the Executive Summary.

--- a/src/bmm/workflows/2-plan-workflows/create-prd/steps-c/step-02c-executive-summary.md
+++ b/src/bmm/workflows/2-plan-workflows/create-prd/steps-c/step-02c-executive-summary.md
@@ -1,0 +1,170 @@
+---
+name: 'step-02c-executive-summary'
+description: 'Generate and append the Executive Summary section to the PRD document'
+
+# File References
+nextStepFile: './step-03-success.md'
+outputFile: '{planning_artifacts}/prd.md'
+
+# Task References
+advancedElicitationTask: '{project-root}/_bmad/core/workflows/advanced-elicitation/workflow.xml'
+partyModeWorkflow: '{project-root}/_bmad/core/workflows/party-mode/workflow.md'
+---
+
+# Step 2c: Executive Summary Generation
+
+**Progress: Step 2c of 13** - Next: Success Criteria
+
+## STEP GOAL:
+
+Generate the Executive Summary content using insights from classification (step 2) and vision discovery (step 2b), then append it to the PRD document.
+
+## MANDATORY EXECUTION RULES (READ FIRST):
+
+### Universal Rules:
+
+- 🛑 NEVER generate content without user input
+- 📖 CRITICAL: Read the complete step file before taking any action
+- 🔄 CRITICAL: When loading next step with 'C', ensure the entire file is read
+- ✅ ALWAYS treat this as collaborative discovery between PM peers
+- 📋 YOU ARE A FACILITATOR, not a content generator
+- ✅ YOU MUST ALWAYS SPEAK OUTPUT In your Agent communication style with the config `{communication_language}`
+
+### Role Reinforcement:
+
+- ✅ You are a product-focused PM facilitator collaborating with an expert peer
+- ✅ We engage in collaborative dialogue, not command-response
+- ✅ Content is drafted collaboratively — present for review before saving
+
+### Step-Specific Rules:
+
+- 🎯 Generate Executive Summary content based on discovered insights
+- 💬 Present draft content for user review and refinement before appending
+- 🚫 FORBIDDEN to append content without user approval via 'C'
+- 🎯 Content must be dense, precise, and zero-fluff (PRD quality standards)
+
+## EXECUTION PROTOCOLS:
+
+- 🎯 Show your analysis before taking any action
+- ⚠️ Present A/P/C menu after generating executive summary content
+- 💾 ONLY save when user chooses C (Continue)
+- 📖 Update output file frontmatter, adding this step name to the end of the list of stepsCompleted
+- 🚫 FORBIDDEN to load next step until C is selected
+
+## CONTEXT BOUNDARIES:
+
+- Current document and frontmatter from steps 1, 2, and 2b are available
+- Project classification exists from step 2 (project type, domain, complexity, context)
+- Vision and differentiator insights exist from step 2b
+- Input documents from step 1 are available (product briefs, research, brainstorming, project docs)
+- This step generates and appends the first substantive content to the PRD
+
+## YOUR TASK:
+
+Draft the Executive Summary section using all discovered insights, present it for user review, and append it to the PRD document when approved.
+
+## EXECUTIVE SUMMARY GENERATION SEQUENCE:
+
+### 1. Synthesize Available Context
+
+Review all available context before drafting:
+- Classification from step 2: project type, domain, complexity, project context
+- Vision and differentiator from step 2b: what makes this special, core insight
+- Input documents: product briefs, research, brainstorming, project docs
+
+### 2. Draft Executive Summary Content
+
+Generate the Executive Summary section using the content structure below. Apply PRD quality standards:
+- High information density — every sentence carries weight
+- Zero fluff — no filler phrases or vague language
+- Precise and actionable — clear, specific statements
+- Dual-audience optimized — readable by humans, consumable by LLMs
+
+### 3. Present Draft for Review
+
+Present the drafted content to the user for review:
+
+"Here's the Executive Summary I've drafted based on our discovery work. Please review and let me know if you'd like any changes:"
+
+Show the full drafted content using the structure from the Content Structure section below.
+
+Allow the user to:
+- Request specific changes to any section
+- Add missing information
+- Refine the language or emphasis
+- Approve as-is
+
+### N. Present MENU OPTIONS
+
+Present the executive summary content for user review, then display menu:
+
+"Here's the Executive Summary for your PRD. Review the content above and let me know what you'd like to do."
+
+Display: "**Select:** [A] Advanced Elicitation [P] Party Mode [C] Continue to Success Criteria (Step 3 of 13)"
+
+#### Menu Handling Logic:
+- IF A: Read fully and follow: {advancedElicitationTask} with the current executive summary content, process the enhanced content that comes back, ask user if they accept the improvements, if yes update content then redisplay menu, if no keep original content then redisplay menu
+- IF P: Read fully and follow: {partyModeWorkflow} with the current executive summary content, process the collaborative improvements, ask user if they accept the changes, if yes update content then redisplay menu, if no keep original content then redisplay menu
+- IF C: Append the final content to {outputFile}, update frontmatter by adding this step name to the end of the stepsCompleted array, then read fully and follow: {nextStepFile}
+- IF Any other: help user respond, then redisplay menu
+
+#### EXECUTION RULES:
+- ALWAYS halt and wait for user input after presenting menu
+- ONLY proceed to next step when user selects 'C'
+- After other menu items execution, return to this menu
+
+## APPEND TO DOCUMENT:
+
+When user selects 'C', append the following content structure directly to the document:
+
+```markdown
+## Executive Summary
+
+{vision_alignment_content}
+
+### What Makes This Special
+
+{product_differentiator_content}
+
+## Project Classification
+
+{project_classification_content}
+```
+
+Where:
+- `{vision_alignment_content}` — Product vision, target users, and the problem being solved. Dense, precise summary drawn from step 2b vision discovery.
+- `{product_differentiator_content}` — What makes this product unique, the core insight, and why users will choose it over alternatives. Drawn from step 2b differentiator discovery.
+- `{project_classification_content}` — Project type, domain, complexity level, and project context (greenfield/brownfield). Drawn from step 2 classification.
+
+## CRITICAL STEP COMPLETION NOTE
+
+ONLY WHEN [C continue option] is selected and [content appended to document], will you then read fully and follow: `{nextStepFile}` to define success criteria.
+
+---
+
+## 🚨 SYSTEM SUCCESS/FAILURE METRICS
+
+### ✅ SUCCESS:
+
+- Executive Summary drafted using insights from steps 2 and 2b
+- Content meets PRD quality standards (dense, precise, zero-fluff)
+- Draft presented to user for review before saving
+- User given opportunity to refine content
+- Content properly appended to document when C selected
+- A/P/C menu presented and handled correctly
+- Frontmatter updated with stepsCompleted when C selected
+
+### ❌ SYSTEM FAILURE:
+
+- Generating content without incorporating discovered vision and classification
+- Appending content without user selecting 'C'
+- Producing vague, fluffy, or low-density content
+- Not presenting draft for user review
+- Not presenting A/P/C menu after content generation
+- Skipping directly to next step without appending content
+
+❌ **CRITICAL**: Reading only partial step file - leads to incomplete understanding and poor decisions
+❌ **CRITICAL**: Proceeding with 'C' without fully reading and understanding the next step file
+❌ **CRITICAL**: Making decisions without complete understanding of step requirements and protocols
+
+**Master Rule:** Generate high-quality Executive Summary content from discovered insights. Present for review, refine collaboratively, and only save when the user approves. This is the first substantive content in the PRD — it sets the quality bar for everything that follows.


### PR DESCRIPTION
## Summary

- Adds **step-02b-vision.md** — collaborative vision/differentiator discovery (facilitation only, no document writes)
- Adds **step-02c-executive-summary.md** — generates and appends Executive Summary, What Makes This Special, and Project Classification sections to the PRD
- Updates **step-02-discovery.md** `nextStepFile` to chain through `step-02b` instead of skipping directly to `step-03`

This closes the gap left when step-02 was refactored to be discovery-only with forward references to steps 2b and 2c that were never created. The workflow previously jumped from classification (step 2) to success criteria (step 3), which assumed the Executive Summary already existed.

**Chain:** `step-02` → `step-02b` → `step-02c` → `step-03`

## Test plan

- [x] Verified `nextStepFile` chain: step-02 → step-02b → step-02c → step-03 → step-04
- [x] Verified step-02b has NO "APPEND TO DOCUMENT" section (discovery-only)
- [x] Verified step-02c HAS "APPEND TO DOCUMENT" with correct content structure
- [x] Verified step-03 precondition ("Executive Summary and Project Classification already exist") is satisfied
- [x] Ran full workflow simulation with agent team + simulated human through steps 1 → 2 → 2b → 2c → 3 (abort)
- [x] Pre-commit hooks pass (lint, markdown, tests, formatting)