### PR TITLE
fix: restore deleted agent-component fragments that break CIS compilation

### DIFF
--- a/src/utility/agent-components/activation-rules.txt
+++ b/src/utility/agent-components/activation-rules.txt
@@ -1,0 +1,6 @@
+  <rules>
+    <r>ALWAYS communicate in {communication_language} UNLESS contradicted by communication_style.</r>
+    <r> Stay in character until exit selected</r>
+    <r> Display Menu items as the item dictates and in the order given.</r>
+    <r> Load files ONLY when executing a user chosen workflow or a command requires it, EXCEPTION: agent activation step 2 config.yaml</r>
+  </rules>

--- a/src/utility/agent-components/activation-steps.txt
+++ b/src/utility/agent-components/activation-steps.txt
@@ -1,0 +1,14 @@
+    <step n="1">Load persona from this current agent file (already in context)</step>
+    <step n="2">🚨 IMMEDIATE ACTION REQUIRED - BEFORE ANY OUTPUT:
+        - Load and read {project-root}/_bmad/{{module}}/config.yaml NOW
+        - Store ALL fields as session variables: {user_name}, {communication_language}, {output_folder}
+        - VERIFY: If config not loaded, STOP and report error to user
+        - DO NOT PROCEED to step 3 until config is successfully loaded and variables stored
+    </step>
+    <step n="3">Remember: user's name is {user_name}</step>
+    {AGENT_SPECIFIC_STEPS}
+    <step n="{MENU_STEP}">Show greeting using {user_name} from config, communicate in {communication_language}, then display numbered list of ALL menu items from menu section</step>
+    <step n="{HELP_STEP}">Let {user_name} know they can invoke the `bmad-help` skill at any time to get advice on what to do next, and that they can combine it with what they need help with <example>Invoke the `bmad-help` skill with a question like "where should I start with an idea I have that does XYZ?"</example></step>
+    <step n="{HALT_STEP}">STOP and WAIT for user input - do NOT execute menu items automatically - accept number or cmd trigger or fuzzy command match</step>
+    <step n="{INPUT_STEP}">On user input: Number → process menu item[n] | Text → case-insensitive substring match | Multiple matches → ask user to clarify | No match → show "Not recognized"</step>
+    <step n="{EXECUTE_STEP}">When processing a menu item: Check menu-handlers section below - extract any attributes from the selected menu item (exec, tmpl, data, action, multi) and follow the corresponding handler instructions</step>

--- a/src/utility/agent-components/agent-command-header.md
+++ b/src/utility/agent-components/agent-command-header.md
@@ -1,0 +1,1 @@
+You must fully embody this agent's persona and follow all activation instructions, steps and rules exactly as specified. NEVER break character until given an exit command.

--- a/src/utility/agent-components/agent.customize.template.yaml
+++ b/src/utility/agent-components/agent.customize.template.yaml
@@ -1,0 +1,41 @@
+# Agent Customization
+# Customize any section below - all are optional
+
+# Override agent name
+agent:
+  metadata:
+    name: ""
+
+# Replace entire persona (not merged)
+persona:
+  role: ""
+  identity: ""
+  communication_style: ""
+  principles: []
+
+# Add custom critical actions (appended after standard config loading)
+critical_actions: []
+
+# Add persistent memories for the agent
+memories: []
+# Example:
+# memories:
+#   - "User prefers detailed technical explanations"
+#   - "Current project uses React and TypeScript"
+
+# Add custom menu items (appended to base menu)
+# Don't include * prefix or help/exit - auto-injected
+menu: []
+# Example:
+# menu:
+#   - trigger: my-workflow
+#     workflow: "{project-root}/custom/my.yaml"
+#     description: My custom workflow
+
+# Add custom prompts (for action="#id" handlers)
+prompts: []
+# Example:
+# prompts:
+# - id: my-prompt
+#   content: |
+#     Prompt instructions here

--- a/src/utility/agent-components/handler-action.txt
+++ b/src/utility/agent-components/handler-action.txt
@@ -1,0 +1,4 @@
+  <handler type="action">
+    When menu item has: action="#id" → Find prompt with id="id" in current agent XML, follow its content
+    When menu item has: action="text" → Follow the text directly as an inline instruction
+  </handler>

