### PR TITLE
fix: ensure --yes flag assigns defaults for all config fields

### DIFF
--- a/tools/cli/installers/lib/core/config-collector.js
+++ b/tools/cli/installers/lib/core/config-collector.js
@@ -735,12 +735,13 @@ class ConfigCollector {
       // Skip prompts mode: use all defaults without asking
       if (this.skipPrompts) {
         await prompts.log.info(`Using default configuration for ${moduleDisplayName}`);
-        // Use defaults for all questions
+        // Use defaults for all questions; use empty string for fields without defaults
         for (const question of questions) {
-          const hasDefault = question.default !== undefined && question.default !== null && question.default !== '';
-          if (hasDefault && typeof question.default !== 'function') {
-            allAnswers[question.name] = question.default;
+          if (typeof question.default === 'function') {
+            continue;
           }
+          const hasDefault = question.default !== undefined && question.default !== null && question.default !== '';
+          allAnswers[question.name] = hasDefault ? question.default : '';
         }
       } else {
         if (!this._silentConfig) await prompts.log.step(`Configuring ${moduleDisplayName}`);


### PR DESCRIPTION
## Summary

Fixes #1803

When running `bmad install --yes`, the config collector skips interactive prompts but only assigns values for fields that have explicit defaults. Fields without defaults are silently skipped, leaving `undefined` values that can cause downstream template rendering failures (e.g., `{{name}}` placeholders left unresolved).

This change ensures that in `skipPrompts` mode, fields without defaults are assigned an empty string fallback, preventing undefined values from propagating through the installer pipeline.

## Changes

- `tools/cli/installers/lib/core/config-collector.js`: Updated `skipPrompts` branch to assign empty string for fields without explicit defaults
- Early-continue for function-type defaults (computed defaults that require prior answers)

## Test plan

- [ ] Run `npx bmad-method install --yes` and verify no `undefined` values appear in generated files
- [ ] Run `npx bmad-method install --yes --directory ./test-output` and inspect output config
- [ ] Verify interactive mode (`npx bmad-method install`) still works as before