### PR TITLE
fix(workflow): use git for dev-story File List

### DIFF
--- a/src/bmm/workflows/4-implementation/create-story/template.md
+++ b/src/bmm/workflows/4-implementation/create-story/template.md
@@ -48,5 +48,13 @@ so that {{benefit}}.
 
 ### File List
 
-<!-- Use `git diff --name-only` and `git status --porcelain` to capture ALL changed files,
-     including infrastructure side-effects: lock files, this story file, sprint-status.yaml -->
+<!-- 
+  Populate using git commands after each task:
+    git diff --name-only
+    git diff --cached --name-only
+    git status --porcelain
+  Include infrastructure side-effects (lock files, sprint-status.yaml, story file).
+  Exclude: _bmad/, _bmad-output/ directories.
+-->
+
+- (list files here, one per line)

--- a/src/bmm/workflows/4-implementation/dev-story/instructions.xml
+++ b/src/bmm/workflows/4-implementation/dev-story/instructions.xml
@@ -296,10 +296,12 @@
     <!-- ONLY MARK COMPLETE IF ALL VALIDATION PASS -->
     <check if="ALL validation gates pass AND tests ACTUALLY exist and pass">
       <action>ONLY THEN mark the task (and subtasks) checkbox with [x]</action>
-      <action>Run `git diff --name-only` and `git status --porcelain` to discover ALL changed files (including infrastructure
-        side-effects like lock files, the story file itself, and sprint-status.yaml)</action>
-      <action>Update File List section from git output with ALL new, modified, or deleted files (paths relative to repo root)</action>
       <action>Add completion notes to Dev Agent Record summarizing what was ACTUALLY implemented and tested</action>
+      <action>Save the story file NOW so its own changes appear in the working tree</action>
+      <action>Run `git diff --name-only`, `git diff --cached --name-only`, and `git status --porcelain` to discover ALL changed files
+        (including infrastructure side-effects like lock files, the story file itself, and sprint-status.yaml)</action>
+      <action>Filter out paths under `_bmad/` and `_bmad-output/` directories from the git output</action>
+      <action>REPLACE the File List section entirely with the filtered results: ALL new, modified, or deleted files (paths relative to repo root, one per line)</action>
     </check>
 
     <check if="ANY validation fails">
@@ -325,7 +327,9 @@
   <step n="9" goal="Story completion and mark for review" tag="sprint-status">
     <action>Verify ALL tasks and subtasks are marked [x] (re-scan the story document now)</action>
     <action>Run the full regression suite (do not skip)</action>
-    <action>Run `git diff --name-only` and `git status --porcelain` to get actual changed files; confirm File List matches git output</action>
+    <action>Save the story file before inspecting the working tree</action>
+    <action>Run `git diff --name-only`, `git diff --cached --name-only`, and `git status --porcelain` to get actual changed files
+      (excluding paths under `_bmad/` and `_bmad-output/`); verify File List contains ALL reported paths and auto-append any missing entries</action>
     <action>Execute enhanced definition-of-done validation</action>
     <action>Update the story Status to: "review"</action>
 
@@ -338,7 +342,7 @@
       - End-to-end tests for critical flows added when story demands them
       - All tests pass (no regressions, new tests successful)
       - Code quality checks pass (linting, static analysis if configured)
-      - File List matches all git-reported changes - run `git diff --name-only` and `git status --porcelain` to verify
+      - File List matches all git-reported changes - run `git diff --name-only`, `git diff --cached --name-only`, and `git status --porcelain` to verify (exclude `_bmad/`, `_bmad-output/`)
       - Dev Agent Record contains implementation notes
       - Change Log includes summary of changes
       - Only permitted story sections were modified


### PR DESCRIPTION
## Summary

The dev-story workflow builds its File List from agent memory, which misses infrastructure side-effects like `pnpm-lock.yaml`, the story file itself, and `sprint-status.yaml`. This causes a false-positive MEDIUM finding on every code-review run.

The fix replaces agent-driven File List updates (Steps 8 and 9) with `git diff --name-only` / `git status --porcelain` - the same approach the code-review workflow already uses for change discovery.

Also adds a hint comment to the story template's File List section so the pattern is visible to agents from the start.

Closes #1789

## Test plan

- Run the dev-story workflow on a story that installs a package or modifies sprint-status.yaml
- Verify the File List in the completed story includes lock files, story file, and sprint-status.yaml
- Run code-review afterward and confirm no false-positive "files changed but not in File List" finding