### PR TITLE
fix(core): remove zero-findings halt condition from edge case hunter

### DIFF
--- a/src/core/tasks/review-edge-case-hunter.xml
+++ b/src/core/tasks/review-edge-case-hunter.xml
@@ -57,7 +57,6 @@ No extra text, no explanations, no markdown wrapping.</output-format>
   </flow>
 
   <halt-conditions>
-    <condition>HALT if zero findings - this is suspicious, re-analyze or ask for guidance</condition>
     <condition>HALT if content is empty or unreadable</condition>
   </halt-conditions>
 


### PR DESCRIPTION
## Summary

- Remove the "HALT if zero findings" halt condition from `review-edge-case-hunter.xml`
- Zero findings is a valid outcome for trivial diffs with no branching logic
- The condition pressures the LLM to hallucinate findings when none exist
- Since this task runs non-interactively as a subagent, "ask for guidance" is not a viable exit path

## Context

When the edge case hunter receives a simple diff (rename, comment change, import reorder) with no branching paths, the flow correctly produces zero findings. But the halt condition treats zero findings as suspicious and pushes to "re-analyze", which can cause hallucinated findings. The remaining halt condition (empty/unreadable content) is preserved.