### PR TITLE
fix: enforce document_output_language in planning workflow step files

### DIFF
--- a/src/bmm/workflows/1-analysis/bmad-create-product-brief/steps/step-02-vision.md
+++ b/src/bmm/workflows/1-analysis/bmad-create-product-brief/steps/step-02-vision.md
@@ -26,6 +26,7 @@ Conduct comprehensive product vision discovery to define the core problem, solut
 - 🔄 CRITICAL: When loading next step with 'C', ensure entire file is read
 - 📋 YOU ARE A FACILITATOR, not a content generator
 - ✅ YOU MUST ALWAYS SPEAK OUTPUT In your Agent communication style with the config `{communication_language}`
+- ✅ YOU MUST ALWAYS WRITE all artifact and document content in `{document_output_language}`
 
 ### Role Reinforcement:
 

--- a/src/bmm/workflows/1-analysis/bmad-create-product-brief/steps/step-03-users.md
+++ b/src/bmm/workflows/1-analysis/bmad-create-product-brief/steps/step-03-users.md
@@ -26,6 +26,7 @@ Define target users with rich personas and map their key interactions with the p
 - 🔄 CRITICAL: When loading next step with 'C', ensure entire file is read
 - 📋 YOU ARE A FACILITATOR, not a content generator
 - ✅ YOU MUST ALWAYS SPEAK OUTPUT In your Agent communication style with the config `{communication_language}`
+- ✅ YOU MUST ALWAYS WRITE all artifact and document content in `{document_output_language}`
 
 ### Role Reinforcement:
 

--- a/src/bmm/workflows/1-analysis/bmad-create-product-brief/steps/step-04-metrics.md
+++ b/src/bmm/workflows/1-analysis/bmad-create-product-brief/steps/step-04-metrics.md
@@ -26,6 +26,7 @@ Define comprehensive success metrics that include user success, business objecti
 - 🔄 CRITICAL: When loading next step with 'C', ensure entire file is read
 - 📋 YOU ARE A FACILITATOR, not a content generator
 - ✅ YOU MUST ALWAYS SPEAK OUTPUT In your Agent communication style with the config `{communication_language}`
+- ✅ YOU MUST ALWAYS WRITE all artifact and document content in `{document_output_language}`
 
 ### Role Reinforcement:
 

--- a/src/bmm/workflows/1-analysis/bmad-create-product-brief/steps/step-05-scope.md
+++ b/src/bmm/workflows/1-analysis/bmad-create-product-brief/steps/step-05-scope.md
@@ -26,6 +26,7 @@ Define MVP scope with clear boundaries and outline future vision through collabo
 - 🔄 CRITICAL: When loading next step with 'C', ensure entire file is read
 - 📋 YOU ARE A FACILITATOR, not a content generator
 - ✅ YOU MUST ALWAYS SPEAK OUTPUT In your Agent communication style with the config `{communication_language}`
+- ✅ YOU MUST ALWAYS WRITE all artifact and document content in `{document_output_language}`
 
 ### Role Reinforcement:
 

--- a/src/bmm/workflows/1-analysis/bmad-create-product-brief/workflow.md
+++ b/src/bmm/workflows/1-analysis/bmad-create-product-brief/workflow.md
@@ -47,6 +47,9 @@ Load and read full config from {project-root}/_bmad/bmm/config.yaml and resolve:
 
 - `project_name`, `output_folder`, `planning_artifacts`, `user_name`, `communication_language`, `document_output_language`, `user_skill_level`
 
+✅ YOU MUST ALWAYS SPEAK OUTPUT In your Agent communication style with the configured `{communication_language}`.
+✅ YOU MUST ALWAYS WRITE all artifact and document content in `{document_output_language}`.
+
 ### 2. First Step EXECUTION
 
 Read fully and follow: `./steps/step-01-init.md` to begin the workflow.

--- a/src/bmm/workflows/2-plan-workflows/bmad-create-ux-design/steps/step-03-core-experience.md
+++ b/src/bmm/workflows/2-plan-workflows/bmad-create-ux-design/steps/step-03-core-experience.md
@@ -11,6 +11,7 @@
 - 💬 FOCUS on defining the core user experience and platform
 - 🎯 COLLABORATIVE discovery, not assumption-based design
 - ✅ YOU MUST ALWAYS SPEAK OUTPUT In your Agent communication style with the config `{communication_language}`
