### PR TITLE
fix: add copy-paste command for adversarial review in quick-spec

### DIFF
--- a/src/bmm/workflows/bmad-quick-flow/quick-spec/steps/step-04-review.md
+++ b/src/bmm/workflows/bmad-quick-flow/quick-spec/steps/step-04-review.md
@@ -120,6 +120,12 @@ Saved to: {finalFile}
 [D] Done - exit workflow
 [P] Party Mode - get expert feedback before dev
 
+To run adversarial review in a fresh context (recommended for information asymmetry):
+
+\`\`\`
+/bmad-review-adversarial-general {finalFile}
+\`\`\`
+
 ---
 
 Once you are fully satisfied with the spec (ideally after **Adversarial Review** and maybe a few rounds of **Advanced Elicitation**), it is recommended to run implementation in a FRESH CONTEXT for best results.


### PR DESCRIPTION
## Summary

Fixes #1659

The final menu in quick-spec step 4 provides a ready-to-copy `quick-dev` command for starting development in a fresh context, but no equivalent command for adversarial review. This is inconsistent since adversarial review also benefits from fresh context for information asymmetry.

## Changes

- `src/bmm/workflows/bmad-quick-flow/quick-spec/steps/step-04-review.md`: Added `/bmad-review-adversarial-general {finalFile}` copy-paste command block in the Next Steps menu, alongside the existing `quick-dev` command

## Test plan

- [ ] Run quick-spec workflow through to step 4 and verify the adversarial review command appears in the menu
- [ ] Verify the command references the correct `{finalFile}` variable