### PR TITLE
fix: restore validate-workflow as native skill directory

### DIFF
--- a/src/core/tasks/validate-workflow/SKILL.md
+++ b/src/core/tasks/validate-workflow/SKILL.md
@@ -1,0 +1,6 @@
+---
+name: validate-workflow
+description: "Run a checklist against a document with thorough analysis and produce a validation report"
+---
+
+Follow the instructions in [workflow.md](workflow.md).

--- a/src/core/tasks/validate-workflow/bmad-skill-manifest.yaml
+++ b/src/core/tasks/validate-workflow/bmad-skill-manifest.yaml
@@ -1,0 +1,1 @@
+type: skill

--- a/src/core/tasks/validate-workflow/workflow.md
+++ b/src/core/tasks/validate-workflow/workflow.md
@@ -1,0 +1,88 @@
+# Validate Workflow Output
+
+**Goal:** Run a checklist against a document with thorough analysis and produce a validation report.
+
+**Inputs:**
+
+- **workflow** (required) — Workflow path containing `checklist.md`
+- **checklist** (optional) — Checklist to validate against (defaults to the workflow's `checklist.md`)
+- **document** (optional) — Document to validate (ask user if not specified)
+
+## STEPS
+
+### Step 1: Setup
+
+- If checklist not provided, load `checklist.md` from the workflow location
+- Try to fuzzy-match files similar to the input document name; if document not provided or unsure, ask user: "Which document should I validate?"
+- Load both the checklist and document
+
+### Step 2: Validate (CRITICAL)
+
+**For EVERY checklist item, WITHOUT SKIPPING ANY:**
+
+1. Read the requirement carefully
+2. Search the document for evidence along with any ancillary loaded documents or artifacts (quotes with line numbers)
+3. Analyze deeply — look for explicit AND implied coverage
+
+**Mark each item as:**
+
+- **PASS** `✓` — Requirement fully met (provide evidence)
+- **PARTIAL** `⚠` — Some coverage but incomplete (explain gaps)
+- **FAIL** `✗` — Not met or severely deficient (explain why)
+- **N/A** `➖` — Not applicable (explain reason)
+
+**DO NOT SKIP ANY SECTIONS OR ITEMS.**
+
+### Step 3: Generate Report
+
+Create `validation-report-{timestamp}.md` in the document's folder with the following format:
+
+```markdown
+# Validation Report
+
+**Document:** {document-path}
+**Checklist:** {checklist-path}
+**Date:** {timestamp}
+
+## Summary
+
+- Overall: X/Y passed (Z%)
+- Critical Issues: {count}
+
+## Section Results
+
+### {Section Name}
+
+Pass Rate: X/Y (Z%)
+
+[MARK] {Item description}
+Evidence: {Quote with line# or explanation}
+{If FAIL/PARTIAL: Impact: {why this matters}}
+
+## Failed Items
+
+{All ✗ items with recommendations}
+
+## Partial Items
+
+{All ⚠ items with what's missing}
+
+## Recommendations
+
+1. Must Fix: {critical failures}
+2. Should Improve: {important gaps}
+3. Consider: {minor improvements}
+```
+
+### Step 4: Summary for User
+
+- Present section-by-section summary
+- Highlight all critical issues
+- Provide path to saved report
+- **HALT** — do not continue unless user asks
+
+## HALT CONDITIONS
+
+- HALT after presenting summary in Step 4
+- HALT with error if no checklist is found and none is provided
+- HALT with error if no document is found and user does not specify one


### PR DESCRIPTION
## What

Recreate the `validate-workflow` task as a native skill directory in `src/core/tasks/validate-workflow/`.

## Why

The validate-workflow task was accidentally deleted during the XML-to-native-skill refactor in #1864. The agent schema (`tools/schema/agent.js`), XML builder, handler definition, and test fixtures still reference `validate-workflow` as a valid command target, creating broken invocations when any agent menu item uses it.

Fixes #1530

## How

- Created `src/core/tasks/validate-workflow/` with `SKILL.md`, `bmad-skill-manifest.yaml`, and `workflow.md`
- Follows the established native skill pattern used by all other core tasks (e.g., `bmad-editorial-review-prose`)
- Workflow content faithfully preserves the original task logic: checklist-driven validation with evidence citations, pass/partial/fail/N/A marks, and structured report generation

## Testing

- Full test suite passes (267 tests total — schemas, refs, installation components)
- Markdown lint clean (349 files, 0 errors)
- Schema validation passes for all 10 agent files