+- ✅ YOU MUST ALWAYS WRITE all artifact and document content in `{document_output_language}`
 
 ## EXECUTION PROTOCOLS:
 

--- a/src/bmm/workflows/2-plan-workflows/bmad-create-ux-design/steps/step-04-emotional-response.md
+++ b/src/bmm/workflows/2-plan-workflows/bmad-create-ux-design/steps/step-04-emotional-response.md
@@ -11,6 +11,7 @@
 - 💬 FOCUS on defining desired emotional responses and user feelings
 - 🎯 COLLABORATIVE discovery, not assumption-based design
 - ✅ YOU MUST ALWAYS SPEAK OUTPUT In your Agent communication style with the config `{communication_language}`
+- ✅ YOU MUST ALWAYS WRITE all artifact and document content in `{document_output_language}`
 
 ## EXECUTION PROTOCOLS:
 

--- a/src/bmm/workflows/2-plan-workflows/bmad-create-ux-design/steps/step-05-inspiration.md
+++ b/src/bmm/workflows/2-plan-workflows/bmad-create-ux-design/steps/step-05-inspiration.md
@@ -11,6 +11,7 @@
 - 💬 FOCUS on analyzing existing UX patterns and extracting inspiration
 - 🎯 COLLABORATIVE discovery, not assumption-based design
 - ✅ YOU MUST ALWAYS SPEAK OUTPUT In your Agent communication style with the config `{communication_language}`
+- ✅ YOU MUST ALWAYS WRITE all artifact and document content in `{document_output_language}`
 
 ## EXECUTION PROTOCOLS:
 

--- a/src/bmm/workflows/2-plan-workflows/bmad-create-ux-design/steps/step-06-design-system.md
+++ b/src/bmm/workflows/2-plan-workflows/bmad-create-ux-design/steps/step-06-design-system.md
@@ -11,6 +11,7 @@
 - 💬 FOCUS on choosing appropriate design system approach
 - 🎯 COLLABORATIVE decision-making, not recommendation-only
 - ✅ YOU MUST ALWAYS SPEAK OUTPUT In your Agent communication style with the config `{communication_language}`
+- ✅ YOU MUST ALWAYS WRITE all artifact and document content in `{document_output_language}`
 
 ## EXECUTION PROTOCOLS:
 

--- a/src/bmm/workflows/2-plan-workflows/bmad-create-ux-design/steps/step-07-defining-experience.md
+++ b/src/bmm/workflows/2-plan-workflows/bmad-create-ux-design/steps/step-07-defining-experience.md
@@ -11,6 +11,7 @@
 - 💬 FOCUS on defining the core interaction that defines the product
 - 🎯 COLLABORATIVE discovery, not assumption-based design
 - ✅ YOU MUST ALWAYS SPEAK OUTPUT In your Agent communication style with the config `{communication_language}`
+- ✅ YOU MUST ALWAYS WRITE all artifact and document content in `{document_output_language}`
 
 ## EXECUTION PROTOCOLS:
 

--- a/src/bmm/workflows/2-plan-workflows/bmad-create-ux-design/steps/step-08-visual-foundation.md
+++ b/src/bmm/workflows/2-plan-workflows/bmad-create-ux-design/steps/step-08-visual-foundation.md
@@ -11,6 +11,7 @@
 - 💬 FOCUS on establishing visual design foundation (colors, typography, spacing)
 - 🎯 COLLABORATIVE discovery, not assumption-based design
 - ✅ YOU MUST ALWAYS SPEAK OUTPUT In your Agent communication style with the config `{communication_language}`
+- ✅ YOU MUST ALWAYS WRITE all artifact and document content in `{document_output_language}`
 
 ## EXECUTION PROTOCOLS:
 

--- a/src/bmm/workflows/2-plan-workflows/bmad-create-ux-design/steps/step-09-design-directions.md
+++ b/src/bmm/workflows/2-plan-workflows/bmad-create-ux-design/steps/step-09-design-directions.md
@@ -11,6 +11,7 @@
 - 💬 FOCUS on generating and evaluating design direction variations
 - 🎯 COLLABORATIVE exploration, not assumption-based design
 - ✅ YOU MUST ALWAYS SPEAK OUTPUT In your Agent communication style with the config `{communication_language}`
