### PR TITLE
docs: align testing page workflow sequence with workflow map

### DIFF
--- a/docs/reference/testing.md
+++ b/docs/reference/testing.md
@@ -95,12 +95,12 @@ TEA also supports P0-P3 risk-based prioritization and optional integrations with
 
 ## How Testing Fits into Workflows
 
-Quinn's Automate workflow appears in Phase 4 (Implementation) of the BMad Method workflow map. A typical sequence:
+Quinn's Automate workflow appears in Phase 4 (Implementation) of the BMad Method workflow map. It is designed to run **after a full epic is complete** -- once all stories have been implemented and reviewed -- to generate an end-to-end, UI-focused test suite covering the features delivered in that epic. A typical epic cycle looks like this:
 
-1. Implement a story with the Dev workflow (`DS`)
-2. Generate tests with Quinn (`QA`) or TEA's Automate workflow
-3. Validate implementation with Code Review (`CR`)
+1. **Per story:** Implement with the Dev workflow (`DS`), then validate with Code Review (`CR`)
+2. **After the epic:** Generate end-to-end tests with Quinn (`QA`) or TEA's Automate workflow
+3. **Wrap up:** Run Retrospective to capture lessons learned
 
 Quinn works directly from source code without loading planning documents (PRD, architecture). TEA workflows can integrate with upstream planning artifacts for traceability.
 
-For more on where testing fits in the overall process, see the [Workflow Map](./workflow-map.md).
+For the full Phase 4 sequence, see the [Workflow Map](./workflow-map.md).


### PR DESCRIPTION
## What

Updated the "How Testing Fits into Workflows" section in `docs/reference/testing.md` so the described sequence matches the Phase 4 ordering in the Workflow Map reference page.

## Why

The testing page described Quinn's Automate workflow as a per-story activity run *before* Code Review (DS -> QA -> CR), while the Workflow Map positions it *after* Code Review as an epic-level activity with the description "Use after a full epic is complete." This contradiction could confuse users about when to run test generation.

Fixes #1759

## How

- Rewrote the numbered sequence in "How Testing Fits into Workflows" to reflect the epic-level cycle: per-story DS+CR, then epic-level QA after the epic, then Retrospective
- Added clarifying text that Automate runs "after a full epic is complete" to match the Workflow Map's description
- Updated the cross-reference link text to point readers to the full Phase 4 sequence

## Testing

- `npm run lint:md` passes (0 errors across 264 files)
- `npm run docs:validate-links` passes (0 issues)
- `npm run docs:build` succeeds (full Astro site builds cleanly)
- Full pre-commit test suite passes (schemas, refs, install, lint, format)