### PR TITLE
fix: add missing skill manifests for research and PRD workflows

### DIFF
--- a/src/bmm/workflows/1-analysis/research/bmad-skill-manifest.yaml
+++ b/src/bmm/workflows/1-analysis/research/bmad-skill-manifest.yaml
@@ -1,0 +1,14 @@
+workflow-domain-research.md:
+  canonicalId: bmad-bmm-domain-research
+  type: workflow
+  description: "Conduct domain and industry research"
+
+workflow-market-research.md:
+  canonicalId: bmad-bmm-market-research
+  type: workflow
+  description: "Conduct market research on competition and customers"
+
+workflow-technical-research.md:
+  canonicalId: bmad-bmm-technical-research
+  type: workflow
+  description: "Conduct technical research on technologies and architecture"

--- a/src/bmm/workflows/2-plan-workflows/create-prd/bmad-skill-manifest.yaml
+++ b/src/bmm/workflows/2-plan-workflows/create-prd/bmad-skill-manifest.yaml
@@ -1,0 +1,14 @@
+workflow-create-prd.md:
+  canonicalId: bmad-bmm-create-prd
+  type: workflow
+  description: "Create a PRD from scratch"
+
+workflow-edit-prd.md:
+  canonicalId: bmad-bmm-edit-prd
+  type: workflow
+  description: "Edit an existing PRD"
+
+workflow-validate-prd.md:
+  canonicalId: bmad-bmm-validate-prd
+  type: workflow
+  description: "Validate a PRD against standards"


### PR DESCRIPTION
## Summary
- Adds `bmad-skill-manifest.yaml` for `src/bmm/workflows/1-analysis/research/` (3 research workflows)
- Adds `bmad-skill-manifest.yaml` for `src/bmm/workflows/2-plan-workflows/create-prd/` (3 PRD workflows)
- These were missed during the all-is-skills migration (#1834), leaving 6 workflows undiscoverable by the native skills installer

## Test plan
- [ ] Run `bmad-cli install` and verify research and PRD workflows appear as native skills
- [ ] Confirm no regressions in other skill manifest discovery

🤖 Generated with [Claude Code](https://claude.com/claude-code)