### PR TITLE
fix: add copy-paste command for adversarial review in fresh context

### DIFF
--- a/src/bmm/workflows/bmad-quick-flow/bmad-quick-spec/steps/step-04-review.md
+++ b/src/bmm/workflows/bmad-quick-flow/bmad-quick-spec/steps/step-04-review.md
@@ -119,7 +119,7 @@ Saved to: {finalFile}
 
 ---
 
-For best results, run **Adversarial Review** in a separate session so the reviewer only sees the spec, not your design rationale. Open a new chat/session and run:
+For best results, run **Adversarial Review** in a separate session so the reviewer should only be provided the spec (`{finalFile}`) when possible. Note that project read access may still exist, but the reviewer should focus solely on the spec content rather than your design rationale. Open a new chat/session and run:
 
 \`\`\`
 bmad-review-adversarial-general {finalFile}
@@ -182,7 +182,7 @@ b) **HALT and wait for user selection.**
 
 `{finalFile}`
 
-If you haven't run an adversarial review yet, open a new chat/session and run:
+If you haven't run an adversarial review yet, open a new chat/session (the reviewer should only be provided the spec when possible -- project read access may still exist, but the focus should be solely on the spec content) and run:
 
 ```
 bmad-review-adversarial-general {finalFile}


### PR DESCRIPTION
## What

Adds a copy-paste command for running adversarial review in a fresh context, matching the existing UX pattern for the quick-dev command.

## Why

In quick-spec step-04-review.md, the final menu provides a ready-to-copy command for starting development in a fresh context, but no equivalent for adversarial review. The workflow recognizes fresh context matters for dev but does not apply the same pattern for adversarial review, which also benefits from information asymmetry.

Fixes #1659

## How

- Added bmad-review-adversarial-general {finalFile} command block in the final menu section
- Uses skill name language (not slash command prefix) per maintainer alignment in #1910
- Follows the same explanation-then-command pattern as the existing quick-dev block
- Added context about why fresh context matters for adversarial review (information asymmetry)

## Testing

- npm run validate:refs passes (0 broken references)
- npm run validate:schemas passes
- npm run lint:md passes (0 errors)
- Full test suite passes (215 tests)