### PR TITLE
feat(coderabbit): add docs-staleness check for src/ changes

### DIFF
--- a/.coderabbit.yaml
+++ b/.coderabbit.yaml
@@ -60,6 +60,13 @@ reviews:
     - "!**/validation-report-*.md"
     - "!CHANGELOG.md"
   path_instructions:
+    - path: "src/**"
+      instructions: |
+        Source file changed. Check whether documentation under docs/ needs
+        a corresponding update — new features, changed behavior, renamed
+        concepts, altered CLI flags, or modified configuration options should
+        all be reflected in the relevant doc pages. Flag missing or outdated
+        docs as a review comment.
     - path: "src/**/skills/**"
       instructions: |
         Skill file. Apply the full rule catalog defined in tools/skill-validator.md.


### PR DESCRIPTION
## Summary

- Adds a `path_instructions` entry for `src/**` that tells CodeRabbit to flag when documentation under `docs/` may need updating whenever source files are modified
- Covers new features, changed behavior, renamed concepts, altered CLI flags, and modified configuration options
- Stacks additively with existing path-specific instructions (skills, workflows, tasks, agents)

## Test plan

- [ ] Open a PR that modifies a file under `src/` and verify CodeRabbit includes the docs-staleness check in its review
- [ ] Open a PR that only modifies files outside `src/` and verify the instruction does not fire

🤖 Generated with [Claude Code](https://claude.com/claude-code)