### PR TITLE
fix: correct code fence imbalance in step-03-starter.md

### DIFF
--- a/src/bmm/workflows/3-solutioning/create-architecture/steps/step-03-starter.md
+++ b/src/bmm/workflows/3-solutioning/create-architecture/steps/step-03-starter.md
@@ -232,7 +232,6 @@ Prepare the content to append to the document:
 ```bash
 {{full_starter_command_with_options}}
 ```
-````
 
 **Architectural Decisions Provided by Starter:**
 
@@ -256,7 +255,7 @@ Prepare the content to append to the document:
 
 **Note:** Project initialization using this command should be the first implementation story.
 
-```
+````
 
 ### 9. Present Content and Menu
 


### PR DESCRIPTION
## Summary

- Fix code fence imbalance in `src/bmm/workflows/3-solutioning/create-architecture/steps/step-03-starter.md`
- The 4-backtick ````markdown fence at line 214 closed prematurely at line 235, orphaning template content (lines 237-258) outside the fence
- A stray 3-backtick fence at line 259 opened a code block that was never closed, causing sections 9-13 (menu handling, success metrics, failure modes, next step) to render as a code block

## Test plan

- [x] All existing tests pass (`npm test`)
- [x] markdownlint passes
- [x] Code fence balance verified (one ```` open at 214, one ```` close at 258)

🤖 Generated with [Claude Code](https://claude.com/claude-code)