--- a/src/utility/agent-components/handler-data.txt
+++ b/src/utility/agent-components/handler-data.txt
@@ -1,0 +1,5 @@
+    <handler type="data">
+      When menu item has: data="path/to/file.json|yaml|yml|csv|xml"
+      Load the file first, parse according to extension
+      Make available as {data} variable to subsequent handler operations
+    </handler>

--- a/src/utility/agent-components/handler-exec.txt
+++ b/src/utility/agent-components/handler-exec.txt
@@ -1,0 +1,6 @@
+    <handler type="exec">
+      When menu item or handler has: exec="path/to/file.md":
+      1. Read fully and follow the file at that path
+      2. Process the complete file and follow all instructions within it
+      3. If there is data="some/path/data-foo.md" with the same item, pass that data path to the executed file as context.
+    </handler>

--- a/src/utility/agent-components/handler-multi.txt
+++ b/src/utility/agent-components/handler-multi.txt
@@ -1,0 +1,13 @@
+      <handler type="multi">
+         When menu item has: type="multi" with nested handlers
+         1. Display the multi item text as a single menu option
+         2. Parse all nested handlers within the multi item
+         3. For each nested handler:
+            - Use the 'match' attribute for fuzzy matching user input (or Exact Match of character code in brackets [])
+            - Process based on handler attributes (exec, action)
+         4. When user input matches a handler's 'match' pattern:
+            - For exec="path/to/file.md": follow the `handler type="exec"` instructions
+            - For action="...": Perform the specified action directly
+         5. Support both exact matches and fuzzy matching based on the match attribute
+         6. If no handler matches, prompt user to choose from available options
+      </handler>

--- a/src/utility/agent-components/handler-tmpl.txt
+++ b/src/utility/agent-components/handler-tmpl.txt
@@ -1,0 +1,5 @@
+    <handler type="tmpl">
+      1. When menu item has: tmpl="path/to/template.md"
+      2. Load template file, parse as markdown with {{mustache}} style variables
+      3. Make template content available as {template} to action/exec/workflow handlers
+    </handler>

--- a/src/utility/agent-components/menu-handlers.txt
+++ b/src/utility/agent-components/menu-handlers.txt
@@ -1,0 +1,6 @@
+    <menu-handlers>
+      <extract>{DYNAMIC_EXTRACT_LIST}</extract>
+      <handlers>
+    {DYNAMIC_HANDLERS}
+      </handlers>
+    </menu-handlers>


### PR DESCRIPTION
## Summary
- PR #2050 deleted `src/utility/agent-components/` during the phase-based refactor, but `tools/cli/lib/activation-builder.js` still references these fragment files via `loadFragment()`
- This causes agent compilation to fail with `Fragment not found: activation-steps.txt` for any agent using the ActivationBuilder pipeline (including 6 CIS module agents)
- Restores all 10 fragment files to their pre-deletion state

## Files restored
- `activation-rules.txt` - XML rules block for agent activation
- `activation-steps.txt` - Sequential activation steps template with placeholders
- `agent-command-header.md` - Agent command header text
- `agent.customize.template.yaml` - Agent customization template
- `handler-action.txt` - Action handler definition
- `handler-data.txt` - Data handler definition
- `handler-exec.txt` - Exec handler definition
- `handler-multi.txt` - Multi handler definition
- `handler-tmpl.txt` - Template handler definition
- `menu-handlers.txt` - Menu handlers wrapper template

## Root cause
`ActivationBuilder` (line 10) resolves fragments via `getSourcePath('utility', 'agent-components')` → `src/utility/agent-components/`. The `buildActivation()` method loads `activation-steps.txt`, `menu-handlers.txt`, `activation-rules.txt`, and dynamic `handler-*.txt` files. All were deleted in #2050.

## Test plan
- [ ] Install BMAD method fresh and verify CIS module agents compile without errors
- [ ] Verify `activation-builder.js` loadFragment calls all resolve
- [ ] Run existing test suite to confirm no regressions

🤖 Generated with [Claude Code](https://claude.com/claude-code)

Co-Authored-By: Claude Opus 4.6 (1M context) <noreply@anthropic.com>