### PR TITLE
fix: correct step file path in check-implementation-readiness workflow

### DIFF
--- a/src/bmm/workflows/3-solutioning/check-implementation-readiness/workflow.md
+++ b/src/bmm/workflows/3-solutioning/check-implementation-readiness/workflow.md
@@ -51,4 +51,4 @@ Load and read full config from {project-root}/_bmad/bmm/config.yaml and resolve:
 
 ### 2. First Step EXECUTION
 
-Read fully and follow: `./step-01-document-discovery.md` to begin the workflow.
+Read fully and follow: `./steps/step-01-document-discovery.md` to begin the workflow.


### PR DESCRIPTION
## What

Fixed the step file path reference in `check-implementation-readiness/workflow.md` to include the `steps/` subdirectory prefix.

## Why

The workflow entry point referenced `./step-01-document-discovery.md` but the file lives in `./steps/step-01-document-discovery.md`. This causes a file-not-found error on first step load, wasting tokens as the agent self-recovers by searching for the file.

Fixes #1615

## How

- Changed `./step-01-document-discovery.md` to `./steps/step-01-document-discovery.md` on line 54 of `workflow.md`
- This aligns with all other workflows in the project (e.g., `create-architecture`, `create-epics-and-stories`, `quick-spec`, `quick-dev`) which correctly use the `steps/` prefix

## Testing

- Verified all 6 step files exist in the `steps/` subdirectory
- Confirmed all other workflow.md files reference `steps/step-XX-*.md`

> This contribution was made with AI assistance (Claude). Reviewed and verified by a human.