### PR TITLE
docs: mention @next install channel

### DIFF
--- a/README.md
+++ b/README.md
@@ -40,7 +40,7 @@ Traditional AI tools do the thinking for you, producing average results. BMad ag
 npx bmad-method install
 ```
 
-> If you are getting a stale beta version, use: `npx bmad-method@6.0.1 install`
+> Want the newest prerelease build? Use `npx bmad-method@next install`. Expect higher churn than the default install.
 
 Follow the installer prompts, then open your AI IDE (Claude Code, Cursor, etc.) in your project folder.
 

--- a/docs/how-to/install-bmad.md
+++ b/docs/how-to/install-bmad.md
@@ -29,6 +29,15 @@ If you want to use a non interactive installer and provide all install options o
 npx bmad-method install
 ```
 
+:::tip[Want the newest prerelease build?]
+Use the `next` dist-tag:
+```bash
+npx bmad-method@next install
+```
+
+This gets you newer changes earlier, with a higher chance of churn than the default install.
+:::
+
 :::tip[Bleeding edge]
 To install the latest from the main branch (may be unstable):
 ```bash

--- a/docs/tutorials/getting-started.md
+++ b/docs/tutorials/getting-started.md
@@ -95,6 +95,8 @@ Open a terminal in your project directory and run:
 npx bmad-method install
 ```
 
+If you want the newest prerelease build instead of the default release channel, use `npx bmad-method@next install`.
+
 When prompted to select modules, choose **BMad Method**.
 
 The installer creates two folders:


### PR DESCRIPTION
## Summary
- replace the stale README note about a pinned beta version with guidance for the `next` dist-tag
- mention `npx bmad-method@next install` in the install guide as an explicit prerelease option
- add the same prerelease note to Getting Started, since that is the page most users actually read

## Testing
- not run separately; docs-only change
