### PR TITLE
fix: add File List and Change Log structure to story template

### DIFF
--- a/src/bmm/workflows/4-implementation/create-story/template.md
+++ b/src/bmm/workflows/4-implementation/create-story/template.md
@@ -47,3 +47,19 @@ so that {{benefit}}.
 ### Completion Notes List
 
 ### File List
+
+<!-- Populated during dev-story execution. List ALL new, modified, or deleted files (paths relative to repo root). -->
+
+| Action | File Path |
+|--------|-----------|
+<!-- | Added | src/example/new-file.ts | -->
+<!-- | Modified | src/example/existing-file.ts | -->
+<!-- | Deleted | src/example/removed-file.ts | -->
+
+### Change Log
+
+<!-- Populated during dev-story execution. Summarize what changed and why. -->
+
+| Date | Summary |
+|------|---------|
+<!-- | YYYY-MM-DD | Initial implementation of story tasks | -->


### PR DESCRIPTION
## What

Expand the `create-story/template.md` with structured File List and Change Log sections.

## Why

The template ends with an empty `### File List` header and no Change Log section. The dev-story workflow (steps 8-9) expects a structured File List with action/path entries and a Change Log with date/summary entries. Without guidance in the template, stories are systematically created with incomplete or missing file tracking.

Fixes #1789

## How

- Added table format for File List: `| Action | File Path |` with comment examples (Added/Modified/Deleted)
- Added Change Log section: `| Date | Summary |` with comment example
- Both sections use HTML comments as placeholder examples so they don't render as content

## Testing

- Markdown lint passes (347 files, 0 errors)
- Full test suite passes