### PR TITLE
chore: normalize skill invocation syntax

### DIFF
--- a/src/bmm/workflows/1-analysis/bmad-create-product-brief/steps/step-02-vision.md
+++ b/src/bmm/workflows/1-analysis/bmad-create-product-brief/steps/step-02-vision.md
@@ -2,9 +2,6 @@
 # File References
 outputFile: '{planning_artifacts}/product-brief-{{project_name}}-{{date}}.md'
 
-# Task References
-advancedElicitationTask: 'skill:bmad-advanced-elicitation'
-partyModeWorkflow: 'skill:bmad-party-mode'
 ---
 
 # Step 2: Product Vision Discovery
@@ -153,8 +150,8 @@ Prepare the following structure for document append:
 
 #### Menu Handling Logic:
 
-- IF A: Read fully and follow: {advancedElicitationTask} with current vision content to dive deeper and refine
-- IF P: Read fully and follow: {partyModeWorkflow} to bring different perspectives to positioning and differentiation
+- IF A: Invoke the `bmad-advanced-elicitation` skill with current vision content to dive deeper and refine
+- IF P: Invoke the `bmad-party-mode` skill to bring different perspectives to positioning and differentiation
 - IF C: Save content to {outputFile}, update frontmatter with stepsCompleted: [1, 2], then read fully and follow: ./step-03-users.md
 - IF Any other comments or queries: help user respond then [Redisplay Menu Options](#7-present-menu-options)
 

--- a/src/bmm/workflows/1-analysis/bmad-create-product-brief/steps/step-03-users.md
+++ b/src/bmm/workflows/1-analysis/bmad-create-product-brief/steps/step-03-users.md
@@ -2,9 +2,6 @@
 # File References
 outputFile: '{planning_artifacts}/product-brief-{{project_name}}-{{date}}.md'
 
-# Task References
-advancedElicitationTask: 'skill:bmad-advanced-elicitation'
-partyModeWorkflow: 'skill:bmad-party-mode'
 ---
 
 # Step 3: Target Users Discovery
@@ -156,8 +153,8 @@ Prepare the following structure for document append:
 
 #### Menu Handling Logic:
 
-- IF A: Read fully and follow: {advancedElicitationTask} with current user content to dive deeper into personas and journeys
-- IF P: Read fully and follow: {partyModeWorkflow} to bring different perspectives to validate user understanding
+- IF A: Invoke the `bmad-advanced-elicitation` skill with current user content to dive deeper into personas and journeys
+- IF P: Invoke the `bmad-party-mode` skill to bring different perspectives to validate user understanding
 - IF C: Save content to {outputFile}, update frontmatter with stepsCompleted: [1, 2, 3], then read fully and follow: ./step-04-metrics.md
 - IF Any other comments or queries: help user respond then [Redisplay Menu Options](#6-present-menu-options)
 

--- a/src/bmm/workflows/1-analysis/bmad-create-product-brief/steps/step-04-metrics.md
+++ b/src/bmm/workflows/1-analysis/bmad-create-product-brief/steps/step-04-metrics.md
@@ -2,9 +2,6 @@
 # File References
 outputFile: '{planning_artifacts}/product-brief-{{project_name}}-{{date}}.md'
 
-# Task References
-advancedElicitationTask: 'skill:bmad-advanced-elicitation'
-partyModeWorkflow: 'skill:bmad-party-mode'
 ---
 
 # Step 4: Success Metrics Definition
@@ -159,8 +156,8 @@ Prepare the following structure for document append:
 
 #### Menu Handling Logic:
 
-- IF A: Read fully and follow: {advancedElicitationTask} with current metrics content to dive deeper into success metric insights
-- IF P: Read fully and follow: {partyModeWorkflow} to bring different perspectives to validate comprehensive metrics
+- IF A: Invoke the `bmad-advanced-elicitation` skill with current metrics content to dive deeper into success metric insights
+- IF P: Invoke the `bmad-party-mode` skill to bring different perspectives to validate comprehensive metrics
 - IF C: Save content to {outputFile}, update frontmatter with stepsCompleted: [1, 2, 3, 4], then read fully and follow: ./step-05-scope.md
 - IF Any other comments or queries: help user respond then [Redisplay Menu Options](#7-present-menu-options)
 

--- a/src/bmm/workflows/1-analysis/bmad-create-product-brief/steps/step-05-scope.md
+++ b/src/bmm/workflows/1-analysis/bmad-create-product-brief/steps/step-05-scope.md
@@ -2,9 +2,6 @@
 # File References
 outputFile: '{planning_artifacts}/product-brief-{{project_name}}-{{date}}.md'
 
-# Task References
-advancedElicitationTask: 'skill:bmad-advanced-elicitation'
-partyModeWorkflow: 'skill:bmad-party-mode'
 ---
 
 # Step 5: MVP Scope Definition
@@ -173,8 +170,8 @@ Prepare the following structure for document append:
 
 #### Menu Handling Logic:
 
-- IF A: Read fully and follow: {advancedElicitationTask} with current scope content to optimize scope definition
-- IF P: Read fully and follow: {partyModeWorkflow} to bring different perspectives to validate MVP scope
+- IF A: Invoke the `bmad-advanced-elicitation` skill with current scope content to optimize scope definition
+- IF P: Invoke the `bmad-party-mode` skill to bring different perspectives to validate MVP scope
 - IF C: Save content to {outputFile}, update frontmatter with stepsCompleted: [1, 2, 3, 4, 5], then read fully and follow: ./step-06-complete.md
 - IF Any other comments or queries: help user respond then [Redisplay Menu Options](#7-present-menu-options)
 

--- a/src/bmm/workflows/2-plan-workflows/bmad-edit-prd/steps-e/step-e-01-discovery.md
+++ b/src/bmm/workflows/2-plan-workflows/bmad-edit-prd/steps-e/step-e-01-discovery.md
@@ -5,8 +5,6 @@ description: 'Discovery & Understanding - Understand what user wants to edit and
 # File references (ONLY variables used in this step)
 altStepFile: './step-e-01b-legacy-conversion.md'
 prdPurpose: '{project-root}/_bmad/bmm/workflows/2-plan-workflows/create-prd/data/prd-purpose.md'
-advancedElicitationTask: 'skill:bmad-advanced-elicitation'
-partyModeWorkflow: 'skill:bmad-party-mode'
 ---
 
 # Step E-1: Discovery & Understanding

--- a/src/bmm/workflows/2-plan-workflows/bmad-edit-prd/steps-e/step-e-02-review.md
+++ b/src/bmm/workflows/2-plan-workflows/bmad-edit-prd/steps-e/step-e-02-review.md
@@ -7,7 +7,6 @@ nextStepFile: './step-e-03-edit.md'
 prdFile: '{prd_file_path}'
 validationReport: '{validation_report_path}'  # If provided
 prdPurpose: '{project-root}/_bmad/bmm/workflows/2-plan-workflows/create-prd/data/prd-purpose.md'
-advancedElicitationTask: 'skill:bmad-advanced-elicitation'
 ---
 
 # Step E-2: Deep Review & Analysis
@@ -220,8 +219,8 @@ Read fully and follow: {nextStepFile} (step-e-03-edit.md)
 
 #### Menu Handling Logic:
 
-- IF A: Read fully and follow: {advancedElicitationTask}, then return to discussion
-- IF P: Read fully and follow: {partyModeWorkflow}, then return to discussion
+- IF A: Invoke the `bmad-advanced-elicitation` skill, then return to discussion
+- IF P: Invoke the `bmad-party-mode` skill, then return to discussion
 - IF C: Document approval, then load {nextStepFile}
 - IF Any other: discuss, then redisplay menu
 

--- a/src/bmm/workflows/2-plan-workflows/bmad-validate-prd/steps-v/step-v-01-discovery.md
+++ b/src/bmm/workflows/2-plan-workflows/bmad-validate-prd/steps-v/step-v-01-discovery.md
@@ -4,8 +4,6 @@ description: 'Document Discovery & Confirmation - Handle fresh context validatio
 
 # File references (ONLY variables used in this step)
 nextStepFile: './step-v-02-format-detection.md'
-advancedElicitationTask: 'skill:bmad-advanced-elicitation'
-partyModeWorkflow: 'skill:bmad-party-mode'
 prdPurpose: '../data/prd-purpose.md'
 ---
 
@@ -195,8 +193,8 @@ Display: **Select an Option:** [A] Advanced Elicitation [P] Party Mode [C] Conti
 
 #### Menu Handling Logic:
 
-- IF A: Read fully and follow: {advancedElicitationTask}, and when finished redisplay the menu
-- IF P: Read fully and follow: {partyModeWorkflow}, and when finished redisplay the menu
+- IF A: Invoke the `bmad-advanced-elicitation` skill, and when finished redisplay the menu
+- IF P: Invoke the `bmad-party-mode` skill, and when finished redisplay the menu
 - IF C: Read fully and follow: {nextStepFile} to begin format detection
 - IF user provides additional document: Load it, update report, redisplay summary
 - IF Any other: help user, then redisplay menu

--- a/src/bmm/workflows/2-plan-workflows/bmad-validate-prd/steps-v/step-v-11-holistic-quality-validation.md
+++ b/src/bmm/workflows/2-plan-workflows/bmad-validate-prd/steps-v/step-v-11-holistic-quality-validation.md
@@ -6,7 +6,6 @@ description: 'Holistic Quality Assessment - Assess PRD as cohesive, compelling d
 nextStepFile: './step-v-12-completeness-validation.md'
 prdFile: '{prd_file_path}'
 validationReportPath: '{validation_report_path}'
-advancedElicitationTask: 'skill:bmad-advanced-elicitation'
 ---
 
 # Step 11: Holistic Quality Assessment
@@ -67,8 +66,8 @@ Assess the PRD as a cohesive, compelling document - evaluating document flow, du
 
 "Perform holistic quality assessment on this PRD using multi-perspective evaluation:
 
-**Read fully and follow the Advanced Elicitation workflow:**
-{advancedElicitationTask}
+**Advanced Elicitation workflow:**
+Invoke the `bmad-advanced-elicitation` skill
 
 **Evaluate the PRD from these perspectives:**
 

--- a/src/bmm/workflows/2-plan-workflows/create-prd/steps-v/step-v-01-discovery.md
+++ b/src/bmm/workflows/2-plan-workflows/create-prd/steps-v/step-v-01-discovery.md
@@ -4,8 +4,6 @@ description: 'Document Discovery & Confirmation - Handle fresh context validatio
 
 # File references (ONLY variables used in this step)
 nextStepFile: './step-v-02-format-detection.md'
-advancedElicitationTask: 'skill:bmad-advanced-elicitation'
-partyModeWorkflow: 'skill:bmad-party-mode'
 prdPurpose: '../data/prd-purpose.md'
 ---
 
@@ -195,8 +193,8 @@ Display: **Select an Option:** [A] Advanced Elicitation [P] Party Mode [C] Conti
 
 #### Menu Handling Logic:
 
-- IF A: Read fully and follow: {advancedElicitationTask}, and when finished redisplay the menu
-- IF P: Read fully and follow: {partyModeWorkflow}, and when finished redisplay the menu
+- IF A: Invoke the `bmad-advanced-elicitation` skill, and when finished redisplay the menu
+- IF P: Invoke the `bmad-party-mode` skill, and when finished redisplay the menu
 - IF C: Read fully and follow: {nextStepFile} to begin format detection
 - IF user provides additional document: Load it, update report, redisplay summary
 - IF Any other: help user, then redisplay menu

--- a/src/bmm/workflows/2-plan-workflows/create-prd/steps-v/step-v-11-holistic-quality-validation.md
+++ b/src/bmm/workflows/2-plan-workflows/create-prd/steps-v/step-v-11-holistic-quality-validation.md
@@ -6,7 +6,6 @@ description: 'Holistic Quality Assessment - Assess PRD as cohesive, compelling d
 nextStepFile: './step-v-12-completeness-validation.md'
 prdFile: '{prd_file_path}'
 validationReportPath: '{validation_report_path}'
-advancedElicitationTask: 'skill:bmad-advanced-elicitation'
 ---
 
 # Step 11: Holistic Quality Assessment
@@ -67,8 +66,8 @@ Assess the PRD as a cohesive, compelling document - evaluating document flow, du
 
 "Perform holistic quality assessment on this PRD using multi-perspective evaluation:
 
-**Read fully and follow the Advanced Elicitation workflow:**
-{advancedElicitationTask}
+**Advanced Elicitation workflow:**
+Invoke the `bmad-advanced-elicitation` skill
 
 **Evaluate the PRD from these perspectives:**
 

--- a/src/bmm/workflows/bmad-generate-project-context/steps/step-02-generate.md
+++ b/src/bmm/workflows/bmad-generate-project-context/steps/step-02-generate.md
@@ -30,8 +30,8 @@ This step will generate content and present choices for each rule category:
 
 ## PROTOCOL INTEGRATION:
 
-- When 'A' selected: Execute skill:bmad-advanced-elicitation
-- When 'P' selected: Execute skill:bmad-party-mode
+- When 'A' selected: Invoke the `bmad-advanced-elicitation` skill
+- When 'P' selected: Invoke the `bmad-party-mode` skill
 - PROTOCOLS always return to display this step's A/P/C menu after the A or P have completed
 - User accepts/rejects protocol changes before proceeding
 
@@ -268,7 +268,7 @@ After each category, show the generated rules and present choices:
 
 #### If 'A' (Advanced Elicitation):
 
-- Execute skill:bmad-advanced-elicitation with current category rules
+- Invoke the `bmad-advanced-elicitation` skill with current category rules
 - Process enhanced rules that come back
 - Ask user: "Accept these enhanced rules for {{category}}? (y/n)"
 - If yes: Update content, then return to A/P/C menu
@@ -276,7 +276,7 @@ After each category, show the generated rules and present choices:
 
 #### If 'P' (Party Mode):
 
-- Execute skill:bmad-party-mode with category rules context
+- Invoke the `bmad-party-mode` skill with category rules context
 - Process collaborative insights on implementation patterns
 - Ask user: "Accept these changes to {{category}} rules? (y/n)"
 - If yes: Update content, then return to A/P/C menu

--- a/src/bmm/workflows/bmad-quick-flow/bmad-quick-dev/steps/step-01-mode-detection.md
+++ b/src/bmm/workflows/bmad-quick-flow/bmad-quick-dev/steps/step-01-mode-detection.md
@@ -85,7 +85,7 @@ Display: "**Select:** [P] Plan first (tech-spec) [E] Execute directly"
 
 #### Menu Handling Logic:
 
-- IF P: Direct user to `{quick_spec_workflow}`. **EXIT Quick Dev.**
+- IF P: Direct user to invoke the `bmad-quick-spec` skill. **EXIT Quick Dev.**
 - IF E: Ask for any additional guidance, then **NEXT:** Read fully and follow: `./step-02-context-gathering.md`
 
 #### EXECUTION RULES:
@@ -107,7 +107,7 @@ Display:
 
 #### Menu Handling Logic:
 
-- IF P: Direct to `{quick_spec_workflow}`. **EXIT Quick Dev.**
+- IF P: Direct user to invoke the `bmad-quick-spec` skill. **EXIT Quick Dev.**
 - IF W: Direct user to run the PRD workflow instead. **EXIT Quick Dev.**
 - IF E: Ask for guidance, then **NEXT:** Read fully and follow: `./step-02-context-gathering.md`
 
@@ -130,7 +130,7 @@ Display:
 
 #### Menu Handling Logic:
 
-- IF P: Direct to `{quick_spec_workflow}`. **EXIT Quick Dev.**
+- IF P: Direct user to invoke the `bmad-quick-spec` skill. **EXIT Quick Dev.**
 - IF W: Direct user to run the PRD workflow instead. **EXIT Quick Dev.**
 - IF E: Ask for guidance, then **NEXT:** Read fully and follow: `./step-02-context-gathering.md`
 

--- a/src/bmm/workflows/bmad-quick-flow/bmad-quick-dev/workflow.md
+++ b/src/bmm/workflows/bmad-quick-flow/bmad-quick-dev/workflow.md
@@ -31,12 +31,6 @@ Load config from `{project-root}/_bmad/bmm/config.yaml` and resolve:
 
 - `project_context` = `**/project-context.md` (load if exists)
 
-### Related Workflows
-
-- `quick_spec_workflow` = `skill:bmad-quick-spec`
-- `party_mode_exec` = `skill:bmad-party-mode`
-- `advanced_elicitation` = `skill:bmad-advanced-elicitation`
-
 ---
 
 ## EXECUTION

--- a/src/bmm/workflows/bmad-quick-flow/bmad-quick-spec/steps/step-01-understand.md
+++ b/src/bmm/workflows/bmad-quick-flow/bmad-quick-spec/steps/step-01-understand.md
@@ -161,8 +161,8 @@ b) **HALT and wait for user selection.**
 
 #### Menu Handling Logic:
 
-- IF A: Read fully and follow: `{advanced_elicitation}` with current tech-spec content, process enhanced insights, ask user "Accept improvements? (y/n)", if yes update WIP file then redisplay menu, if no keep original then redisplay menu
-- IF P: Read fully and follow: `{party_mode_exec}` with current tech-spec content, process collaborative insights, ask user "Accept changes? (y/n)", if yes update WIP file then redisplay menu, if no keep original then redisplay menu
+- IF A: Invoke the `bmad-advanced-elicitation` skill with current tech-spec content, process enhanced insights, ask user "Accept improvements? (y/n)", if yes update WIP file then redisplay menu, if no keep original then redisplay menu
+- IF P: Invoke the `bmad-party-mode` skill with current tech-spec content, process collaborative insights, ask user "Accept changes? (y/n)", if yes update WIP file then redisplay menu, if no keep original then redisplay menu
 - IF C: Verify `{wipFile}` has `stepsCompleted: [1]`, then read fully and follow: `./step-02-investigate.md`
 - IF Any other comments or queries: respond helpfully then redisplay menu
 

--- a/src/bmm/workflows/bmad-quick-flow/bmad-quick-spec/steps/step-02-investigate.md
+++ b/src/bmm/workflows/bmad-quick-flow/bmad-quick-spec/steps/step-02-investigate.md
@@ -116,8 +116,8 @@ Display: "**Select:** [A] Advanced Elicitation [P] Party Mode [C] Continue to Ge
 
 #### Menu Handling Logic:
 
-- IF A: Read fully and follow: `{advanced_elicitation}` with current tech-spec content, process enhanced insights, ask user "Accept improvements? (y/n)", if yes update WIP file then redisplay menu, if no keep original then redisplay menu
-- IF P: Read fully and follow: `{party_mode_exec}` with current tech-spec content, process collaborative insights, ask user "Accept changes? (y/n)", if yes update WIP file then redisplay menu, if no keep original then redisplay menu
+- IF A: Invoke the `bmad-advanced-elicitation` skill with current tech-spec content, process enhanced insights, ask user "Accept improvements? (y/n)", if yes update WIP file then redisplay menu, if no keep original then redisplay menu
+- IF P: Invoke the `bmad-party-mode` skill with current tech-spec content, process collaborative insights, ask user "Accept changes? (y/n)", if yes update WIP file then redisplay menu, if no keep original then redisplay menu
 - IF C: Verify frontmatter updated with `stepsCompleted: [1, 2]`, then read fully and follow: `./step-03-generate.md`
 - IF Any other comments or queries: respond helpfully then redisplay menu
 

--- a/src/bmm/workflows/bmad-quick-flow/bmad-quick-spec/steps/step-04-review.md
+++ b/src/bmm/workflows/bmad-quick-flow/bmad-quick-spec/steps/step-04-review.md
@@ -48,8 +48,8 @@ Display: "**Select:** [C] Continue [E] Edit [Q] Questions [A] Advanced Elicitati
 - IF C: Proceed to Section 3 (Finalize the Spec)
 - IF E: Proceed to Section 2 (Handle Review Feedback), then return here and redisplay menu
 - IF Q: Answer questions, then redisplay this menu
-- IF A: Read fully and follow: `{advanced_elicitation}` with current spec content, process enhanced insights, ask user "Accept improvements? (y/n)", if yes update spec then redisplay menu, if no keep original then redisplay menu
-- IF P: Read fully and follow: `{party_mode_exec}` with current spec content, process collaborative insights, ask user "Accept changes? (y/n)", if yes update spec then redisplay menu, if no keep original then redisplay menu
+- IF A: Invoke the `bmad-advanced-elicitation` skill with current spec content, process enhanced insights, ask user "Accept improvements? (y/n)", if yes update spec then redisplay menu, if no keep original then redisplay menu
+- IF P: Invoke the `bmad-party-mode` skill with current spec content, process collaborative insights, ask user "Accept changes? (y/n)", if yes update spec then redisplay menu, if no keep original then redisplay menu
 - IF Any other comments or queries: respond helpfully then redisplay menu
 
 #### EXECUTION RULES:
@@ -134,10 +134,10 @@ b) **HALT and wait for user selection.**
 
 #### Menu Handling Logic:
 
-- IF A: Read fully and follow: `{advanced_elicitation}` with current spec content, process enhanced insights, ask user "Accept improvements? (y/n)", if yes update spec then redisplay menu, if no keep original then redisplay menu
+- IF A: Invoke the `bmad-advanced-elicitation` skill with current spec content, process enhanced insights, ask user "Accept improvements? (y/n)", if yes update spec then redisplay menu, if no keep original then redisplay menu
 - IF B: Invoke the `bmad-quick-dev` skill with `{finalFile}` in a fresh context if possible (warn: fresh context is better)
 - IF D: Exit workflow - display final confirmation and path to spec
-- IF P: Read fully and follow: `{party_mode_exec}` with current spec content, process collaborative insights, ask user "Accept changes? (y/n)", if yes update spec then redisplay menu, if no keep original then redisplay menu
+- IF P: Invoke the `bmad-party-mode` skill with current spec content, process collaborative insights, ask user "Accept changes? (y/n)", if yes update spec then redisplay menu, if no keep original then redisplay menu
 - IF R: Execute Adversarial Review (see below)
 - IF Any other comments or queries: respond helpfully then redisplay menu
 

--- a/src/bmm/workflows/bmad-quick-flow/bmad-quick-spec/workflow.md
+++ b/src/bmm/workflows/bmad-quick-flow/bmad-quick-spec/workflow.md
@@ -1,9 +1,6 @@
 ---
 main_config: '{project-root}/_bmad/bmm/config.yaml'
 
-# Checkpoint handler references
-advanced_elicitation: 'skill:bmad-advanced-elicitation'
-party_mode_exec: 'skill:bmad-party-mode'
 ---
 
 # Quick-Spec Workflow

--- a/src/core/skills/bmad-brainstorming/steps/step-03-technique-execution.md
+++ b/src/core/skills/bmad-brainstorming/steps/step-03-technique-execution.md
@@ -1,7 +1,7 @@
 # Step 3: Interactive Technique Execution and Facilitation
 
 ---
-advancedElicitationTask: 'skill:bmad-advanced-elicitation'
+
 ---
 
 ## MANDATORY EXECUTION RULES (READ FIRST):
@@ -303,7 +303,7 @@ After final technique element:
 #### If 'K', 'T', 'A', or 'B' (Continue Exploring):
 
 - **Stay in Step 3** and restart the facilitation loop for the chosen path (or pause if break requested).
-- For option A, invoke Advanced Elicitation: `{advancedElicitationTask}`
+- For option A: Invoke the `bmad-advanced-elicitation` skill
 
 ### 9. Update Documentation
 

--- a/src/core/skills/bmad-brainstorming/workflow.md
+++ b/src/core/skills/bmad-brainstorming/workflow.md
@@ -44,8 +44,6 @@ Load config from `{project-root}/_bmad/core/config.yaml` and resolve:
 
 All steps MUST reference `{brainstorming_session_output_file}` instead of the full path pattern.
 - `context_file` = Optional context file path from workflow invocation for project-specific guidance
-- `advancedElicitationTask` = `skill:bmad-advanced-elicitation`
-
 ---
 
 ## EXECUTION

--- a/src/core/tasks/bmad-create-prd/steps-c/step-05-domain.md
+++ b/src/core/tasks/bmad-create-prd/steps-c/step-05-domain.md
@@ -142,7 +142,7 @@ Display: "**Select:** [A] Advanced Elicitation [P] Party Mode [C] Continue - Sav
 
 #### Menu Handling Logic:
 - IF A: Invoke the `bmad-advanced-elicitation` skill, and when finished redisplay the menu
-- IF P: Read fully and follow: `skill:bmad-party-mode` and when finished redisplay the menu
+- IF P: Invoke the `bmad-party-mode` skill, and when finished redisplay the menu
 - IF C: Save content to {outputFile}, update frontmatter, then read fully and follow: ./step-06-innovation.md
 - IF Any other comments or queries: help user respond then [Redisplay Menu Options](#n-present-menu-options)
 


### PR DESCRIPTION
## Summary

- Replace three inconsistent skill reference patterns (frontmatter variables with raw paths, frontmatter `skill:` prefix variables, inline `Execute skill:` syntax) with a single convention: `Invoke the \`skill-name\` skill`
- Remove frontmatter variables that existed solely to hold skill references from 14 files
- 20 files changed across workflow and task step files in `src/`

## Out of scope

Agent YAML `exec:` fields and CSV `workflow-file` columns are structured data formats (parsed by compiler/installer), not prose invocation syntax — intentionally untouched.

## Test plan

- [x] `npm run validate:refs -- --strict` passes (0 broken references)
- [x] Full pre-commit hook passes (lint, format, markdownlint, all test suites)
- [x] `grep -r 'skill:bmad-' src/*.md` returns only 2 legitimate non-invocation references
- [x] `grep -rE '(advancedElicitationTask|party_mode_exec|advanced_elicitation|quick_spec_workflow|partyModeWorkflow)' src/` returns zero matches

🤖 Generated with [Claude Code](https://claude.com/claude-code)