### PR TITLE
feat(quick-dev): add VS Code opening ergonomics to step 5

### DIFF
--- a/src/bmm/workflows/bmad-quick-flow/bmad-quick-dev-new-preview/step-05-present.md
+++ b/src/bmm/workflows/bmad-quick-flow/bmad-quick-dev-new-preview/step-05-present.md
@@ -55,13 +55,12 @@ When there is only one concern, omit the bold label — just list the stops dire
 
 1. **Plan-code-review:** Change `{spec_file}` status to `done` in the frontmatter.
 2. If version control is available and the tree is dirty, create a local commit with a conventional message derived from the spec title (plan-code-review) or the intent (one-shot).
-3. Open the spec in the user's editor so they can click through the Suggested Review Order:
+3. **Plan-code-review only:** Open the spec in the user's editor so they can click through the Suggested Review Order:
    - Run `code -r "{spec_file}"` to open the spec in the current VS Code window (reuses the window where the project or worktree is open). Always double-quote the path to handle spaces and special characters.
    - If `code` is not available (command fails), skip gracefully and tell the user the spec file path instead.
 4. Display summary of your work to the user, including the commit hash if one was created. Include:
-   - A note that the spec is open in their editor (or the file path if it couldn't be opened).
+   - **Plan-code-review:** A note that the spec is open in their editor (or the file path if it couldn't be opened). Mention that `{spec_file}` now contains a Suggested Review Order.
    - **Navigation tip:** "Ctrl+click (Cmd+click on macOS) the links in the Suggested Review Order to jump to each stop."
-   - For plan-code-review, mention that `{spec_file}` now contains a Suggested Review Order.
    - Offer to push and/or create a pull request.
 
 Workflow complete.


### PR DESCRIPTION
## Summary

- Replace `vscode://file/` absolute URI links in Suggested Review Order with workspace-root-relative markdown links using `#L` anchors — portable across machines and worktrees
- Add `code -r {spec_file}` open-in-editor step after commit with graceful fallback when VS Code CLI unavailable
- Add Ctrl/Cmd+click navigation tip for reviewers

## Context

Story 1.2 from the av-hitl-review implementation plan. Builds on Story 1.1 (PR #2033) which added the Suggested Review Order generation.

Research confirmed VS Code natively supports `[text](/path#L42)` in markdown since v1.63 for all file types. The `vscode://file/` format required absolute paths, broke across machines, and locked to a single editor.

## Test plan

- [ ] Run quick-dev on a small change — verify the Suggested Review Order uses `[name:line](/path#L42)` links instead of `vscode://file/` URIs
- [ ] Open the generated spec in VS Code editor (source view) — verify Ctrl+click on a link opens the referenced file at the correct line
- [ ] Verify `code -r` opens the spec in the existing VS Code window (not a new one)
- [ ] Test with `code` CLI unavailable — verify step 5 prints the spec path and continues gracefully