### PR TITLE
fix: add brainstorming reconciliation to prevent silent idea loss in PRD

### DIFF
--- a/src/bmm/workflows/2-plan-workflows/create-prd/steps-c/step-11-polish.md
+++ b/src/bmm/workflows/2-plan-workflows/create-prd/steps-c/step-11-polish.md
@@ -99,6 +99,22 @@ Review the entire document with PRD purpose principles in mind:
 - Are technical terms used appropriately?
 - Would stakeholders find this easy to understand?
 
+### 2b. Brainstorming Reconciliation (if brainstorming input exists)
+
+**Check the PRD frontmatter `inputDocuments` for any brainstorming document** (e.g., `brainstorming-session*.md`, `brainstorming-report.md`). If a brainstorming document was used as input:
+
+1. **Load the brainstorming document** and extract all distinct ideas, themes, and recommendations
+2. **Cross-reference against the PRD** — for each brainstorming idea, check if it landed in any PRD section (requirements, success criteria, user journeys, scope, etc.)
+3. **Identify dropped ideas** — ideas from brainstorming that do not appear anywhere in the PRD. Pay special attention to:
+   - Tone, personality, and interaction design ideas (these are most commonly lost)
+   - Design philosophy and coaching approach ideas
+   - "What should this feel like" ideas (UX feel, not just UX function)
+   - Qualitative/soft ideas that don't map cleanly to functional requirements
+4. **Present findings to user**: "These brainstorming ideas did not make it into the PRD: [list]. Should any be incorporated?"
+5. **If user wants to incorporate dropped ideas**: Add them to the most appropriate PRD section (success criteria, non-functional requirements, or a new section if needed)
+
+**Why this matters**: Brainstorming documents are often long, and the PRD's structured template has an implicit bias toward concrete/structural ideas. Soft ideas (tone, philosophy, interaction feel) frequently get silently dropped because they don't map cleanly to FR/NFR format.
+
 ### 3. Optimization Actions
 
 Make targeted improvements:
@@ -193,6 +209,7 @@ When user selects 'C', replace the entire document content with the polished ver
 ✅ User's voice and intent preserved
 ✅ Document is more readable and professional
 ✅ A/P/C menu presented and handled correctly
+✅ Brainstorming reconciliation completed (if brainstorming input exists)
 ✅ Polished document saved when C selected
 
 ## FAILURE MODES:


### PR DESCRIPTION
## Summary

Fixes #1674

When feeding brainstorming sessions into the PRD workflow, soft/qualitative ideas (tone, personality, interaction design, coaching philosophy) get silently dropped because they don't map cleanly to the PRD template's structured format (FR/NFR). The resulting PRD reads as complete and coherent, so the loss is invisible without manually diffing against the brainstorming output.

## Changes

- `src/bmm/workflows/2-plan-workflows/create-prd/steps-c/step-11-polish.md`: Added section "2b. Brainstorming Reconciliation" that:
  1. Checks if a brainstorming document exists in `inputDocuments` frontmatter
  2. Cross-references all brainstorming ideas against the PRD
  3. Identifies dropped ideas (especially tone, philosophy, interaction design)
  4. Presents findings to user for decision on incorporation
  5. Skips gracefully when no brainstorming input exists

## Design Rationale

- Placed in step-11 (polish) rather than a new step to avoid renumbering the 12-step workflow
- The polish step is the natural place for document quality review
- The check is conditional — only runs when brainstorming was an input document
- No breaking changes to existing flow

## Test plan

- [ ] Run PRD workflow with brainstorming document as input — verify reconciliation identifies dropped ideas
- [ ] Run PRD workflow without brainstorming input — verify step is skipped gracefully
- [ ] Verify soft/qualitative ideas (tone, philosophy) are specifically flagged