### PR TITLE
fix: replace broken party-mode file path refs with skill syntax

### DIFF
--- a/src/bmm/workflows/1-analysis/bmad-create-product-brief/steps/step-02-vision.md
+++ b/src/bmm/workflows/1-analysis/bmad-create-product-brief/steps/step-02-vision.md
@@ -4,7 +4,7 @@ outputFile: '{planning_artifacts}/product-brief-{{project_name}}-{{date}}.md'
 
 # Task References
 advancedElicitationTask: 'skill:bmad-advanced-elicitation'
-partyModeWorkflow: '{project-root}/_bmad/core/workflows/bmad-party-mode/workflow.md'
+partyModeWorkflow: 'skill:bmad-party-mode'
 ---
 
 # Step 2: Product Vision Discovery

--- a/src/bmm/workflows/1-analysis/bmad-create-product-brief/steps/step-03-users.md
+++ b/src/bmm/workflows/1-analysis/bmad-create-product-brief/steps/step-03-users.md
@@ -4,7 +4,7 @@ outputFile: '{planning_artifacts}/product-brief-{{project_name}}-{{date}}.md'
 
 # Task References
 advancedElicitationTask: 'skill:bmad-advanced-elicitation'
-partyModeWorkflow: '{project-root}/_bmad/core/workflows/bmad-party-mode/workflow.md'
+partyModeWorkflow: 'skill:bmad-party-mode'
 ---
 
 # Step 3: Target Users Discovery

--- a/src/bmm/workflows/1-analysis/bmad-create-product-brief/steps/step-04-metrics.md
+++ b/src/bmm/workflows/1-analysis/bmad-create-product-brief/steps/step-04-metrics.md
@@ -4,7 +4,7 @@ outputFile: '{planning_artifacts}/product-brief-{{project_name}}-{{date}}.md'
 
 # Task References
 advancedElicitationTask: 'skill:bmad-advanced-elicitation'
-partyModeWorkflow: '{project-root}/_bmad/core/workflows/bmad-party-mode/workflow.md'
+partyModeWorkflow: 'skill:bmad-party-mode'
 ---
 
 # Step 4: Success Metrics Definition

--- a/src/bmm/workflows/1-analysis/bmad-create-product-brief/steps/step-05-scope.md
+++ b/src/bmm/workflows/1-analysis/bmad-create-product-brief/steps/step-05-scope.md
@@ -4,7 +4,7 @@ outputFile: '{planning_artifacts}/product-brief-{{project_name}}-{{date}}.md'
 
 # Task References
 advancedElicitationTask: 'skill:bmad-advanced-elicitation'
-partyModeWorkflow: '{project-root}/_bmad/core/workflows/bmad-party-mode/workflow.md'
+partyModeWorkflow: 'skill:bmad-party-mode'
 ---
 
 # Step 5: MVP Scope Definition

--- a/src/bmm/workflows/2-plan-workflows/bmad-edit-prd/steps-e/step-e-01-discovery.md
+++ b/src/bmm/workflows/2-plan-workflows/bmad-edit-prd/steps-e/step-e-01-discovery.md
@@ -6,7 +6,7 @@ description: 'Discovery & Understanding - Understand what user wants to edit and
 altStepFile: './step-e-01b-legacy-conversion.md'
 prdPurpose: '{project-root}/_bmad/bmm/workflows/2-plan-workflows/create-prd/data/prd-purpose.md'
 advancedElicitationTask: 'skill:bmad-advanced-elicitation'
-partyModeWorkflow: '{project-root}/_bmad/core/workflows/bmad-party-mode/workflow.md'
+partyModeWorkflow: 'skill:bmad-party-mode'
 ---
 
 # Step E-1: Discovery & Understanding

--- a/src/bmm/workflows/2-plan-workflows/bmad-validate-prd/steps-v/step-v-01-discovery.md
+++ b/src/bmm/workflows/2-plan-workflows/bmad-validate-prd/steps-v/step-v-01-discovery.md
@@ -5,7 +5,7 @@ description: 'Document Discovery & Confirmation - Handle fresh context validatio
 # File references (ONLY variables used in this step)
 nextStepFile: './step-v-02-format-detection.md'
 advancedElicitationTask: 'skill:bmad-advanced-elicitation'
-partyModeWorkflow: '{project-root}/_bmad/core/workflows/bmad-party-mode/workflow.md'
+partyModeWorkflow: 'skill:bmad-party-mode'
 prdPurpose: '../data/prd-purpose.md'
 ---
 

