### PR TITLE
fix(quick-dev): preserve tracking identifiers in spec slug

### DIFF
--- a/src/bmm-skills/4-implementation/bmad-quick-dev/step-01-clarify-and-route.md
+++ b/src/bmm-skills/4-implementation/bmad-quick-dev/step-01-clarify-and-route.md
@@ -56,7 +56,7 @@ Never ask extra questions if you already understand what the user intends.
    **EARLY EXIT** → `./step-oneshot.md`
 
    **b) Plan-code-review** — everything else. When uncertain whether blast radius is truly zero, choose this path.
-   1. Derive a valid kebab-case slug from the clarified intent. If `{implementation_artifacts}/tech-spec-{slug}.md` already exists, append `-2`, `-3`, etc. Set `spec_file` = `{implementation_artifacts}/tech-spec-{slug}.md`.
+   1. Derive a valid kebab-case slug from the clarified intent. If the intent references a tracking identifier (story number, issue number, ticket ID), lead the slug with it (e.g. `3-2-digest-delivery`, `gh-47-fix-auth`). If `{implementation_artifacts}/tech-spec-{slug}.md` already exists, append `-2`, `-3`, etc. Set `spec_file` = `{implementation_artifacts}/tech-spec-{slug}.md`.
 
 
 ## NEXT


### PR DESCRIPTION
## Summary
- Step-01 slug derivation now instructs the LLM to lead with tracking identifiers (story numbers, issue IDs, ticket IDs) when present
- Tightened from "numbered" to "tracking" to avoid false positives on domain numbers (retries, 2FA, HTTP codes)
- Added inline examples (`3-2-digest-delivery`, `gh-47-fix-auth`) to anchor consistent behavior

## Test plan
- [ ] Invoke quick-dev with an intent referencing a story number (e.g. "story 3-2: add digest delivery") — slug should lead with `3-2`
- [ ] Invoke quick-dev with an intent containing incidental numbers (e.g. "add 3 retries") — slug should NOT lead with `3`
- [ ] Invoke quick-dev with a GitHub issue reference (e.g. "GH-47 fix auth") — slug should lead with `gh-47`

🤖 Generated with [Claude Code](https://claude.com/claude-code)