### PR TITLE
refactor(installer): remove dead .agent.yaml/.xml fallback logic

### DIFF
--- a/tools/cli/installers/lib/core/manifest-generator.js
+++ b/tools/cli/installers/lib/core/manifest-generator.js
@@ -704,21 +704,12 @@ class ManifestGenerator {
           continue;
         }
 
-        // Check if this looks like a module (has agents, workflows, or tasks directory)
+        // Check if this looks like a module (has agents directory or skill manifests)
         const modulePath = path.join(bmadDir, entry.name);
         const hasAgents = await fs.pathExists(path.join(modulePath, 'agents'));
-        const hasWorkflows = await fs.pathExists(path.join(modulePath, 'workflows'));
-        const hasTasks = await fs.pathExists(path.join(modulePath, 'tasks'));
-        const hasTools = await fs.pathExists(path.join(modulePath, 'tools'));
+        const hasSkills = await this._hasSkillMdRecursive(modulePath);
 
-        // Check for native-entrypoint-only modules: recursive scan for SKILL.md
-        let hasSkills = false;
-        if (!hasAgents && !hasWorkflows && !hasTasks && !hasTools) {
-          hasSkills = await this._hasSkillMdRecursive(modulePath);
-        }
-
-        // If it has any of these directories or skill manifests, it's likely a module
-        if (hasAgents || hasWorkflows || hasTasks || hasTools || hasSkills) {
+        if (hasAgents || hasSkills) {
           modules.push(entry.name);
         }
       }

--- a/tools/cli/installers/lib/ide/shared/skill-manifest.js
+++ b/tools/cli/installers/lib/ide/shared/skill-manifest.js
@@ -27,7 +27,7 @@ async function loadSkillManifest(dirPath) {
 /**
  * Get the canonicalId for a specific file from a loaded skill manifest.
  * @param {Object|null} manifest - Loaded manifest (from loadSkillManifest)
- * @param {string} filename - Source filename to look up (e.g., 'pm.md', 'help.md', 'pm.agent.yaml')
+ * @param {string} filename - Source filename to look up (e.g., 'pm.md', 'help.md')
  * @returns {string} canonicalId or empty string
  */
 function getCanonicalId(manifest, filename) {
@@ -36,12 +36,6 @@ function getCanonicalId(manifest, filename) {
   if (manifest.__single) return manifest.__single.canonicalId || '';
   // Multi-entry: look up by filename directly
   if (manifest[filename]) return manifest[filename].canonicalId || '';
-  // Fallback: try alternate extensions for compiled files
-  const baseName = filename.replace(/\.(md|xml)$/i, '');
-  const agentKey = `${baseName}.agent.yaml`;
-  if (manifest[agentKey]) return manifest[agentKey].canonicalId || '';
-  const xmlKey = `${baseName}.xml`;
-  if (manifest[xmlKey]) return manifest[xmlKey].canonicalId || '';
   return '';
 }
 
@@ -57,12 +51,6 @@ function getArtifactType(manifest, filename) {
   if (manifest.__single) return manifest.__single.type || null;
   // Multi-entry: look up by filename directly
   if (manifest[filename]) return manifest[filename].type || null;
-  // Fallback: try alternate extensions for compiled files
-  const baseName = filename.replace(/\.(md|xml)$/i, '');
-  const agentKey = `${baseName}.agent.yaml`;
-  if (manifest[agentKey]) return manifest[agentKey].type || null;
-  const xmlKey = `${baseName}.xml`;
-  if (manifest[xmlKey]) return manifest[xmlKey].type || null;
   return null;
 }
 
@@ -78,12 +66,6 @@ function getInstallToBmad(manifest, filename) {
   if (manifest.__single) return manifest.__single.install_to_bmad !== false;
   // Multi-entry: look up by filename directly
   if (manifest[filename]) return manifest[filename].install_to_bmad !== false;
-  // Fallback: try alternate extensions for compiled files
-  const baseName = filename.replace(/\.(md|xml)$/i, '');
-  const agentKey = `${baseName}.agent.yaml`;
-  if (manifest[agentKey]) return manifest[agentKey].install_to_bmad !== false;
-  const xmlKey = `${baseName}.xml`;
-  if (manifest[xmlKey]) return manifest[xmlKey].install_to_bmad !== false;
   return true;
 }
 


### PR DESCRIPTION
## Summary

- Remove dead `.agent.yaml`/`.xml` fallback blocks from `getCanonicalId`, `getArtifactType`, `getInstallToBmad` in `skill-manifest.js`
- Simplify `scanInstalledModules()` to use `agents/` dir check + recursive SKILL.md scan, removing `workflows/`/`tasks/`/`tools/` directory checks

## Test plan

- [x] `npm ci && npm run quality` passes (227 tests, all lint/format/refs/skills clean)
- [x] `grep` confirms no `.agent.yaml`/`.xml` fallback references remain in `skill-manifest.js`
- [x] 3-layer adversarial review (blind hunter, edge case hunter, acceptance auditor) — all clear