### PR TITLE
fix(skill): clean up bmad-retrospective validation findings

### DIFF
--- a/src/bmm/workflows/4-implementation/bmad-retrospective/workflow.md
+++ b/src/bmm/workflows/4-implementation/bmad-retrospective/workflow.md
@@ -37,7 +37,6 @@ Load config from `{project-root}/_bmad/bmm/config.yaml` and resolve:
 
 ### Paths
 
-- `installed_path` = `.`
 - `sprint_status_file` = `{implementation_artifacts}/sprint-status.yaml`
 
 ### Input Files


### PR DESCRIPTION
## Summary

- Remove unused `installed_path` from workflow.md (PATH-02)

## Test plan

- [ ] Skill validator passes with 0 findings
- [ ] Installer produces correct output
- [ ] Repo test suite passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)