### PR TITLE
fix(config): remove Windsurf from recommended/preferred IDEs

### DIFF
--- a/README.md
+++ b/README.md
@@ -32,7 +32,7 @@ npx bmad-method install
 
 > If you are getting a stale beta version, use: `npx bmad-method@6.0.1 install`
 
-Follow the installer prompts, then open your AI IDE (Claude Code, Codex, Windsurf, etc.) in your project folder.
+Follow the installer prompts, then open your AI IDE (Claude Code, Cursor, etc.) in your project folder.
 
 **Non-Interactive Installation** (for CI/CD):
 

--- a/docs/how-to/established-projects.md
+++ b/docs/how-to/established-projects.md
@@ -12,7 +12,7 @@ This guide covers the essential workflow for onboarding to existing projects wit
 :::note[Prerequisites]
 - BMad Method installed (`npx bmad-method install`)
 - An existing codebase you want to work on
-- Access to an AI-powered IDE (Claude Code, Cursor, or Windsurf)
+- Access to an AI-powered IDE (Claude Code or Cursor)
 :::
 
 ## Step 1: Clean Up Completed Planning Artifacts

--- a/docs/how-to/install-bmad.md
+++ b/docs/how-to/install-bmad.md
@@ -18,7 +18,7 @@ If you want to use a non interactive installer and provide all install options o
 :::note[Prerequisites]
 - **Node.js** 20+ (required for the installer)
 - **Git** (recommended)
-- **AI tool** (Claude Code, Cursor, Windsurf, or similar)
+- **AI tool** (Claude Code, Cursor, or similar)
 :::
 
 ## Steps
@@ -49,8 +49,6 @@ Pick which AI tools you use:
 
 - Claude Code
 - Cursor
-- Windsurf
-- Kiro
 - Others
 
 Each tool has its own way of integrating commands. The installer creates tiny prompt files to activate workflows and agents — it just puts them where your tool expects to find them.

--- a/docs/how-to/non-interactive-installation.md
+++ b/docs/how-to/non-interactive-installation.md
@@ -59,7 +59,7 @@ Check the [BMad registry](https://github.com/bmad-code-org) for available extern
 
 Available tool IDs for the `--tools` flag:
 
-**Preferred:** `claude-code`, `cursor`, `windsurf`
+**Preferred:** `claude-code`, `cursor`
 
 Run `npx bmad-method install` interactively once to see the full current list of supported tools, or check the [platform codes configuration](https://github.com/bmad-code-org/BMAD-METHOD/blob/main/tools/cli/installers/lib/ide/platform-codes.yaml).
 

--- a/docs/how-to/quick-fixes.md
+++ b/docs/how-to/quick-fixes.md
@@ -16,7 +16,7 @@ Use the **DEV agent** directly for bug fixes, refactorings, or small targeted ch
 
 :::note[Prerequisites]
 - BMad Method installed (`npx bmad-method install`)
-- An AI-powered IDE (Claude Code, Cursor, Windsurf, or similar)
+- An AI-powered IDE (Claude Code, Cursor, or similar)
 :::
 
 ## Choose Your Approach

--- a/docs/index.md
+++ b/docs/index.md
@@ -39,9 +39,7 @@ BMad works with any AI coding assistant that supports custom system prompts or p
 
 - **[Claude Code](https://code.claude.com)** — Anthropic's CLI tool (recommended)
 - **[Cursor](https://cursor.sh)** — AI-first code editor
-- **[Windsurf](https://codeium.com/windsurf)** — Codeium's AI IDE
-- **[Kiro](https://kiro.dev)** — Amazon's AI-powered IDE
-- **[Roo Code](https://roocode.com)** — VS Code extension
+- **[Codex CLI](https://github.com/openai/codex)** — OpenAI's terminal coding agent
 
 You should be comfortable with basic software development concepts like version control, project structure, and agile workflows. No prior experience with BMad-style agent systems is required—that's what these docs are for.
 

--- a/docs/tutorials/getting-started.md
+++ b/docs/tutorials/getting-started.md
@@ -16,7 +16,7 @@ Build software faster using AI-powered workflows with specialized agents that gu
 :::note[Prerequisites]
 - **Node.js 20+** — Required for the installer
 - **Git** — Recommended for version control
-- **AI-powered IDE** — Claude Code, Cursor, Windsurf, or similar
+- **AI-powered IDE** — Claude Code, Cursor, or similar
 - **A project idea** — Even a simple one works for learning
 :::
 

--- a/tools/cli/installers/lib/ide/codex.js
+++ b/tools/cli/installers/lib/ide/codex.js
@@ -14,7 +14,7 @@ const prompts = require('../../../lib/prompts');
  */
 class CodexSetup extends BaseIdeSetup {
   constructor() {
-    super('codex', 'Codex', true); // preferred IDE
+    super('codex', 'Codex', false);
   }
 
   /**

--- a/tools/cli/installers/lib/ide/platform-codes.yaml
+++ b/tools/cli/installers/lib/ide/platform-codes.yaml
@@ -168,7 +168,7 @@ platforms:
 
   windsurf:
     name: "Windsurf"
-    preferred: true
+    preferred: false
     category: ide
     description: "AI-powered IDE with cascade flows"
     installer:

--- a/tools/cli/lib/ui.js
+++ b/tools/cli/lib/ui.js
@@ -582,7 +582,7 @@ class UI {
   /**
    * Prompt for tool/IDE selection (called after module configuration)
    * Uses a split prompt approach:
-   *   1. Recommended tools - standard multiselect for 3 preferred tools
+   *   1. Recommended tools - standard multiselect for preferred tools
    *   2. Additional tools - autocompleteMultiselect with search capability
    * @param {string} projectDir - Project directory to check for existing IDEs
    * @param {Object} options - Command-line options

--- a/tools/platform-codes.yaml
+++ b/tools/platform-codes.yaml
@@ -18,12 +18,6 @@ platforms:
     category: cli
     description: "Anthropic's official CLI for Claude"
 
-  windsurf:
-    name: "Windsurf"
-    preferred: true
-    category: ide
-    description: "AI-powered IDE with cascade flows"
-
   cursor:
     name: "Cursor"
     preferred: true
@@ -126,6 +120,12 @@ platforms:
     preferred: false
     category: ide
     description: "AI coding tool"
+
+  windsurf:
+    name: "Windsurf"
+    preferred: false
+    category: ide
+    description: "AI-powered IDE with cascade flows"
 
 # Platform categories
 categories:


### PR DESCRIPTION
## Summary

- Set `preferred: false` for Windsurf in both `platform-codes.yaml` files — only Claude Code and Cursor are now recommended
- Moved Windsurf from "Recommended Platforms" to "Other IDEs" section in `tools/platform-codes.yaml`
- Fixed `codex.js` hardcoding `preferred: true` in its constructor (overriding the YAML config)
- Removed stale "3 preferred tools" count from `ui.js` JSDoc comment
- Updated 7 doc pages to list only Claude Code and Cursor as recommended
- Updated `docs/index.md` popular tools list to Claude Code, Cursor, and Codex CLI

Windsurf remains a **supported** platform — installer still works, templates stay, reference tables stay, bug report template still lists it.

## Test plan

- [x] All pre-commit hooks pass (lint, format, schemas, tests)
- [x] `node tools/validate-doc-links.js` — 0 issues
- [x] Doc site builds successfully
- [x] `grep -ri windsurf docs/` — only `reference/commands.md` (support context)
- [x] Both YAML files: only `claude-code` and `cursor` have `preferred: true`
- [x] No other JS installers hardcode `preferred: true`