### PR TITLE
fix: address review findings from party-mode skill conversion

### DIFF
--- a/src/bmm/workflows/bmad-quick-flow/bmad-quick-dev-new-preview/workflow.md
+++ b/src/bmm/workflows/bmad-quick-flow/bmad-quick-dev-new-preview/workflow.md
@@ -1,9 +1,5 @@
 ---
 main_config: '{project-root}/_bmad/bmm/config.yaml'
-
-# Related workflows
-advanced_elicitation: '{project-root}/_bmad/core/workflows/advanced-elicitation/workflow.md'
-party_mode_exec: '{project-root}/_bmad/core/workflows/bmad-party-mode/workflow.md'
 ---
 
 # Quick Dev New Preview Workflow

--- a/src/bmm/workflows/generate-project-context/steps/step-02-generate.md
+++ b/src/bmm/workflows/generate-project-context/steps/step-02-generate.md
@@ -30,7 +30,7 @@ This step will generate content and present choices for each rule category:
 ## PROTOCOL INTEGRATION:
 
 - When 'A' selected: Execute {project-root}/_bmad/core/workflows/advanced-elicitation/workflow.md
-- When 'P' selected: Execute {project-root}/_bmad/core/workflows/bmad-party-mode
+- When 'P' selected: Execute {project-root}/_bmad/core/workflows/bmad-party-mode/workflow.md
 - PROTOCOLS always return to display this step's A/P/C menu after the A or P have completed
 - User accepts/rejects protocol changes before proceeding
 

--- a/src/core/workflows/bmad-party-mode/steps/step-03-graceful-exit.md
+++ b/src/core/workflows/bmad-party-mode/steps/step-03-graceful-exit.md
@@ -93,7 +93,6 @@ Final workflow completion steps:
 ```yaml
 ---
 stepsCompleted: [1, 2, 3]
-workflowType: 'party-mode'
 user_name: '{{user_name}}'
 date: '{{date}}'
 agents_loaded: true

--- a/src/core/workflows/bmad-party-mode/workflow.md
+++ b/src/core/workflows/bmad-party-mode/workflow.md
@@ -114,7 +114,6 @@ Load step: `./steps/step-02-discussion-orchestration.md`
 ```yaml
 ---
 stepsCompleted: [1]
-workflowType: 'party-mode'
 user_name: '{{user_name}}'
 date: '{{date}}'
 agents_loaded: true


### PR DESCRIPTION
## Summary

- Fix bare directory reference missing `/workflow.md` in step-02-generate.md (flagged by both Augment and CodeRabbit)
- Remove stale `workflowType: 'party-mode'` from workflow.md and step-03-graceful-exit.md
- Remove unused decorative `party_mode_exec` and `advanced_elicitation` aliases from quick-dev-new-preview workflow

## Test plan

- [ ] `npm test` passes
- [ ] Grep confirms no bare `bmad-party-mode` directory references remain (all end with `/workflow.md`)
- [ ] Grep confirms no `workflowType: 'party-mode'` remains in source

🤖 Generated with [Claude Code](https://claude.com/claude-code)