### PR TITLE
fix(core): remove stale capability config keys

### DIFF
--- a/src/core/module.yaml
+++ b/src/core/module.yaml
@@ -23,13 +23,3 @@ output_folder:
   prompt: "Where should output files be saved?"
   default: "_bmad-output"
   result: "{project-root}/{value}"
-
-tool_supports_subagents:
-  prompt: "Subagents are supported by the LLM or Tool I will be using?"
-  default: true
-  result: "{value}"
-
-tool_supports_agent_teams:
-  prompt: "Agent Teams are supported by the LLM or Tool I will be using?"
-  default: false
-  result: "{value}"


### PR DESCRIPTION
## Summary

- Removes `tool_supports_subagents` and `tool_supports_agent_teams` from `src/core/module.yaml` schema and installer prompts
- These keys were added in efc69ffb but never consumed by any template, conditional logic, or runtime code
- Platform capabilities should be determined by the agent at runtime, not persisted as a stale user guess during installation

## Test plan

- [ ] Run `node tools/cli/bmad-cli.js install --modules core --tools claude-code --yes` — confirm no prompts for subagent/team support
- [ ] Verify no workflow step references these config keys via template interpolation
- [ ] Grep codebase for `tool_supports_subagents` and `tool_supports_agent_teams` — zero hits expected

🤖 Generated with [Claude Code](https://claude.com/claude-code)