--- a/src/bmm/workflows/2-plan-workflows/create-prd/steps-v/step-v-01-discovery.md
+++ b/src/bmm/workflows/2-plan-workflows/create-prd/steps-v/step-v-01-discovery.md
@@ -5,7 +5,7 @@ description: 'Document Discovery & Confirmation - Handle fresh context validatio
 # File references (ONLY variables used in this step)
 nextStepFile: './step-v-02-format-detection.md'
 advancedElicitationTask: 'skill:bmad-advanced-elicitation'
-partyModeWorkflow: '{project-root}/_bmad/core/workflows/bmad-party-mode/workflow.md'
+partyModeWorkflow: 'skill:bmad-party-mode'
 prdPurpose: '../data/prd-purpose.md'
 ---
 

--- a/src/bmm/workflows/bmad-generate-project-context/steps/step-02-generate.md
+++ b/src/bmm/workflows/bmad-generate-project-context/steps/step-02-generate.md
@@ -31,7 +31,7 @@ This step will generate content and present choices for each rule category:
 ## PROTOCOL INTEGRATION:
 
 - When 'A' selected: Execute skill:bmad-advanced-elicitation
-- When 'P' selected: Execute {project-root}/_bmad/core/workflows/bmad-party-mode/workflow.md
+- When 'P' selected: Execute skill:bmad-party-mode
 - PROTOCOLS always return to display this step's A/P/C menu after the A or P have completed
 - User accepts/rejects protocol changes before proceeding
 

--- a/src/bmm/workflows/bmad-quick-flow/bmad-quick-dev/workflow.md
+++ b/src/bmm/workflows/bmad-quick-flow/bmad-quick-dev/workflow.md
@@ -34,7 +34,7 @@ Load config from `{project-root}/_bmad/bmm/config.yaml` and resolve:
 ### Related Workflows
 
 - `quick_spec_workflow` = `skill:bmad-quick-spec`
-- `party_mode_exec` = `{project-root}/_bmad/core/workflows/bmad-party-mode/workflow.md`
+- `party_mode_exec` = `skill:bmad-party-mode`
 - `advanced_elicitation` = `skill:bmad-advanced-elicitation`
 
 ---

--- a/src/bmm/workflows/bmad-quick-flow/bmad-quick-spec/workflow.md
+++ b/src/bmm/workflows/bmad-quick-flow/bmad-quick-spec/workflow.md
@@ -3,7 +3,7 @@ main_config: '{project-root}/_bmad/bmm/config.yaml'
 
 # Checkpoint handler references
 advanced_elicitation: 'skill:bmad-advanced-elicitation'
-party_mode_exec: '{project-root}/_bmad/core/workflows/bmad-party-mode/workflow.md'
+party_mode_exec: 'skill:bmad-party-mode'
 ---
 
 # Quick-Spec Workflow

--- a/src/core/tasks/bmad-create-prd/steps-c/step-05-domain.md
+++ b/src/core/tasks/bmad-create-prd/steps-c/step-05-domain.md
@@ -142,7 +142,7 @@ Display: "**Select:** [A] Advanced Elicitation [P] Party Mode [C] Continue - Sav
 
 #### Menu Handling Logic:
 - IF A: Invoke the `bmad-advanced-elicitation` skill, and when finished redisplay the menu
-- IF P: Read fully and follow: `{project-root}/_bmad/core/workflows/bmad-party-mode/workflow.md` and when finished redisplay the menu
+- IF P: Read fully and follow: `skill:bmad-party-mode` and when finished redisplay the menu
 - IF C: Save content to {outputFile}, update frontmatter, then read fully and follow: ./step-06-innovation.md
 - IF Any other comments or queries: help user respond then [Redisplay Menu Options](#n-present-menu-options)
 


### PR DESCRIPTION
## Summary
- Party-mode workflow moved from `core/workflows/` to `core/skills/` in PR #1959, breaking `validate:refs`
- Replaced all 11 raw `{project-root}/_bmad/core/workflows/bmad-party-mode/workflow.md` references with `skill:bmad-party-mode` syntax
- Matches the convention already used for `skill:bmad-advanced-elicitation` in the same files

## Test plan
- [x] `npm run validate:refs` — 0 broken references
- [x] Full push gate passes (format, lint, lint:md, docs:build, validate:schemas, test:schemas, test:install, validate:refs)

🤖 Generated with [Claude Code](https://claude.com/claude-code)