### PR TITLE
hotfix: add npx cache workaround to Quick Start

### DIFF
--- a/README.md
+++ b/README.md
@@ -30,6 +30,8 @@ Traditional AI tools do the thinking for you, producing average results. BMad ag
 npx bmad-method install
 ```
 
+> If you are getting a stale beta version, use: `npx bmad-method@6.0.1 install`
+
 Follow the installer prompts, then open your AI IDE (Claude Code, Codex, Windsurf, etc.) in your project folder.
 
 **Non-Interactive Installation** (for CI/CD):


### PR DESCRIPTION
## Summary
- Adds workaround for users getting a stale beta version when running `npx bmad-method install`
- Documents `npx bmad-method@6.0.1 install` as the fix

## Test plan
- [ ] Verify README renders correctly on GitHub

🤖 Generated with [Claude Code](https://claude.com/claude-code)