### PR TITLE
fix(create-story): normalize internal path refs to relative

### DIFF
--- a/src/bmm/workflows/4-implementation/bmad-create-story/checklist.md
+++ b/src/bmm/workflows/4-implementation/bmad-create-story/checklist.md
@@ -36,7 +36,7 @@ This is a COMPETITION to create the **ULTIMATE story context** that makes LLM de
 - The workflow framework will automatically:
   - Load this checklist file
   - Load the newly created story file (`{story_file_path}`)
-  - Load workflow variables from `{installed_path}/workflow.md`
+  - Load workflow variables from `./workflow.md`
   - Execute the validation process
 
 ### **When Running in Fresh Context:**
@@ -61,7 +61,7 @@ You will systematically re-do the entire story creation process, but with a crit
 
 ### **Step 1: Load and Understand the Target**
 
-1. **Load the workflow configuration**: `{installed_path}/workflow.md` for variable inclusion
+1. **Load the workflow configuration**: `./workflow.md` for variable inclusion
 2. **Load the story file**: `{story_file_path}` (provided by user or discovered)
 3. **Extract metadata**: epic_num, story_num, story_key, story_title from story file
 4. **Resolve all workflow variables**: implementation_artifacts, epics_file, architecture_file, etc.

--- a/src/bmm/workflows/4-implementation/bmad-create-story/workflow.md
+++ b/src/bmm/workflows/4-implementation/bmad-create-story/workflow.md
@@ -1,8 +1,3 @@
----
-name: bmad-create-story
-description: 'Creates a dedicated story file with all the context the agent will need to implement it later. Use when the user says "create the next story" or "create story [story identifier]"'
----
-
 # Create Story Workflow
 
 **Goal:** Create a comprehensive story file that gives the dev agent everything needed for flawless implementation.
@@ -217,10 +212,10 @@ Load config from `{project-root}/_bmad/bmm/config.yaml` and resolve:
 </step>
 
 <step n="2" goal="Load and analyze core artifacts">
-  <critical>🔬 EXHAUSTIVE ARTIFACT ANALYSIS - This is where you prevent future developer fuckups!</critical>
+  <critical>🔬 EXHAUSTIVE ARTIFACT ANALYSIS - This is where you prevent future developer mistakes!</critical>
 
   <!-- Load all available content through discovery protocol -->
-  <action>Read fully and follow `{installed_path}/discover-inputs.md` to load all input files</action>
+  <action>Read fully and follow `./discover-inputs.md` to load all input files</action>
   <note>Available content: {epics_content}, {prd_content}, {architecture_content}, {ux_content},
   {project_context}</note>
 
@@ -352,7 +347,7 @@ Load config from `{project-root}/_bmad/bmm/config.yaml` and resolve:
 </step>
 
 <step n="6" goal="Update sprint status and finalize">
-  <action>Validate the newly created story file {story_file} against {installed_path}/checklist.md and apply any required fixes before finalizing</action>
+  <action>Validate the newly created story file {story_file} against `./checklist.md` and apply any required fixes before finalizing</action>
   <action>Save story document unconditionally</action>
 
   <!-- Update sprint status -->


### PR DESCRIPTION
## Summary

Post-conversion cleanup for the create-story native skill:

- Remove `name`/`description` frontmatter from `workflow.md` (metadata belongs in `SKILL.md`)
- Replace `{installed_path}/` references with `./` relative paths in `workflow.md` and `checklist.md`

These are mechanical fixes per the workflow-to-skill conversion patch process — no behavior changes.

## Files changed

- `src/bmm/workflows/4-implementation/bmad-create-story/workflow.md`
- `src/bmm/workflows/4-implementation/bmad-create-story/checklist.md`