### PR TITLE
fix: file references in Gemini commands templates

### DIFF
--- a/tools/cli/installers/lib/ide/templates/combined/gemini-agent.toml
+++ b/tools/cli/installers/lib/ide/templates/combined/gemini-agent.toml
@@ -3,12 +3,12 @@ prompt = """
 CRITICAL: You are now the BMad '{{name}}' agent.
 
 PRE-FLIGHT CHECKLIST:
-1.  [ ] IMMEDIATE ACTION: Load and parse {project-root}/{{bmadFolderName}}/{{module}}/config.yaml - store ALL config values in memory for use throughout the session.
-2.  [ ] IMMEDIATE ACTION: Read and internalize the full agent definition at {project-root}/{{bmadFolderName}}/{{path}}.
+1.  [ ] IMMEDIATE ACTION: Load and parse @{{{bmadFolderName}}/{{module}}/config.yaml} - store ALL config values in memory for use throughout the session.
+2.  [ ] IMMEDIATE ACTION: Read and internalize the full agent definition at @{{{bmadFolderName}}/{{path}}}.
 3.  [ ] CONFIRM: The user's name from config is {user_name}.
 
 Only after all checks are complete, greet the user by name and display the menu.
 Acknowledge this checklist is complete in your first response.
 
-AGENT DEFINITION: {project-root}/{{bmadFolderName}}/{{path}}
+AGENT DEFINITION: @{{{bmadFolderName}}/{{path}}}
 """

--- a/tools/cli/installers/lib/ide/templates/combined/gemini-task.toml
+++ b/tools/cli/installers/lib/ide/templates/combined/gemini-task.toml
@@ -3,9 +3,9 @@ prompt = """
 Execute the BMAD '{{name}}' task.
 
 TASK INSTRUCTIONS:
-1. LOAD the task file from {project-root}/{{bmadFolderName}}/{{path}}
+1. LOAD the task file from @{{{bmadFolderName}}/{{path}}}
 2. READ its entire contents
 3. FOLLOW every instruction precisely as specified
 
-TASK FILE: {project-root}/{{bmadFolderName}}/{{path}}
+TASK FILE: @{{{bmadFolderName}}/{{path}}}
 """

--- a/tools/cli/installers/lib/ide/templates/combined/gemini-tool.toml
+++ b/tools/cli/installers/lib/ide/templates/combined/gemini-tool.toml
@@ -3,9 +3,9 @@ prompt = """
 Execute the BMAD '{{name}}' tool.
 
 TOOL INSTRUCTIONS:
-1. LOAD the tool file from {project-root}/{{bmadFolderName}}/{{path}}
+1. LOAD the tool file from @{{{bmadFolderName}}/{{path}}}
 2. READ its entire contents
 3. FOLLOW every instruction precisely as specified
 
-TOOL FILE: {project-root}/{{bmadFolderName}}/{{path}}
+TOOL FILE: @{{{bmadFolderName}}/{{path}}}
 """

--- a/tools/cli/installers/lib/ide/templates/combined/gemini-workflow-yaml.toml
+++ b/tools/cli/installers/lib/ide/templates/combined/gemini-workflow-yaml.toml
@@ -4,7 +4,7 @@ Execute the BMAD '{{name}}' workflow.
 
 CRITICAL: This is a structured YAML workflow. Follow these steps precisely:
 
-1. LOAD the workflow definition from {project-root}/{{bmadFolderName}}/{{workflow_path}}
+1. LOAD the workflow definition from @{{{bmadFolderName}}/{{workflow_path}}}
 2. PARSE the YAML structure to understand:
    - Workflow phases and steps
    - Required inputs and outputs
@@ -12,5 +12,5 @@ CRITICAL: This is a structured YAML workflow. Follow these steps precisely:
 3. EXECUTE each step in order
 4. VALIDATE outputs before proceeding to next step
 
-WORKFLOW FILE: {project-root}/{{bmadFolderName}}/{{workflow_path}}
+WORKFLOW FILE: @{{{bmadFolderName}}/{{workflow_path}}}
 """

--- a/tools/cli/installers/lib/ide/templates/combined/gemini-workflow.toml
+++ b/tools/cli/installers/lib/ide/templates/combined/gemini-workflow.toml
@@ -5,10 +5,10 @@ Execute the BMAD '{{name}}' workflow.
 CRITICAL: You must load and follow the workflow definition exactly.
 
 WORKFLOW INSTRUCTIONS:
-1. LOAD the workflow file from {project-root}/{{bmadFolderName}}/{{workflow_path}}
+1. LOAD the workflow file from @{{{bmadFolderName}}/{{workflow_path}}}
 2. READ its entire contents
 3. FOLLOW every step precisely as specified
 4. DO NOT skip or modify any steps
 
-WORKFLOW FILE: {project-root}/{{bmadFolderName}}/{{workflow_path}}
+WORKFLOW FILE: @{{{bmadFolderName}}/{{workflow_path}}}
 """


### PR DESCRIPTION
## What
fixed files refs in Gemini commands
issue: https://github.com/bmad-code-org/BMAD-METHOD/issues/1704

## Why
because Gemini CLI was not able to load agent files, i.e. could not recognize {project-root} variable.

## How
- changed file refs syntax according to https://geminicli.com/docs/cli/custom-commands/

## Testing
- exec `npm run bmad:install`
- start `gemini`
- try any agent, e.g. `/bmad-agent-bmm-dev`
- check that agent is successfully loaded and agent menu is shown
