### PR TITLE
fix(opencode): use native agents/ and commands/ layout instead of skills/

### DIFF
--- a/test/test-installation-components.js
+++ b/test/test-installation-components.js
@@ -410,34 +410,47 @@ async function runTests() {
   console.log('');
 
   // ============================================================
-  // Test 8: OpenCode Native Skills Install
+  // Test 8: OpenCode Multi-Target Install (agents + commands)
   // ============================================================
-  console.log(`${colors.yellow}Test Suite 8: OpenCode Native Skills${colors.reset}\n`);
+  console.log(`${colors.yellow}Test Suite 8: OpenCode Multi-Target Install${colors.reset}\n`);
 
   try {
     clearCache();
     const platformCodes = await loadPlatformCodes();
     const opencodeInstaller = platformCodes.platforms.opencode?.installer;
 
-    assert(opencodeInstaller?.target_dir === '.opencode/skills', 'OpenCode target_dir uses native skills path');
+    assert(
+      Array.isArray(opencodeInstaller?.targets) && opencodeInstaller.targets.length === 2,
+      'OpenCode installer uses multi-target layout with 2 targets',
+    );
 
-    assert(opencodeInstaller?.skill_format === true, 'OpenCode installer enables native skill output');
+    assert(
+      opencodeInstaller?.targets?.[0]?.target_dir === '.opencode/agents' &&
+        opencodeInstaller?.targets?.[0]?.artifact_types?.includes('agents'),
+      'OpenCode agents target writes to .opencode/agents',
+    );
+
+    assert(
+      opencodeInstaller?.targets?.[1]?.target_dir === '.opencode/commands' &&
+        ['workflows', 'tasks', 'tools'].every((t) => opencodeInstaller?.targets?.[1]?.artifact_types?.includes(t)),
+      'OpenCode commands target writes workflows, tasks, and tools to .opencode/commands',
+    );
 
     assert(opencodeInstaller?.ancestor_conflict_check === true, 'OpenCode installer enables ancestor conflict checks');
 
     assert(
       Array.isArray(opencodeInstaller?.legacy_targets) &&
-        ['.opencode/agents', '.opencode/commands', '.opencode/agent', '.opencode/command'].every((legacyTarget) =>
+        ['.opencode/skills', '.opencode/agent', '.opencode/command'].every((legacyTarget) =>
           opencodeInstaller.legacy_targets.includes(legacyTarget),
         ),
-      'OpenCode installer cleans split legacy agent and command output',
+      'OpenCode installer cleans legacy skills and singular agent/command output',
     );
 
     const tempProjectDir = await fs.mkdtemp(path.join(os.tmpdir(), 'bmad-opencode-test-'));
     const installedBmadDir = await createTestBmadFixture();
+    // Create legacy dirs that should be cleaned up
     const legacyDirs = [
-      path.join(tempProjectDir, '.opencode', 'agents', 'bmad-legacy-agent'),
-      path.join(tempProjectDir, '.opencode', 'commands', 'bmad-legacy-command'),
+      path.join(tempProjectDir, '.opencode', 'skills', 'bmad-legacy-skill'),
       path.join(tempProjectDir, '.opencode', 'agent', 'bmad-legacy-agent-singular'),
       path.join(tempProjectDir, '.opencode', 'command', 'bmad-legacy-command-singular'),
     ];
@@ -457,10 +470,19 @@ async function runTests() {
 
     assert(result.success === true, 'OpenCode setup succeeds against temp project');
 
-    const skillFile = path.join(tempProjectDir, '.opencode', 'skills', 'bmad-master', 'SKILL.md');
-    assert(await fs.pathExists(skillFile), 'OpenCode install writes SKILL.md directory output');
+    // Agents should be flat files in .opencode/agents/ (canonicalId = bmad-master from fixture)
+    const agentFile = path.join(tempProjectDir, '.opencode', 'agents', 'bmad-master.md');
+    assert(await fs.pathExists(agentFile), 'OpenCode install writes flat agent files to .opencode/agents');
 
-    for (const legacyDir of ['agents', 'commands', 'agent', 'command']) {
+    // Agent file should have opencode-specific frontmatter (mode: all)
+    const agentContent = await fs.readFile(agentFile, 'utf8');
+    assert(agentContent.includes('mode: all'), 'OpenCode agent file uses opencode-specific frontmatter');
+
+    // Commands directory should exist (for workflows/tasks)
+    assert(await fs.pathExists(path.join(tempProjectDir, '.opencode', 'commands')), 'OpenCode creates .opencode/commands directory');
+
+    // Legacy dirs should be cleaned up
+    for (const legacyDir of ['skills', 'agent', 'command']) {
       assert(
         !(await fs.pathExists(path.join(tempProjectDir, '.opencode', legacyDir))),
         `OpenCode setup removes legacy .opencode/${legacyDir} dir`,
@@ -470,7 +492,7 @@ async function runTests() {
     await fs.remove(tempProjectDir);
     await fs.remove(installedBmadDir);
   } catch (error) {
-    assert(false, 'OpenCode native skills migration test succeeds', error.message);
+    assert(false, 'OpenCode multi-target migration test succeeds', error.message);
   }
 
   console.log('');
@@ -788,10 +810,11 @@ async function runTests() {
     const childProjectDir = path.join(parentProjectDir, 'child');
     const installedBmadDir = await createTestBmadFixture();
 
+    // Place existing BMAD agent files in parent's .opencode/agents (multi-target layout)
     await fs.ensureDir(path.join(parentProjectDir, '.git'));
-    await fs.ensureDir(path.join(parentProjectDir, '.opencode', 'skills', 'bmad-existing'));
+    await fs.ensureDir(path.join(parentProjectDir, '.opencode', 'agents'));
     await fs.ensureDir(childProjectDir);
-    await fs.writeFile(path.join(parentProjectDir, '.opencode', 'skills', 'bmad-existing', 'SKILL.md'), 'legacy\n');
+    await fs.writeFile(path.join(parentProjectDir, '.opencode', 'agents', 'bmad-agent-bmm-pm.md'), 'existing\n');
 
     const ideManager = new IdeManager();
     await ideManager.ensureInitialized();
@@ -799,13 +822,13 @@ async function runTests() {
       silent: true,
       selectedModules: ['bmm'],
     });
-    const expectedConflictDir = await fs.realpath(path.join(parentProjectDir, '.opencode', 'skills'));
+    const expectedConflictDir = await fs.realpath(path.join(parentProjectDir, '.opencode', 'agents'));
 
-    assert(result.success === false, 'OpenCode setup refuses install when ancestor skills already exist');
+    assert(result.success === false, 'OpenCode setup refuses install when ancestor agents already exist');
     assert(result.handlerResult?.reason === 'ancestor-conflict', 'OpenCode ancestor rejection reports ancestor-conflict reason');
     assert(
       result.handlerResult?.conflictDir === expectedConflictDir,
-      'OpenCode ancestor rejection points at ancestor .opencode/skills dir',
+      'OpenCode ancestor rejection points at ancestor .opencode/agents dir',
     );
 
     await fs.remove(tempRoot);

--- a/tools/cli/installers/lib/ide/_config-driven.js
+++ b/tools/cli/installers/lib/ide/_config-driven.js
@@ -36,8 +36,8 @@ class ConfigDrivenIdeSetup extends BaseIdeSetup {
 
   /**
    * Detect whether this IDE already has configuration in the project.
-   * For skill_format platforms, checks for bmad-prefixed entries in target_dir
-   * (matching old codex.js behavior) instead of just checking directory existence.
+   * For skill_format platforms, checks for bmad-prefixed entries in target_dir.
+   * For multi-target platforms, checks all target directories for bmad-prefixed entries.
    * @param {string} projectDir - Project directory
    * @returns {Promise<boolean>}
    */
@@ -54,6 +54,25 @@ class ConfigDrivenIdeSetup extends BaseIdeSetup {
       }
       return false;
     }
+
+    // For multi-target platforms, check all target directories for bmad-prefixed entries
+    if (this.installerConfig?.targets) {
+      for (const target of this.installerConfig.targets) {
+        const dir = path.join(projectDir || process.cwd(), target.target_dir);
+        if (await fs.pathExists(dir)) {
+          try {
+            const entries = await fs.readdir(dir);
+            if (entries.some((e) => typeof e === 'string' && e.startsWith('bmad'))) {
+              return true;
+            }
+          } catch {
+            // Skip unreadable directories
+          }
+        }
+      }
+      return false;
+    }
+
     return super.detect(projectDir);
   }
 
@@ -982,34 +1001,48 @@ LOAD and execute from: {project-root}/{{bmadFolderName}}/{{path}}
   }
 
   /**
-   * Check ancestor directories for existing BMAD files in the same target_dir.
-   * IDEs like Claude Code inherit commands from parent directories, so an existing
-   * installation in an ancestor would cause duplicate commands.
+   * Check ancestor directories for existing BMAD files in target directories.
+   * IDEs like Claude Code and OpenCode inherit commands from parent directories,
+   * so an existing installation in an ancestor would cause duplicate commands.
+   * Supports both single target_dir and multi-target configurations.
    * @param {string} projectDir - Project directory being installed to
    * @returns {Promise<string|null>} Path to conflicting directory, or null if clean
    */
   async findAncestorConflict(projectDir) {
-    const targetDir = this.installerConfig?.target_dir;
-    if (!targetDir) return null;
+    // Collect all target directories to check
+    const targetDirs = [];
+    if (this.installerConfig?.target_dir) {
+      targetDirs.push(this.installerConfig.target_dir);
+    }
+    if (this.installerConfig?.targets) {
+      for (const target of this.installerConfig.targets) {
+        if (target.target_dir && !targetDirs.includes(target.target_dir)) {
+          targetDirs.push(target.target_dir);
+        }
+      }
+    }
+    if (targetDirs.length === 0) return null;
 
     const resolvedProject = await fs.realpath(path.resolve(projectDir));
     let current = path.dirname(resolvedProject);
     const root = path.parse(current).root;
 
     while (current !== root && current.length > root.length) {
-      const candidatePath = path.join(current, targetDir);
-      try {
-        if (await fs.pathExists(candidatePath)) {
-          const entries = await fs.readdir(candidatePath);
-          const hasBmad = entries.some(
-            (e) => typeof e === 'string' && e.toLowerCase().startsWith('bmad') && !e.toLowerCase().startsWith('bmad-os-'),
-          );
-          if (hasBmad) {
-            return candidatePath;
+      for (const targetDir of targetDirs) {
+        const candidatePath = path.join(current, targetDir);
+        try {
+          if (await fs.pathExists(candidatePath)) {
+            const entries = await fs.readdir(candidatePath);
+            const hasBmad = entries.some(
+              (e) => typeof e === 'string' && e.toLowerCase().startsWith('bmad') && !e.toLowerCase().startsWith('bmad-os-'),
+            );
+            if (hasBmad) {
+              return candidatePath;
+            }
           }
+        } catch {
+          // Can't read directory — skip
         }
-      } catch {
-        // Can't read directory — skip
       }
       current = path.dirname(current);
     }

--- a/tools/cli/installers/lib/ide/platform-codes.yaml
+++ b/tools/cli/installers/lib/ide/platform-codes.yaml
@@ -193,13 +193,17 @@ platforms:
     description: "OpenCode terminal coding assistant"
     installer:
       legacy_targets:
-        - .opencode/agents
-        - .opencode/commands
+        - .opencode/skills
         - .opencode/agent
         - .opencode/command
-      target_dir: .opencode/skills
-      template_type: opencode
-      skill_format: true
+      target_dir: .opencode/agents # For detection; actual output uses targets below
+      targets:
+        - target_dir: .opencode/agents
+          template_type: opencode
+          artifact_types: [agents]
+        - target_dir: .opencode/commands
+          template_type: opencode
+          artifact_types: [workflows, tasks, tools]
       ancestor_conflict_check: true
 
   pi:


### PR DESCRIPTION
## Summary

- OpenCode does not have a native "skills" concept — it uses `.opencode/agents/` for agent persona definitions and `.opencode/commands/` for slash commands
- The installer was incorrectly placing everything into `.opencode/skills/` as `SKILL.md` directories, which duplicated content from `_bmad/` and prevented workflows from appearing as native opencode commands
- Switch opencode to a **multi-target layout** using the existing `targets` mechanism in `_config-driven.js`:
  - `.opencode/agents/` — flat agent launcher files (using `opencode-agent` template with `mode: all` frontmatter)
  - `.opencode/commands/` — flat workflow/task/tool command files (thin loaders pointing to `_bmad/` canonical sources)

## What changed

### `platform-codes.yaml`
- Replaced single `target_dir: .opencode/skills` + `skill_format: true` with a `targets` array containing two entries (agents + commands)
- Moved `.opencode/skills` into `legacy_targets` so existing skill-based installations are cleaned up on upgrade
- Removed `.opencode/agents` and `.opencode/commands` from `legacy_targets` since they are now active output targets

### `_config-driven.js`
- **`detect()`**: Added multi-target detection — checks all `targets[].target_dir` directories for bmad-prefixed entries (previously only worked for single `target_dir` with `skill_format`)
- **`findAncestorConflict()`**: Now collects target directories from both `target_dir` and `targets[]` for ancestor conflict checking, so platforms with multiple output directories are fully covered

### `test-installation-components.js`
- Updated OpenCode test suite (Suite 8) to verify multi-target layout: flat agent files in `.opencode/agents/`, commands directory created, opencode-specific `mode: all` frontmatter
- Updated ancestor conflict test (Suite 15) to check `.opencode/agents/` instead of `.opencode/skills/`
- All 234 tests pass, 0 failures

## Motivation

This was discovered by comparing a v6.0.4 installation (`poc-create-brief`) — which correctly used `.opencode/agents/` + `.opencode/commands/` — against a v6.2.0 installation which placed everything in `.opencode/skills/`. The v6.0.4 output was the correct structure for opencode's native concepts, and this PR restores that behavior using the config-driven architecture.