### PR TITLE
fix: force trusted publish without token auth

### DIFF
--- a/.github/workflows/publish.yaml
+++ b/.github/workflows/publish.yaml
@@ -169,6 +169,26 @@ jobs:
         env:
           NODE_AUTH_TOKEN: ""
 
+      - name: Print npm debug logs
+        if: always()
+        run: |
+          LOG_DIR="$HOME/.npm/_logs"
+          echo "npm log directory: $LOG_DIR"
+          ls -la "$LOG_DIR" || true
+
+          found=0
+          for file in "$LOG_DIR"/*-debug-0.log; do
+            [ -e "$file" ] || continue
+            found=1
+            echo "::group::npm-debug $(basename "$file")"
+            cat "$file"
+            echo "::endgroup::"
+          done
+
+          if [ "$found" -eq 0 ]; then
+            echo "No npm *-debug-0.log files found."
+          fi
+
       - name: Push version commit and tag
         if: github.event_name == 'workflow_dispatch' && inputs.channel == 'latest'
         run: git push origin main --follow-tags


### PR DESCRIPTION
## What
Force npm publish steps to run without token auth by clearing  at publish time.

## Why
Trusted publishing with OIDC should not rely on token-based auth. In recent runs,  was present in the job environment and publish returned E404 despite correct OIDC claims.

## How
- keep existing OIDC diagnostics
- add  debug line
- set  on both publish steps ( and ) to prevent token-auth fallback