### PR TITLE
refactor(quick-dev): replace unconditional artifact scan with intent cascade

### DIFF
--- a/src/bmm-skills/4-implementation/bmad-quick-dev/step-01-clarify-and-route.md
+++ b/src/bmm-skills/4-implementation/bmad-quick-dev/step-01-clarify-and-route.md
@@ -15,13 +15,27 @@ spec_file: '' # set at runtime for plan-code-review before leaving this step
 - The user chose this workflow on purpose. Later steps (e.g. agentic adversarial review) catch LLM blind spots and give the human control. Do not skip them.
 - **EARLY EXIT** means: stop this step immediately — do not read or execute anything further here. Read and fully follow the target file instead. Return here ONLY if a later step explicitly says to loop back.
 
-## ARTIFACT SCAN
+## Intent check (do this first)
 
-- `{wipFile}` exists? → Offer resume or archive.
-- Active specs (`ready-for-dev`, `in-progress`, `in-review`) in `{implementation_artifacts}`? → List them and HALT. Ask user which to resume (or `[N]` for new).
-  - If `ready-for-dev` or `in-progress` selected: Set `spec_file`. **EARLY EXIT** → `./step-03-implement.md`
-  - If `in-review` selected: Set `spec_file`. **EARLY EXIT** → `./step-04-review.md`
-- Unformatted spec or intent file lacking `status` frontmatter in `{implementation_artifacts}`? → Suggest to the user to treat its contents as the starting intent for this workflow. DO NOT attempt to infer a state and resume it.
+Before listing artifacts or prompting the user, check whether you already know the intent. Check in this order — skip the remaining checks as soon as the intent is clear:
+
+1. Explicit argument
+   Did the user pass a specific file path, spec name, or clear instruction this message?
+   - If it points to a file that matches the tech-spec template (has `status` frontmatter with a recognized value: ready-for-dev, in-progress, or in-review) → set `spec_file` and **EARLY EXIT** to the appropriate step (step-03 for ready/in-progress, step-04 for review).
+   - Anything else (intent files, external docs, plans, descriptions) → ingest it as starting intent and proceed to INSTRUCTIONS. Do not attempt to infer a workflow state from it.
+
+2. Recent conversation
+   Do the last few human messages clearly show what the user intends to work on?
+   Use the same routing as above.
+
+3. Otherwise — scan artifacts and ask
+   - `{wipFile}` exists? → Offer resume or archive.
+   - Active specs (`ready-for-dev`, `in-progress`, `in-review`) in `{implementation_artifacts}`? → List them and HALT. Ask user which to resume (or `[N]` for new).
+     - If `ready-for-dev` or `in-progress` selected: Set `spec_file`. **EARLY EXIT** → `./step-03-implement.md`
+     - If `in-review` selected: Set `spec_file`. **EARLY EXIT** → `./step-04-review.md`
+   - Unformatted spec or intent file lacking `status` frontmatter? → Suggest treating its contents as the starting intent. Do NOT attempt to infer a state and resume it.
+
+Never ask extra questions if you already understand what the user intends.
 
 ## INSTRUCTIONS
 


### PR DESCRIPTION
## Summary

quick-devs step-01 used to run a full artifact scan on every invocation -- listing active specs and halting for input even when the user already said what they want. This adds an intent check that short-circuits that scan:

1. **Explicit argument** -- user passed a file or instruction. Use it directly. Only EARLY EXITs for files that match the tech-spec template shape (proper status frontmatter). Everything else is treated as starting intent.
2. **Recent conversation** -- last few messages make intent obvious. Use that.
3. **Artifact scan** -- nothing clear. Run the original scan with all existing behaviors (wipFile, active spec listing, unformatted file suggestion).

The scan still exists and works the same way -- it just doesnt fire when its not needed.

## Test plan

- [ ] /bmad-quick-dev intent-foo.md -- resolves from argument, no scan prompt
- [ ] /bmad-quick-dev spec-something.md (with status: ready-for-dev) -- EARLY EXITs to step-03
- [ ] /bmad-quick-dev after discussing a spec in conversation -- resolves from context
- [ ] /bmad-quick-dev cold, no context -- falls through to full artifact scan as before
- [ ] /bmad-quick-dev random-doc.md (no status frontmatter) -- treated as starting intent, not routed