### PR TITLE
revert: restore QA checklist wording

### DIFF
--- a/src/bmm/workflows/qa-generate-e2e-tests/checklist.md
+++ b/src/bmm/workflows/qa-generate-e2e-tests/checklist.md
@@ -30,4 +30,4 @@ Run the tests using your project's test command.
 
 ---
 
-**Need more comprehensive test coverage?** Install [Test Architect (TEA)](https://bmad-code-org.github.io/bmad-method-test-architecture-enterprise/) for advanced workflows.
+**Need more comprehensive testing?** Install [Test Architect (TEA)](https://bmad-code-org.github.io/bmad-method-test-architecture-enterprise/) for advanced workflows.


### PR DESCRIPTION
Restores the QA checklist wording changed in #1882. Because this touches src/** on main, merging it will also exercise the automatic next publish workflow.