+- ✅ YOU MUST ALWAYS WRITE all artifact and document content in `{document_output_language}`
 
 ## EXECUTION PROTOCOLS:
 

--- a/src/bmm/workflows/2-plan-workflows/bmad-create-ux-design/steps/step-10-user-journeys.md
+++ b/src/bmm/workflows/2-plan-workflows/bmad-create-ux-design/steps/step-10-user-journeys.md
@@ -11,6 +11,7 @@
 - 💬 FOCUS on designing user flows and journey interactions
 - 🎯 COLLABORATIVE flow design, not assumption-based layouts
 - ✅ YOU MUST ALWAYS SPEAK OUTPUT In your Agent communication style with the config `{communication_language}`
+- ✅ YOU MUST ALWAYS WRITE all artifact and document content in `{document_output_language}`
 
 ## EXECUTION PROTOCOLS:
 

--- a/src/bmm/workflows/2-plan-workflows/bmad-create-ux-design/steps/step-11-component-strategy.md
+++ b/src/bmm/workflows/2-plan-workflows/bmad-create-ux-design/steps/step-11-component-strategy.md
@@ -11,6 +11,7 @@
 - 💬 FOCUS on defining component library strategy and custom components
 - 🎯 COLLABORATIVE component planning, not assumption-based design
 - ✅ YOU MUST ALWAYS SPEAK OUTPUT In your Agent communication style with the config `{communication_language}`
+- ✅ YOU MUST ALWAYS WRITE all artifact and document content in `{document_output_language}`
 
 ## EXECUTION PROTOCOLS:
 

--- a/src/bmm/workflows/2-plan-workflows/bmad-create-ux-design/steps/step-12-ux-patterns.md
+++ b/src/bmm/workflows/2-plan-workflows/bmad-create-ux-design/steps/step-12-ux-patterns.md
@@ -11,6 +11,7 @@
 - 💬 FOCUS on establishing consistency patterns for common UX situations
 - 🎯 COLLABORATIVE pattern definition, not assumption-based design
 - ✅ YOU MUST ALWAYS SPEAK OUTPUT In your Agent communication style with the config `{communication_language}`
+- ✅ YOU MUST ALWAYS WRITE all artifact and document content in `{document_output_language}`
 
 ## EXECUTION PROTOCOLS:
 

--- a/src/bmm/workflows/2-plan-workflows/bmad-create-ux-design/steps/step-13-responsive-accessibility.md
+++ b/src/bmm/workflows/2-plan-workflows/bmad-create-ux-design/steps/step-13-responsive-accessibility.md
@@ -11,6 +11,7 @@
 - 💬 FOCUS on responsive design strategy and accessibility compliance
 - 🎯 COLLABORATIVE strategy definition, not assumption-based design
 - ✅ YOU MUST ALWAYS SPEAK OUTPUT In your Agent communication style with the config `{communication_language}`
+- ✅ YOU MUST ALWAYS WRITE all artifact and document content in `{document_output_language}`
 
 ## EXECUTION PROTOCOLS:
 

--- a/src/bmm/workflows/2-plan-workflows/bmad-create-ux-design/workflow.md
+++ b/src/bmm/workflows/2-plan-workflows/bmad-create-ux-design/workflow.md
@@ -34,4 +34,5 @@ Load config from `{project-root}/_bmad/bmm/config.yaml` and resolve:
 ## EXECUTION
 
 - ✅ YOU MUST ALWAYS SPEAK OUTPUT In your Agent communication style with the config `{communication_language}`
+- ✅ YOU MUST ALWAYS WRITE all artifact and document content in `{document_output_language}`
 - Read fully and follow: `./steps/step-01-init.md` to begin the UX design workflow.

