### PR TITLE
docs(zh-cn): remove slash prefix from skill examples in code blocks

### DIFF
--- a/docs/zh-cn/how-to/established-projects.md
+++ b/docs/zh-cn/how-to/established-projects.md
@@ -68,9 +68,9 @@ sidebar:
 - 理解自然语言查询
 
 ```
-/bmad-help 我有一个现有的 Rails 应用，我应该从哪里开始？
-/bmad-help quick-flow 和完整方法有什么区别？
-/bmad-help 显示我有哪些可用的工作流程
+bmad-help 我有一个现有的 Rails 应用，我应该从哪里开始？
+bmad-help quick-flow 和完整方法有什么区别？
+bmad-help 显示我有哪些可用的工作流程
 ```
 
 BMad-Help 还会在**每个工作流程结束时自动运行**，提供关于下一步该做什么的清晰指导。

--- a/docs/zh-cn/how-to/get-answers-about-bmad.md
+++ b/docs/zh-cn/how-to/get-answers-about-bmad.md
@@ -21,16 +21,16 @@ BMad-Help 不仅仅是一个查询工具——它：
 只需使用斜杠命令运行它：
 
 ```
-/bmad-help
+bmad-help
 ```
 
 或者结合自然语言查询：
 
 ```
-/bmad-help 我有一个 SaaS 想法并且知道所有功能。我应该从哪里开始？
-/bmad-help 我在 UX 设计方面有哪些选择？
-/bmad-help 我在 PRD 工作流上卡住了
-/bmad-help 向我展示到目前为止已完成的内容
+bmad-help 我有一个 SaaS 想法并且知道所有功能。我应该从哪里开始？
+bmad-help 我在 UX 设计方面有哪些选择？
+bmad-help 我在 PRD 工作流上卡住了
+bmad-help 向我展示到目前为止已完成的内容
 ```
 
 BMad-Help 会回应：

--- a/docs/zh-cn/how-to/install-bmad.md
+++ b/docs/zh-cn/how-to/install-bmad.md
@@ -86,8 +86,8 @@ your-project/
 
 你也可以向它提问：
 ```
-/bmad-help 我刚安装完成，应该先做什么？
-/bmad-help 对于 SaaS 项目我有哪些选项？
+bmad-help 我刚安装完成，应该先做什么？
+bmad-help 对于 SaaS 项目我有哪些选项？
 ```
 
 ## 故障排除


### PR DESCRIPTION
## Summary
- Fixes incomplete slash removal in three Chinese how-to docs
- Code block examples still used `/bmad-help` after PR #1892 updated the prose to `bmad-help`
- Updated examples in `get-answers-about-bmad.md`, `install-bmad.md`, and `established-projects.md`

## Test plan
- [x] Verified only code block examples were changed
- [x] All CI checks pass locally (markdownlint, prettier, etc.)