### PR TITLE
fix(quick-dev): remove redundant H1 title from spec template

### DIFF
--- a/src/bmm-skills/4-implementation/bmad-quick-dev/spec-template.md
+++ b/src/bmm-skills/4-implementation/bmad-quick-dev/spec-template.md
@@ -11,8 +11,6 @@ context: [] # optional: max 3 project-wide standards/docs. NO source code files.
      Cohesive cross-layer stories (DB+BE+UI) stay in ONE file.
      IMPORTANT: Remove all HTML comments when filling this template. -->
 
-# {title}
-
 <frozen-after-approval reason="human-owned intent — do not modify unless human renegotiates">
 
 ## Intent


### PR DESCRIPTION
## Summary

- Removed the duplicate `# {title}` H1 heading from `spec-template.md` — the frontmatter `title` field is the single source of truth
- No structural dependencies on the H1 exist anywhere in the codebase (workflow steps, parsers, other templates)

## Test plan

- [x] `npm run quality` passes (227 tests, all linters, docs build, ref validation, skill validation)
- [x] Adversarial review confirmed zero breakage risk

🤖 Generated with [Claude Code](https://claude.com/claude-code)