--- a/src/bmm/workflows/2-plan-workflows/create-prd/steps-c/step-02-discovery.md
+++ b/src/bmm/workflows/2-plan-workflows/create-prd/steps-c/step-02-discovery.md
@@ -33,6 +33,7 @@ Discover and classify the project - understand what type of product this is, wha
 - ✅ ALWAYS treat this as collaborative discovery between PM peers
 - 📋 YOU ARE A FACILITATOR, not a content generator
 - ✅ YOU MUST ALWAYS SPEAK OUTPUT In your Agent communication style with the config `{communication_language}`
+- ✅ YOU MUST ALWAYS WRITE all artifact and document content in `{document_output_language}`
 
 ### Role Reinforcement:
 

--- a/src/bmm/workflows/2-plan-workflows/create-prd/steps-c/step-02b-vision.md
+++ b/src/bmm/workflows/2-plan-workflows/create-prd/steps-c/step-02b-vision.md
@@ -29,6 +29,7 @@ Discover what makes this product special and understand the product vision throu
 - ✅ ALWAYS treat this as collaborative discovery between PM peers
 - 📋 YOU ARE A FACILITATOR, not a content generator
 - ✅ YOU MUST ALWAYS SPEAK OUTPUT In your Agent communication style with the config `{communication_language}`
+- ✅ YOU MUST ALWAYS WRITE all artifact and document content in `{document_output_language}`
 
 ### Role Reinforcement:
 

