### PR TITLE
fix: change default Codex install location from global to project

### DIFF
--- a/tools/cli/installers/lib/ide/codex.js
+++ b/tools/cli/installers/lib/ide/codex.js
@@ -23,9 +23,9 @@ class CodexSetup extends BaseIdeSetup {
    * @returns {Object} Collected configuration
    */
   async collectConfiguration(options = {}) {
-    // Non-interactive mode: use default (global)
+    // Non-interactive mode: use default (project) - recommended for real work
     if (options.skipPrompts) {
-      return { installLocation: 'global' };
+      return { installLocation: options.codexLocation || 'project' };
     }
 
     let confirmed = false;


### PR DESCRIPTION
 ## Summary

- Change non-interactive Codex install default from global to project, aligning with the interactive prompt's own "Recommended for real work" guidance

  Closes #1655

## Context

The interactive installer already recommends project-specific installs, but --yes mode silently picked global. Rather than adding a  --codex-location flag (which sets a precedent for per-IDE flags across all supported tools), we fix the default to match our own recommendation.

Test plan

- npx bmad-method install --tools codex --yes installs to <project>/.codex/prompts
- Interactive Codex install still prompts with both options
- Existing tests pass