### PR TITLE
fix: use double quotes in skill templates to prevent YAML parse errors

### DIFF
--- a/tools/cli/installers/lib/ide/_config-driven.js
+++ b/tools/cli/installers/lib/ide/_config-driven.js
@@ -403,8 +403,8 @@ class ConfigDrivenIdeSetup extends BaseIdeSetup {
   getDefaultTemplate(artifactType) {
     if (artifactType === 'agent') {
       return `---
-name: '{{name}}'
-description: '{{description}}'
+name: "{{name}}"
+description: "{{description}}"
 disable-model-invocation: true
 ---
 
@@ -418,8 +418,8 @@ You must fully embody this agent's persona and follow all activation instruction
 `;
     }
     return `---
-name: '{{name}}'
-description: '{{description}}'
+name: "{{name}}"
+description: "{{description}}"
 ---
 
 # {{name}}
@@ -468,7 +468,7 @@ LOAD and execute from: {project-root}/{{bmadFolderName}}/{{path}}
       .replaceAll('{{name}}', artifact.name || '')
       .replaceAll('{{module}}', artifact.module || 'core')
       .replaceAll('{{path}}', pathToUse)
-      .replaceAll('{{description}}', artifact.description || `${artifact.name} ${artifact.type || ''}`)
+      .replaceAll('{{description}}', (artifact.description || `${artifact.name} ${artifact.type || ''}`).replaceAll('"', String.raw`\"`))
       .replaceAll('{{workflow_path}}', pathToUse);
 
     return rendered;


### PR DESCRIPTION
## What

Switch default skill templates from single-quoted to double-quoted YAML values and escape descriptions during rendering.

## Why

The `getDefaultTemplate()` method in `_config-driven.js` wraps `{{description}}` in single quotes. When a workflow description contains an apostrophe (e.g., "agent's workflow"), the generated YAML frontmatter becomes invalid, causing parse failures in IDEs like Antigravity. This is the same class of issue fixed for Gemini templates in #1746.

Fixes #1744

## How

- Changed `name: '{{name}}'` → `name: "{{name}}"` in both agent and default templates
- Changed `description: '{{description}}'` → `description: "{{description}}"` in both templates
- Added `replaceAll('"', String.raw\`\\"\`)` to description escaping in `renderTemplate()` for safety

## Testing

- Full test suite passes (215 installation tests, 52 schema tests, lint, format)
- Verified the change applies to the fallback templates used by platforms without custom templates