### PR TITLE
ci: run quality checks on pushes to main

### DIFF
--- a/.github/workflows/quality.yaml
+++ b/.github/workflows/quality.yaml
@@ -1,6 +1,6 @@
 name: Quality & Validation
 
-# Runs comprehensive quality checks on all PRs:
+# Runs comprehensive quality checks on all PRs and pushes to main:
 # - Prettier (formatting)
 # - ESLint (linting)
 # - markdownlint (markdown quality)
@@ -10,6 +10,8 @@ name: Quality & Validation
 # Keep this workflow aligned with `npm run quality` in `package.json`.
 
 "on":
+  push:
+    branches: [main]
   pull_request:
     branches: ["**"]
   workflow_dispatch:


### PR DESCRIPTION
## Summary
- Add `push: branches: [main]` trigger to the quality workflow
- Previously only `pull_request` events ran CI, so direct pushes to main (including merged PRs) bypassed all quality checks

## Test plan
- [ ] Verify the workflow triggers on a push to main after merge
- [ ] Confirm PR-triggered runs still work as before

🤖 Generated with [Claude Code](https://claude.com/claude-code)