### PR TITLE
chore(bmm): complete quick-dev-new-preview native skill metadata

### DIFF
--- a/src/bmm/workflows/bmad-quick-flow/bmad-quick-dev-new-preview/workflow.md
+++ b/src/bmm/workflows/bmad-quick-flow/bmad-quick-dev-new-preview/workflow.md
@@ -1,4 +1,6 @@
 ---
+name: bmad-quick-dev-new-preview
+description: 'Implements any user intent, requirement, story, bug fix or change request by producing clean working code artifacts that follow the project''s existing architecture, patterns and conventions. Use when the user wants to build, fix, tweak, refactor, add or modify any code, component or feature.'
 main_config: '{project-root}/_bmad/bmm/config.yaml'
 ---
 


### PR DESCRIPTION
## Summary
- complete the mechanical conversion requirements for `bmad-quick-dev-new-preview` by adding missing `workflow.md` frontmatter fields
- add `name: bmad-quick-dev-new-preview`
- add non-empty `description` matching the skill trigger text

## Why
`bmad-skill-manifest.yaml` is already `type: skill`; this PR closes a remaining mechanical metadata gap so `workflow.md` complies with native skill requirements without changing behavior.

## Mechanical Constraints
- no workflow logic changes
- no step sequence changes
- no prompt hardening/optimization
- no behavioral redesign

## Validation
- `node tools/cli/bmad-cli.js install --directory /Users/alex/src/bmad --modules bmm --tools claude-code --yes`
  - verified `.claude/skills/bmad-quick-dev-new-preview/` exists with `workflow.md`, `steps/`, template, and `SKILL.md`
  - verified `_bmad/_config/skill-manifest.csv` contains `bmad-quick-dev-new-preview`
- `npm test` passed (full repo suite)

## Functional Equivalence (before/after)
1. Workflow body equivalence
   - compared `workflow.md` content after frontmatter against previous HEAD
   - SHA-256 matched exactly; no body diff
2. Asset equivalence
   - compared SHA-256 set for `steps/*.md` and `tech-spec-template.md` against previous HEAD
   - hashes matched exactly

## Notes
- No pre-existing behavioral issues were introduced or modified in this pass.