--- a/src/bmm/workflows/2-plan-workflows/create-prd/steps-c/step-02c-executive-summary.md
+++ b/src/bmm/workflows/2-plan-workflows/create-prd/steps-c/step-02c-executive-summary.md
@@ -29,6 +29,7 @@ Generate the Executive Summary content using insights from classification (step 
 - ✅ ALWAYS treat this as collaborative discovery between PM peers
 - 📋 YOU ARE A FACILITATOR, not a content generator
 - ✅ YOU MUST ALWAYS SPEAK OUTPUT In your Agent communication style with the config `{communication_language}`
+- ✅ YOU MUST ALWAYS WRITE all artifact and document content in `{document_output_language}`
 
 ### Role Reinforcement:
 

--- a/src/bmm/workflows/2-plan-workflows/create-prd/steps-c/step-03-success.md
+++ b/src/bmm/workflows/2-plan-workflows/create-prd/steps-c/step-03-success.md
@@ -26,6 +26,7 @@ partyModeWorkflow: '{project-root}/_bmad/core/workflows/bmad-party-mode/workflow
 - 💬 FOCUS on defining what winning looks like for this product
 - 🎯 COLLABORATIVE discovery, not assumption-based goal setting
 - ✅ YOU MUST ALWAYS SPEAK OUTPUT In your Agent communication style with the config `{communication_language}`
+- ✅ YOU MUST ALWAYS WRITE all artifact and document content in `{document_output_language}`
 
 ## EXECUTION PROTOCOLS:
 

--- a/src/bmm/workflows/2-plan-workflows/create-prd/steps-c/step-04-journeys.md
+++ b/src/bmm/workflows/2-plan-workflows/create-prd/steps-c/step-04-journeys.md
@@ -26,6 +26,7 @@ partyModeWorkflow: '{project-root}/_bmad/core/workflows/bmad-party-mode/workflow
 - 💬 FOCUS on mapping ALL user types that interact with the system
 - 🎯 CRITICAL: No journey = no functional requirements = product doesn't exist
 - ✅ YOU MUST ALWAYS SPEAK OUTPUT In your Agent communication style with the config `{communication_language}`
+- ✅ YOU MUST ALWAYS WRITE all artifact and document content in `{document_output_language}`
 
 ## EXECUTION PROTOCOLS:
 

--- a/src/bmm/workflows/2-plan-workflows/create-prd/steps-c/step-05-domain.md
+++ b/src/bmm/workflows/2-plan-workflows/create-prd/steps-c/step-05-domain.md
@@ -30,6 +30,7 @@ For complex domains only that have a mapping in {domainComplexityCSV}, explore d
 - ✅ ALWAYS treat this as collaborative discovery between PM peers
 - 📋 YOU ARE A FACILITATOR, not a content generator
 - ✅ YOU MUST ALWAYS SPEAK OUTPUT In your Agent communication style with the config `{communication_language}`
+- ✅ YOU MUST ALWAYS WRITE all artifact and document content in `{document_output_language}`
 
 ### Role Reinforcement:
 

--- a/src/bmm/workflows/2-plan-workflows/create-prd/steps-c/step-06-innovation.md
+++ b/src/bmm/workflows/2-plan-workflows/create-prd/steps-c/step-06-innovation.md
@@ -29,6 +29,7 @@ partyModeWorkflow: '{project-root}/_bmad/core/workflows/bmad-party-mode/workflow
 - 💬 FOCUS on detecting and exploring innovative aspects of the product
 - 🎯 OPTIONAL STEP: Only proceed if innovation signals are detected
 - ✅ YOU MUST ALWAYS SPEAK OUTPUT In your Agent communication style with the config `{communication_language}`
+- ✅ YOU MUST ALWAYS WRITE all artifact and document content in `{document_output_language}`
 
 ## EXECUTION PROTOCOLS:
 

--- a/src/bmm/workflows/2-plan-workflows/create-prd/steps-c/step-07-project-type.md
+++ b/src/bmm/workflows/2-plan-workflows/create-prd/steps-c/step-07-project-type.md
@@ -29,6 +29,7 @@ partyModeWorkflow: '{project-root}/_bmad/core/workflows/bmad-party-mode/workflow
 - 💬 FOCUS on project-type specific requirements and technical considerations
 - 🎯 DATA-DRIVEN: Use CSV configuration to guide discovery
 - ✅ YOU MUST ALWAYS SPEAK OUTPUT In your Agent communication style with the config `{communication_language}`
+- ✅ YOU MUST ALWAYS WRITE all artifact and document content in `{document_output_language}`
 
 ## EXECUTION PROTOCOLS:
 

--- a/src/bmm/workflows/2-plan-workflows/create-prd/steps-c/step-08-scoping.md
+++ b/src/bmm/workflows/2-plan-workflows/create-prd/steps-c/step-08-scoping.md
@@ -26,6 +26,7 @@ partyModeWorkflow: '{project-root}/_bmad/core/workflows/bmad-party-mode/workflow
 - 💬 FOCUS on strategic scope decisions that keep projects viable
 - 🎯 EMPHASIZE lean MVP thinking while preserving long-term vision
 - ✅ YOU MUST ALWAYS SPEAK OUTPUT In your Agent communication style with the config `{communication_language}`
+- ✅ YOU MUST ALWAYS WRITE all artifact and document content in `{document_output_language}`
 
 ## EXECUTION PROTOCOLS:
 

--- a/src/bmm/workflows/2-plan-workflows/create-prd/steps-c/step-09-functional.md
+++ b/src/bmm/workflows/2-plan-workflows/create-prd/steps-c/step-09-functional.md
@@ -26,6 +26,7 @@ partyModeWorkflow: '{project-root}/_bmad/core/workflows/bmad-party-mode/workflow
 - 💬 FOCUS on creating comprehensive capability inventory for the product
 - 🎯 CRITICAL: This is THE CAPABILITY CONTRACT for all downstream work
 - ✅ YOU MUST ALWAYS SPEAK OUTPUT In your Agent communication style with the config `{communication_language}`
+- ✅ YOU MUST ALWAYS WRITE all artifact and document content in `{document_output_language}`
 
 ## EXECUTION PROTOCOLS:
 

--- a/src/bmm/workflows/2-plan-workflows/create-prd/steps-c/step-10-nonfunctional.md
+++ b/src/bmm/workflows/2-plan-workflows/create-prd/steps-c/step-10-nonfunctional.md
@@ -26,6 +26,7 @@ partyModeWorkflow: '{project-root}/_bmad/core/workflows/bmad-party-mode/workflow
 - 💬 FOCUS on quality attributes that matter for THIS specific product
 - 🎯 SELECTIVE: Only document NFRs that actually apply to the product
 - ✅ YOU MUST ALWAYS SPEAK OUTPUT In your Agent communication style with the config `{communication_language}`
+- ✅ YOU MUST ALWAYS WRITE all artifact and document content in `{document_output_language}`
 
 ## EXECUTION PROTOCOLS:
 

--- a/src/bmm/workflows/2-plan-workflows/create-prd/steps-c/step-11-polish.md
+++ b/src/bmm/workflows/2-plan-workflows/create-prd/steps-c/step-11-polish.md
@@ -26,6 +26,7 @@ partyModeWorkflow: '{project-root}/_bmad/core/workflows/bmad-party-mode/workflow
 - 💬 PRESERVE user's voice and intent
 - 🎯 MAINTAIN all essential information while improving presentation
 - ✅ YOU MUST ALWAYS SPEAK OUTPUT In your Agent communication style with the config `{communication_language}`
+- ✅ YOU MUST ALWAYS WRITE all artifact and document content in `{document_output_language}`
 
 ## EXECUTION PROTOCOLS:
 

--- a/src/bmm/workflows/2-plan-workflows/create-prd/steps-e/step-e-01-discovery.md
+++ b/src/bmm/workflows/2-plan-workflows/create-prd/steps-e/step-e-01-discovery.md
@@ -24,6 +24,7 @@ Understand what the user wants to edit in the PRD, detect PRD format/type, check
 - 🔄 CRITICAL: When loading next step with 'C', ensure entire file is read
 - 📋 YOU ARE A FACILITATOR, not a content generator
 - ✅ YOU MUST ALWAYS SPEAK OUTPUT In your Agent communication style with the config `{communication_language}`
+- ✅ YOU MUST ALWAYS WRITE all artifact and document content in `{document_output_language}`
 
 ### Role Reinforcement:
 

--- a/src/bmm/workflows/2-plan-workflows/create-prd/steps-e/step-e-02-review.md
+++ b/src/bmm/workflows/2-plan-workflows/create-prd/steps-e/step-e-02-review.md
@@ -25,6 +25,7 @@ Thoroughly review the existing PRD, analyze validation report findings (if provi
 - 🔄 CRITICAL: When loading next step with 'C', ensure entire file is read
 - 📋 YOU ARE A FACILITATOR, not a content generator
 - ✅ YOU MUST ALWAYS SPEAK OUTPUT In your Agent communication style with the config `{communication_language}`
+- ✅ YOU MUST ALWAYS WRITE all artifact and document content in `{document_output_language}`
 
 ### Role Reinforcement:
 

--- a/src/bmm/workflows/2-plan-workflows/create-prd/steps-e/step-e-03-edit.md
+++ b/src/bmm/workflows/2-plan-workflows/create-prd/steps-e/step-e-03-edit.md
@@ -23,6 +23,7 @@ Apply changes to the PRD following the approved change plan from step e-02, incl
 - 🔄 CRITICAL: When loading next step with 'C', ensure entire file is read
 - 📋 YOU ARE A FACILITATOR, not a content generator
 - ✅ YOU MUST ALWAYS SPEAK OUTPUT In your Agent communication style with the config `{communication_language}`
+- ✅ YOU MUST ALWAYS WRITE all artifact and document content in `{document_output_language}`
 
 ### Role Reinforcement:
 

--- a/src/bmm/workflows/2-plan-workflows/create-prd/steps-v/step-v-10-smart-validation.md
+++ b/src/bmm/workflows/2-plan-workflows/create-prd/steps-v/step-v-10-smart-validation.md
@@ -23,6 +23,7 @@ Validate Functional Requirements meet SMART quality criteria (Specific, Measurab
 - 🔄 CRITICAL: When loading next step with 'C', ensure entire file is read
 - 📋 YOU ARE A FACILITATOR, not a content generator
 - ✅ YOU MUST ALWAYS SPEAK OUTPUT In your Agent communication style with the config `{communication_language}`
+- ✅ YOU MUST ALWAYS WRITE all artifact and document content in `{document_output_language}`
 
 ### Role Reinforcement:
 

--- a/src/bmm/workflows/2-plan-workflows/create-prd/steps-v/step-v-11-holistic-quality-validation.md
+++ b/src/bmm/workflows/2-plan-workflows/create-prd/steps-v/step-v-11-holistic-quality-validation.md
@@ -24,6 +24,7 @@ Assess the PRD as a cohesive, compelling document - evaluating document flow, du
 - 🔄 CRITICAL: When loading next step with 'C', ensure entire file is read
 - 📋 YOU ARE A FACILITATOR, not a content generator
 - ✅ YOU MUST ALWAYS SPEAK OUTPUT In your Agent communication style with the config `{communication_language}`
+- ✅ YOU MUST ALWAYS WRITE all artifact and document content in `{document_output_language}`
 
 ### Role Reinforcement:
 

--- a/src/bmm/workflows/2-plan-workflows/create-prd/steps-v/step-v-13-report-complete.md
+++ b/src/bmm/workflows/2-plan-workflows/create-prd/steps-v/step-v-13-report-complete.md
@@ -22,6 +22,7 @@ Finalize validation report, summarize all findings from steps 1-12, present summ
 - 🔄 CRITICAL: When loading next step with 'C', ensure entire file is read
 - 📋 YOU ARE A FACILITATOR, not a content generator
 - ✅ YOU MUST ALWAYS SPEAK OUTPUT In your Agent communication style with the config `{communication_language}`
+- ✅ YOU MUST ALWAYS WRITE all artifact and document content in `{document_output_language}`
 
 ### Role Reinforcement:
 

--- a/src/bmm/workflows/2-plan-workflows/create-prd/workflow-create-prd.md
+++ b/src/bmm/workflows/2-plan-workflows/create-prd/workflow-create-prd.md
@@ -55,6 +55,7 @@ Load and read full config from {main_config} and resolve:
 - `date` as system-generated current datetime
 
 ✅ YOU MUST ALWAYS SPEAK OUTPUT In your Agent communication style with the configured `{communication_language}`.
+✅ YOU MUST ALWAYS WRITE all artifact and document content in `{document_output_language}`.
 
 ### 2. Route to Create Workflow
 

--- a/src/bmm/workflows/2-plan-workflows/create-prd/workflow-edit-prd.md
+++ b/src/bmm/workflows/2-plan-workflows/create-prd/workflow-edit-prd.md
@@ -55,6 +55,7 @@ Load and read full config from {main_config} and resolve:
 - `date` as system-generated current datetime
 
 ✅ YOU MUST ALWAYS SPEAK OUTPUT In your Agent communication style with the configured `{communication_language}`.
+✅ YOU MUST ALWAYS WRITE all artifact and document content in `{document_output_language}`.
 
 ### 2. Route to Edit Workflow
 

--- a/src/bmm/workflows/2-plan-workflows/create-prd/workflow-validate-prd.md
+++ b/src/bmm/workflows/2-plan-workflows/create-prd/workflow-validate-prd.md
@@ -55,6 +55,7 @@ Load and read full config from {main_config} and resolve:
 - `date` as system-generated current datetime
 
 ✅ YOU MUST ALWAYS SPEAK OUTPUT In your Agent communication style with the configured `{communication_language}`.
+✅ YOU MUST ALWAYS WRITE all artifact and document content in `{document_output_language}`.
 
 ### 2. Route to Validate Workflow
 

--- a/src/bmm/workflows/document-project/workflows/deep-dive-instructions.md
+++ b/src/bmm/workflows/document-project/workflows/deep-dive-instructions.md
@@ -4,6 +4,8 @@
 
 <critical>This workflow performs exhaustive deep-dive documentation of specific areas</critical>
 <critical>Handles: deep_dive mode only</critical>
+<critical>YOU MUST ALWAYS SPEAK OUTPUT In your Agent communication style with the configured `{communication_language}`</critical>
+<critical>YOU MUST ALWAYS WRITE all artifact and document content in `{document_output_language}`</critical>
 
 <step n="13" goal="Deep-dive documentation of specific area" if="workflow_mode == deep_dive">
 <critical>Deep-dive mode requires literal full-file review. Sampling, guessing, or relying solely on tooling output is FORBIDDEN.</critical>

--- a/src/bmm/workflows/document-project/workflows/deep-dive-workflow.md
+++ b/src/bmm/workflows/document-project/workflows/deep-dive-workflow.md
@@ -20,7 +20,11 @@ Load config from `{project-root}/_bmad/bmm/config.yaml` and resolve:
 
 - `project_knowledge`
 - `user_name`
+- `communication_language`, `document_output_language`
 - `date` as system-generated current datetime
+
+✅ YOU MUST ALWAYS SPEAK OUTPUT In your Agent communication style with the configured `{communication_language}`.
+✅ YOU MUST ALWAYS WRITE all artifact and document content in `{document_output_language}`.
 
 ### Paths
 

--- a/src/bmm/workflows/document-project/workflows/full-scan-instructions.md
+++ b/src/bmm/workflows/document-project/workflows/full-scan-instructions.md
@@ -4,6 +4,8 @@
 
 <critical>This workflow performs complete project documentation (Steps 1-12)</critical>
 <critical>Handles: initial_scan and full_rescan modes</critical>
+<critical>YOU MUST ALWAYS SPEAK OUTPUT In your Agent communication style with the configured `{communication_language}`</critical>
+<critical>YOU MUST ALWAYS WRITE all artifact and document content in `{document_output_language}`</critical>
 
 <step n="0.5" goal="Load documentation requirements data for fresh starts (not needed for resume)" if="resume_mode == false">
 <critical>DATA LOADING STRATEGY - Understanding the Documentation Requirements System:</critical>

--- a/src/bmm/workflows/document-project/workflows/full-scan-workflow.md
+++ b/src/bmm/workflows/document-project/workflows/full-scan-workflow.md
@@ -19,7 +19,11 @@ Load config from `{project-root}/_bmad/bmm/config.yaml` and resolve:
 
 - `project_knowledge`
 - `user_name`
+- `communication_language`, `document_output_language`
 - `date` as system-generated current datetime
+
+✅ YOU MUST ALWAYS SPEAK OUTPUT In your Agent communication style with the configured `{communication_language}`.
+✅ YOU MUST ALWAYS WRITE all artifact and document content in `{document_output_language}`.
 
 ### Paths
 

--- a/src/bmm/workflows/generate-project-context/steps/step-02-generate.md
+++ b/src/bmm/workflows/generate-project-context/steps/step-02-generate.md
@@ -9,6 +9,7 @@
 - 🎯 KEEP CONTENT LEAN - optimize for LLM context efficiency
 - ⚠️ ABSOLUTELY NO TIME ESTIMATES - AI development speed has fundamentally changed
 - ✅ YOU MUST ALWAYS SPEAK OUTPUT In your Agent communication style with the config `{communication_language}`
+- ✅ YOU MUST ALWAYS WRITE all artifact and document content in `{document_output_language}`
 
 ## EXECUTION PROTOCOLS:
 

--- a/src/bmm/workflows/generate-project-context/workflow.md
+++ b/src/bmm/workflows/generate-project-context/workflow.md
@@ -33,6 +33,7 @@ Load config from `{project-root}/_bmad/bmm/config.yaml` and resolve:
 - `communication_language`, `document_output_language`, `user_skill_level`
 - `date` as system-generated current datetime
 - ✅ YOU MUST ALWAYS SPEAK OUTPUT In your Agent communication style with the config `{communication_language}`
+- ✅ YOU MUST ALWAYS WRITE all artifact and document content in `{document_output_language}`
 
 ### Paths
 


### PR DESCRIPTION
## Summary

Fixes #1966

- Planning workflows loaded `document_output_language` from config but never enforced it in step files — only `communication_language` was enforced
- Generated artifacts (product briefs, PRDs, UX specs, project docs) were written in the conversation language instead of the configured document output language
- Added explicit `document_output_language` enforcement in all content-generating step files across 5 workflow families (44 files, 54 insertions)

## Affected workflows

- `create-product-brief` — steps 02–05 + workflow entry
- `create-prd` — steps-c 02–11, steps-e 01–03, steps-v 10/11/13 + all 3 workflow entries
- `create-ux-design` — steps 03–13 + workflow entry
- `generate-project-context` — step-02 + workflow entry
- `document-project` — full-scan and deep-dive sub-workflows (added both language rules since they had neither)

## Test plan

- [ ] Configure `communication_language: Italian` and `document_output_language: English`
- [ ] Run create-product-brief — verify brief content is in English, conversation is in Italian
- [ ] Run create-prd — verify PRD content is in English
- [ ] Run create-ux-design — verify UX spec content is in English
- [ ] Run document-project — verify generated docs are in English

🤖 Generated with [Claude Code](https://claude.com/claude-code)