### PR TITLE
fix(skill): clean up bmad-create-product-brief validation findings

### DIFF
--- a/src/bmm/workflows/1-analysis/bmad-create-product-brief/product-brief.template.md
+++ b/src/bmm/workflows/1-analysis/bmad-create-product-brief/product-brief.template.md
@@ -1,8 +1,8 @@
 ---
 stepsCompleted: []
 inputDocuments: []
-date: { system-date }
-author: { user }
+date: {{system-date}}
+author: {{user_name}}
 ---
 
 # Product Brief: {{project_name}}

--- a/src/bmm/workflows/1-analysis/bmad-create-product-brief/steps/step-01-init.md
+++ b/src/bmm/workflows/1-analysis/bmad-create-product-brief/steps/step-01-init.md
@@ -1,13 +1,6 @@
 ---
-name: 'step-01-init'
-description: 'Initialize the product brief workflow by detecting continuation state and setting up the document'
-
 # File References
-nextStepFile: './step-02-vision.md'
 outputFile: '{planning_artifacts}/product-brief-{{project_name}}-{{date}}.md'
-
-# Template References
-productBriefTemplate: '../product-brief.template.md'
 ---
 
 # Step 1: Product Brief Initialization
@@ -88,7 +81,7 @@ load context documents using smart discovery. Documents can be in the following 
 - {planning_artifacts}/**
 - {output_folder}/**
 - {product_knowledge}/**
-- docs/**
+- {project-root}/docs/**
 
 Also - when searching - documents can be a single markdown file, or a folder with an index and multiple files. For Example, if searching for `*foo*.md` and not found, also search for a folder called *foo*/index.md (which indicates sharded content)
 
@@ -112,7 +105,7 @@ Try to discover the following:
 
 **Document Setup:**
 
-- Copy the template from `{productBriefTemplate}` to `{outputFile}`, and update the frontmatter fields
+- Copy the template from `../product-brief.template.md` to `{outputFile}`, and update the frontmatter fields
 
 #### C. Present Initialization Results
 
@@ -141,7 +134,7 @@ Display: "**Proceeding to product vision discovery...**"
 
 #### Menu Handling Logic:
 
-- After setup report is presented, without delay, read fully and follow: {nextStepFile}
+- After setup report is presented, without delay, read fully and follow: ./step-02-vision.md
 
 #### EXECUTION RULES:
 
@@ -150,7 +143,7 @@ Display: "**Proceeding to product vision discovery...**"
 
 ## CRITICAL STEP COMPLETION NOTE
 
-ONLY WHEN [setup completion is achieved and frontmatter properly updated], will you then read fully and follow: `{nextStepFile}` to begin product vision discovery.
+ONLY WHEN [setup completion is achieved and frontmatter properly updated], will you then read fully and follow: `./step-02-vision.md` to begin product vision discovery.
 
 ---
 

--- a/src/bmm/workflows/1-analysis/bmad-create-product-brief/steps/step-01b-continue.md
+++ b/src/bmm/workflows/1-analysis/bmad-create-product-brief/steps/step-01b-continue.md
@@ -1,7 +1,4 @@
 ---
-name: 'step-01b-continue'
-description: 'Resume the product brief workflow from where it was left off, ensuring smooth continuation'
-
 # File References
 outputFile: '{planning_artifacts}/product-brief-{{project_name}}-{{date}}.md'
 ---

--- a/src/bmm/workflows/1-analysis/bmad-create-product-brief/steps/step-02-vision.md
+++ b/src/bmm/workflows/1-analysis/bmad-create-product-brief/steps/step-02-vision.md
@@ -1,9 +1,5 @@
 ---
-name: 'step-02-vision'
-description: 'Discover and define the core product vision, problem statement, and unique value proposition'
-
 # File References
-nextStepFile: './step-03-users.md'
 outputFile: '{planning_artifacts}/product-brief-{{project_name}}-{{date}}.md'
 
 # Task References
