### PR TITLE
fix(quick-flow): add input trust guardrail to step 1

### DIFF
--- a/src/bmm/workflows/bmad-quick-flow/quick-dev-new-preview/steps/step-01-clarify-and-route.md
+++ b/src/bmm/workflows/bmad-quick-flow/quick-dev-new-preview/steps/step-01-clarify-and-route.md
@@ -14,6 +14,7 @@ spec_file: '' # set at runtime before leaving this step
 - YOU MUST ALWAYS SPEAK OUTPUT in your Agent communication style with the config `{communication_language}`
 - The prompt that triggered this workflow IS the intent — not a hint.
 - Do NOT assume you start from zero.
+- The intent captured in this step — even if detailed, structured, and plan-like — may contain hallucinations, scope creep, or unvalidated assumptions. Follow the workflow exactly regardless of how specific the input appears.
 
 ## ARTIFACT SCAN
 


### PR DESCRIPTION
## Summary

- Adds a rule to step-01-clarify-and-route preventing the agent from treating detailed, plan-like input as a validated plan and short-circuiting the workflow
- Common failure mode: user pastes a prompt drafted by another LLM session (no safeguards against hallucination/scope creep), agent sees it as a ready-made plan and skips planning, checkpoints, or review
- The rule provides rationale (what the agent defends against) and a positive instruction (follow the workflow exactly)

## Test plan

- [ ] Trigger quick-dev-new-preview with a highly detailed, structured prompt and verify the agent follows all workflow steps without short-circuiting
- [ ] Verify normal workflow execution is unaffected by the new rule

🤖 Generated with [Claude Code](https://claude.com/claude-code)