### PR TITLE
docs(zh-cn): refine install and non-interactive guides

### DIFF
--- a/docs/zh-cn/how-to/install-bmad.md
+++ b/docs/zh-cn/how-to/install-bmad.md
@@ -76,6 +76,9 @@ npx github:bmad-code-org/BMAD-METHOD install
 
 ## 你将获得
 
+以下目录结构仅作示例。工具相关目录会随你选择的平台变化（例如可能是
+`.claude/skills`、`.cursor/skills` 或 `.kiro/skills`），并不一定会同时出现。
+
 ```text
 your-project/
 ├── _bmad/

--- a/docs/zh-cn/how-to/non-interactive-installation.md
+++ b/docs/zh-cn/how-to/non-interactive-installation.md
@@ -1,6 +1,6 @@
 ---
 title: "非交互式安装"
-description: 使用命令行标志安装 BMad，适用于 CI/CD 流水线和自动化部署
+description: 使用命令行参数安装 BMad，适用于 CI/CD 流水线和自动化部署
 sidebar:
   order: 2
 ---
@@ -67,8 +67,8 @@ sidebar:
 
 | 模式 | 描述 | 示例 |
 |------|-------------|---------|
-| 完全非交互式 | 提供所有标志以跳过所有提示 | `npx bmad-method install --directory . --modules bmm --tools claude-code --yes` |
-| 半交互式 | 提供部分标志；BMad 提示其余部分 | `npx bmad-method install --directory . --modules bmm` |
+| 完全非交互式 | 提供所有参数以跳过所有提示 | `npx bmad-method install --directory . --modules bmm --tools claude-code --yes` |
+| 半交互式 | 提供部分参数；BMad 提示其余部分 | `npx bmad-method install --directory . --modules bmm` |
 | 仅使用默认值 | 使用 `-y` 接受所有默认值 | `npx bmad-method install --yes` |
 | 不包含工具 | 跳过工具/IDE 配置 | `npx bmad-method install --modules bmm --tools none` |
 
@@ -141,7 +141,7 @@ BMad 会验证你提供的所有参数：
 
 :::tip[最佳实践]
 - 为 `--directory` 使用绝对路径以避免歧义
-- 在 CI/CD 流水线中使用前先在本地测试标志
+- 在 CI/CD 流水线中使用前先在本地测试参数
 - 结合 `-y` 实现真正的无人值守安装
 - 如果在安装过程中遇到问题，使用 `--debug`
 :::


### PR DESCRIPTION
## What
This PR updates two Chinese installation guides: `docs/zh-cn/how-to/install-bmad.md` and `docs/zh-cn/how-to/non-interactive-installation.md`. It standardizes installation wording, parameter terminology, and task flow, and adds clearer guidance for prerelease installs and skills enablement.
> 本次 PR 修订了 `docs/zh-cn/how-to/install-bmad.md` 与 `docs/zh-cn/how-to/non-interactive-installation.md` 两篇中文安装指南。重点是统一安装场景说明、参数术语和步骤表达，并补齐预发布安装与 skills 启用提示。

## Why
The previous Chinese installation docs had inconsistencies in terminology and setup instructions across interactive vs non-interactive scenarios, which could cause user confusion during onboarding. This change improves executability and consistency while keeping semantic parity with the English source.  
Fixes `#issue_number` (if applicable)
> 现有中文安装文档在术语、参数描述和安装路径表达上存在不一致，容易让用户在交互式与非交互式场景间产生理解偏差。该改动用于提升中文文档的可执行性与一致性，并与英文源文保持语义对齐。  
Fixes `#issue_number`（如适用）

## How
- Refined the interactive install guide by adding `@next` prerelease install guidance, a skills enablement note, and a clearer “What You Get” structure section.  
- Standardized “flags/parameters” terminology in the non-interactive guide and improved validation/error-handling wording, including clearer `Invalid directory` troubleshooting.  
- Removed redundant glossary appendices from both pages to keep the how-to guides focused on actionable installation tasks.  
> - 更新交互式安装指南文案：补充 `@next` 预发布安装说明、增加 skills 启用提示，并优化“你将获得”目录结构示例。  
> - 统一非交互式安装文档中“标志/参数”表述，修正参数校验与错误处理章节，明确 `Invalid directory` 等常见问题提示。  
> - 清理两篇文档末尾冗余术语附录，保持 how-to 文档聚焦于安装任务本身。  


## Testing
Ran `npm ci && npm run quality` successfully. This includes format checks, linting, docs build, installation component tests, reference validation, and skill validation.
> 已执行 `npm ci && npm run quality`，检查通过。该流程覆盖格式检查、lint、文档构建、安装组件测试、引用校验与技能校验。