@@ -159,7 +155,7 @@ Prepare the following structure for document append:
 
 - IF A: Read fully and follow: {advancedElicitationTask} with current vision content to dive deeper and refine
 - IF P: Read fully and follow: {partyModeWorkflow} to bring different perspectives to positioning and differentiation
-- IF C: Save content to {outputFile}, update frontmatter with stepsCompleted: [1, 2], then read fully and follow: {nextStepFile}
+- IF C: Save content to {outputFile}, update frontmatter with stepsCompleted: [1, 2], then read fully and follow: ./step-03-users.md
 - IF Any other comments or queries: help user respond then [Redisplay Menu Options](#7-present-menu-options)
 
 #### EXECUTION RULES:
@@ -171,7 +167,7 @@ Prepare the following structure for document append:
 
 ## CRITICAL STEP COMPLETION NOTE
 
-ONLY WHEN [C continue option] is selected and [vision content finalized and saved to document with frontmatter updated], will you then read fully and follow: `{nextStepFile}` to begin target user discovery.
+ONLY WHEN [C continue option] is selected and [vision content finalized and saved to document with frontmatter updated], will you then read fully and follow: `./step-03-users.md` to begin target user discovery.
 
 ---
 

--- a/src/bmm/workflows/1-analysis/bmad-create-product-brief/steps/step-03-users.md
+++ b/src/bmm/workflows/1-analysis/bmad-create-product-brief/steps/step-03-users.md
@@ -1,9 +1,5 @@
 ---
-name: 'step-03-users'
-description: 'Define target users with rich personas and map their key interactions with the product'
-
 # File References
-nextStepFile: './step-04-metrics.md'
 outputFile: '{planning_artifacts}/product-brief-{{project_name}}-{{date}}.md'
 
 # Task References
@@ -162,7 +158,7 @@ Prepare the following structure for document append:
 
 - IF A: Read fully and follow: {advancedElicitationTask} with current user content to dive deeper into personas and journeys
 - IF P: Read fully and follow: {partyModeWorkflow} to bring different perspectives to validate user understanding
-- IF C: Save content to {outputFile}, update frontmatter with stepsCompleted: [1, 2, 3], then read fully and follow: {nextStepFile}
+- IF C: Save content to {outputFile}, update frontmatter with stepsCompleted: [1, 2, 3], then read fully and follow: ./step-04-metrics.md
 - IF Any other comments or queries: help user respond then [Redisplay Menu Options](#6-present-menu-options)
 
 #### EXECUTION RULES:
@@ -174,7 +170,7 @@ Prepare the following structure for document append:
 
 ## CRITICAL STEP COMPLETION NOTE
 
-ONLY WHEN [C continue option] is selected and [user personas finalized and saved to document with frontmatter updated], will you then read fully and follow: `{nextStepFile}` to begin success metrics definition.
+ONLY WHEN [C continue option] is selected and [user personas finalized and saved to document with frontmatter updated], will you then read fully and follow: `./step-04-metrics.md` to begin success metrics definition.
 
 ---
 

--- a/src/bmm/workflows/1-analysis/bmad-create-product-brief/steps/step-04-metrics.md
+++ b/src/bmm/workflows/1-analysis/bmad-create-product-brief/steps/step-04-metrics.md
@@ -1,9 +1,5 @@
 ---
-name: 'step-04-metrics'
-description: 'Define comprehensive success metrics that include user success, business objectives, and key performance indicators'
-
 # File References
-nextStepFile: './step-05-scope.md'
 outputFile: '{planning_artifacts}/product-brief-{{project_name}}-{{date}}.md'
 
 # Task References
@@ -165,7 +161,7 @@ Prepare the following structure for document append:
 
 - IF A: Read fully and follow: {advancedElicitationTask} with current metrics content to dive deeper into success metric insights
 - IF P: Read fully and follow: {partyModeWorkflow} to bring different perspectives to validate comprehensive metrics
-- IF C: Save content to {outputFile}, update frontmatter with stepsCompleted: [1, 2, 3, 4], then read fully and follow: {nextStepFile}
+- IF C: Save content to {outputFile}, update frontmatter with stepsCompleted: [1, 2, 3, 4], then read fully and follow: ./step-05-scope.md
 - IF Any other comments or queries: help user respond then [Redisplay Menu Options](#7-present-menu-options)
 
 #### EXECUTION RULES:
@@ -177,7 +173,7 @@ Prepare the following structure for document append:
 
 ## CRITICAL STEP COMPLETION NOTE
 
-ONLY WHEN [C continue option] is selected and [success metrics finalized and saved to document with frontmatter updated], will you then read fully and follow: `{nextStepFile}` to begin MVP scope definition.
+ONLY WHEN [C continue option] is selected and [success metrics finalized and saved to document with frontmatter updated], will you then read fully and follow: `./step-05-scope.md` to begin MVP scope definition.
 
 ---
 

--- a/src/bmm/workflows/1-analysis/bmad-create-product-brief/steps/step-05-scope.md
+++ b/src/bmm/workflows/1-analysis/bmad-create-product-brief/steps/step-05-scope.md
@@ -1,9 +1,5 @@
 ---
-name: 'step-05-scope'
-description: 'Define MVP scope with clear boundaries and outline future vision while managing scope creep'
-
 # File References
-nextStepFile: './step-06-complete.md'
 outputFile: '{planning_artifacts}/product-brief-{{project_name}}-{{date}}.md'
 
 # Task References
@@ -179,7 +175,7 @@ Prepare the following structure for document append:
 
 - IF A: Read fully and follow: {advancedElicitationTask} with current scope content to optimize scope definition
 - IF P: Read fully and follow: {partyModeWorkflow} to bring different perspectives to validate MVP scope
-- IF C: Save content to {outputFile}, update frontmatter with stepsCompleted: [1, 2, 3, 4, 5], then read fully and follow: {nextStepFile}
+- IF C: Save content to {outputFile}, update frontmatter with stepsCompleted: [1, 2, 3, 4, 5], then read fully and follow: ./step-06-complete.md
 - IF Any other comments or queries: help user respond then [Redisplay Menu Options](#7-present-menu-options)
 
 #### EXECUTION RULES:
@@ -191,7 +187,7 @@ Prepare the following structure for document append:
 
 ## CRITICAL STEP COMPLETION NOTE
 
-ONLY WHEN [C continue option] is selected and [MVP scope finalized and saved to document with frontmatter updated], will you then read fully and follow: `{nextStepFile}` to complete the product brief workflow.
+ONLY WHEN [C continue option] is selected and [MVP scope finalized and saved to document with frontmatter updated], will you then read fully and follow: `./step-06-complete.md` to complete the product brief workflow.
 
 ---
 

--- a/src/bmm/workflows/1-analysis/bmad-create-product-brief/steps/step-06-complete.md
+++ b/src/bmm/workflows/1-analysis/bmad-create-product-brief/steps/step-06-complete.md
@@ -1,7 +1,4 @@
 ---
-name: 'step-06-complete'
-description: 'Complete the product brief workflow, update status files, and suggest next steps for the project'
-
 # File References
 outputFile: '{planning_artifacts}/product-brief-{{project_name}}-{{date}}.md'
 ---


### PR DESCRIPTION
## Summary

- Remove `name`/`description` from all 7 step file frontmatters (STEP-06)
- Inline `nextStepFile` and `productBriefTemplate` path variables as literal relative paths (PATH-04)
- Prefix bare `docs/**` with `{project-root}` (PATH-03)
- Normalize template placeholders to `{{double-curly}}` convention (REF-01)

## Test plan

- [ ] Skill validator passes with 0 findings
- [ ] Installer produces correct output
- [ ] Repo test suite passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)