### PR TITLE
fix(installer): separate skill and agent counts in summary

### DIFF
--- a/test/test-installation-components.js
+++ b/test/test-installation-components.js
@@ -1846,7 +1846,7 @@ async function runTests() {
     });
 
     assert(result.success === true, 'Antigravity setup succeeds with overlapping skill names');
-    assert(result.detail === '2 skills, 2 agents', 'Installer detail reports total skills and total agents');
+    assert(result.detail === '2 agents', 'Installer detail reports agents separately from skills');
     assert(result.handlerResult.results.skillDirectories === 2, 'Result exposes unique skill directory count');
     assert(result.handlerResult.results.agents === 2, 'Result retains generated agent write count');
     assert(result.handlerResult.results.workflows === 1, 'Result retains generated workflow count');

--- a/tools/cli/installers/lib/ide/_config-driven.js
+++ b/tools/cli/installers/lib/ide/_config-driven.js
@@ -712,9 +712,10 @@ LOAD and execute from: {project-root}/{{bmadFolderName}}/{{path}}
   async printSummary(results, targetDir, options = {}) {
     if (options.silent) return;
     const parts = [];
-    const totalSkills =
+    const totalDirs =
       results.skillDirectories || (results.workflows || 0) + (results.tasks || 0) + (results.tools || 0) + (results.skills || 0);
-    if (totalSkills > 0) parts.push(`${totalSkills} skills`);
+    const skillCount = totalDirs - (results.agents || 0);
+    if (skillCount > 0) parts.push(`${skillCount} skills`);
     if (results.agents > 0) parts.push(`${results.agents} agents`);
     await prompts.log.success(`${this.name} configured: ${parts.join(', ')} → ${targetDir}`);
   }

--- a/tools/cli/installers/lib/ide/manager.js
+++ b/tools/cli/installers/lib/ide/manager.js
@@ -162,8 +162,9 @@ class IdeManager {
         // Config-driven handlers return { success, results: { agents, workflows, tasks, tools } }
         const r = handlerResult.results;
         const parts = [];
-        const totalSkills = r.skillDirectories || (r.workflows || 0) + (r.tasks || 0) + (r.tools || 0) + (r.skills || 0);
-        if (totalSkills > 0) parts.push(`${totalSkills} skills`);
+        const totalDirs = r.skillDirectories || (r.workflows || 0) + (r.tasks || 0) + (r.tools || 0) + (r.skills || 0);
+        const skillCount = totalDirs - (r.agents || 0);
+        if (skillCount > 0) parts.push(`${skillCount} skills`);
         if (r.agents > 0) parts.push(`${r.agents} agents`);
         detail = parts.join(', ');
       }


### PR DESCRIPTION
## Summary
- Subtract agent count from total skill directories so the install summary shows non-agent skills and agents as distinct counts (e.g. `34 skills, 10 agents` instead of `44 skills, 10 agents`)
- Fixes double-counting where agent skill directories were included in both the skill total and the agent count

## Verification
- `node test/test-installation-components.js` — all 223 tests pass
- Manual install with `--tools claude-code` shows `34 skills, 10 agents`
- Manual install with `--tools none` shows `No IDE selected`