### PR TITLE
Add language to replace Research overview and methodology section

### DIFF
--- a/src/bmm/workflows/1-analysis/research/domain-steps/step-06-research-synthesis.md
+++ b/src/bmm/workflows/1-analysis/research/domain-steps/step-06-research-synthesis.md
@@ -373,6 +373,7 @@ _This comprehensive research document serves as an authoritative reference on {{
 
 #### If 'C' (Complete Research):
 
+- **Replace** the template placeholder `[Research overview and methodology will be appended here]` in the `## Research Overview` section near the top of the document with a concise 2-3 paragraph overview summarizing the research scope, key findings, and a pointer to the full executive summary in the Research Synthesis section
 - Append the complete document to the research file
 - Update frontmatter: `stepsCompleted: [1, 2, 3, 4, 5]`
 - Complete the domain research workflow
@@ -380,7 +381,7 @@ _This comprehensive research document serves as an authoritative reference on {{
 
 ## APPEND TO DOCUMENT:
 
-When user selects 'C', append the complete comprehensive research document using the full structure above.
+When user selects 'C', append the complete comprehensive research document using the full structure above. Also replace the `[Research overview and methodology will be appended here]` placeholder in the Research Overview section at the top of the document.
 
 ## SUCCESS METRICS:
 

--- a/src/bmm/workflows/1-analysis/research/market-steps/step-06-research-completion.md
+++ b/src/bmm/workflows/1-analysis/research/market-steps/step-06-research-completion.md
@@ -389,13 +389,14 @@ _This comprehensive market research document serves as an authoritative market r
 
 #### If 'C' (Complete Research):
 
+- **Replace** the template placeholder `[Research overview and methodology will be appended here]` in the `## Research Overview` section near the top of the document with a concise 2-3 paragraph overview summarizing the research scope, key findings, and a pointer to the full executive summary in the Research Synthesis section
 - Append the final content to the research document
 - Update frontmatter: `stepsCompleted: [1, 2, 3, 4]`
 - Complete the market research workflow
 
 ## APPEND TO DOCUMENT:
 
-When user selects 'C', append the content directly to the research document using the structure from step 4.
+When user selects 'C', append the content directly to the research document using the structure from step 4. Also replace the `[Research overview and methodology will be appended here]` placeholder in the Research Overview section at the top of the document.
 
 ## SUCCESS METRICS:
 

--- a/src/bmm/workflows/1-analysis/research/technical-steps/step-06-research-synthesis.md
+++ b/src/bmm/workflows/1-analysis/research/technical-steps/step-06-research-synthesis.md
@@ -416,6 +416,7 @@ _This comprehensive technical research document serves as an authoritative techn
 
 #### If 'C' (Complete Research):
 
+- **Replace** the template placeholder `[Research overview and methodology will be appended here]` in the `## Research Overview` section near the top of the document with a concise 2-3 paragraph overview summarizing the research scope, key findings, and a pointer to the full executive summary in the Research Synthesis section
 - Append the complete technical document to the research file
 - Update frontmatter: `stepsCompleted: [1, 2, 3, 4, 5, 6]`
 - Complete the technical research workflow
@@ -423,7 +424,7 @@ _This comprehensive technical research document serves as an authoritative techn
 
 ## APPEND TO DOCUMENT:
 
-When user selects 'C', append the complete comprehensive technical research document using the full structure above.
+When user selects 'C', append the complete comprehensive technical research document using the full structure above. Also replace the `[Research overview and methodology will be appended here]` placeholder in the Research Overview section at the top of the document.
 
 ## SUCCESS METRICS:
 


### PR DESCRIPTION
Add language to replace Research overview and methodology section

## What
Added language to step-06 to go back and replace the placeholder text in the Research overview and methodology section


## Why
The final documents were produced with template placeholder text instead of the intended summary
Fixes #1640

## How
- In section "6. Handle Final ..." "If 'C' (Complete Research):" I added specific language instructing the agent to replace the placeholder text
- In section "6. Handle Final ..." "APPEND TO DOCUMENT:" I added similar language

## Testing
Ran the workflows on two separate projects.  Worked as expected.