### PR TITLE
docs: fix contradictory Quinn workflow placement in testing reference

### DIFF
--- a/docs/reference/testing.md
+++ b/docs/reference/testing.md
@@ -95,11 +95,11 @@ TEA also supports P0-P3 risk-based prioritization and optional integrations with
 
 ## How Testing Fits into Workflows
 
-Quinn's Automate workflow appears in Phase 4 (Implementation) of the BMad Method workflow map. A typical sequence:
+Quinn's Automate workflow appears in Phase 4 (Implementation) of the BMad Method workflow map. It is designed to run **after a full epic is complete** — once all stories in an epic have been implemented and code-reviewed. A typical sequence:
 
-1. Implement a story with the Dev workflow (`DS`)
-2. Generate tests with Quinn (`QA`) or TEA's Automate workflow
-3. Validate implementation with Code Review (`CR`)
+1. For each story in the epic: implement with Dev (`DS`), then validate with Code Review (`CR`)
+2. After the epic is complete: generate tests with Quinn (`QA`) or TEA's Automate workflow
+3. Run retrospective (`bmad-retrospective`) to capture lessons learned
 
 Quinn works directly from source code without loading planning documents (PRD, architecture). TEA workflows can integrate with upstream planning artifacts for traceability.
 


### PR DESCRIPTION
## Summary

Fixes #1759

The testing reference page incorrectly described Quinn's Automate workflow as running per-story before Code Review, contradicting the workflow map which positions it after epic completion. This creates confusion about when to run Quinn.

## Changes

- `docs/reference/testing.md`: Updated "How Testing Fits into Workflows" section to align with the workflow map — Quinn runs after a full epic is complete (all stories implemented and code-reviewed), not per-story before Code Review

## Test plan

- [ ] Verify the updated sequence matches the Phase 4 table in `docs/reference/workflow-map.md`
- [ ] Review rendered documentation for clarity