### PR TITLE
fix: add consumer propagation check to bmad-quick-dev workflow

### DIFF
--- a/src/bmm-skills/4-implementation/bmad-quick-dev/step-02-plan.md
+++ b/src/bmm-skills/4-implementation/bmad-quick-dev/step-02-plan.md
@@ -12,7 +12,7 @@ deferred_work_file: '{implementation_artifacts}/deferred-work.md'
 
 ## INSTRUCTIONS
 
-1. Investigate codebase. _Isolate deep exploration in sub-agents/tasks where available. To prevent context snowballing, instruct subagents to give you distilled summaries only._
+1. Investigate codebase. _Isolate deep exploration in sub-agents/tasks where available. To prevent context snowballing, instruct subagents to give you distilled summaries only._ If the approach introduces new type variants, error codes, or DB values: grep all consumers of the parent type/column and annotate each in the Code Map as `consumer — update required` or `consumer — excluded (reason)`.
 2. Read `./spec-template.md` fully. Fill it out based on the intent and investigation, and write the result to `{wipFile}`.
 3. Self-review against READY FOR DEVELOPMENT standard.
 4. If intent gaps exist, do not fantasize, do not leave open questions, HALT and ask the human.

--- a/src/bmm-skills/4-implementation/bmad-quick-dev/step-02-plan.md
+++ b/src/bmm-skills/4-implementation/bmad-quick-dev/step-02-plan.md
@@ -12,7 +12,7 @@ deferred_work_file: '{implementation_artifacts}/deferred-work.md'
 
 ## INSTRUCTIONS
 
-1. Investigate codebase. _Isolate deep exploration in sub-agents/tasks where available. To prevent context snowballing, instruct subagents to give you distilled summaries only._ If the approach introduces new type variants, error codes, or DB values: grep all consumers of the parent type/column and annotate each in the Code Map as `consumer — update required` or `consumer — excluded (reason)`.
+1. Investigate codebase. _Isolate deep exploration in sub-agents/tasks where available. To prevent context snowballing, instruct subagents to give you distilled summaries only._ If the approach introduces new type variants, error codes, or DB values: grep all consumers of the parent type/column and annotate each in the Code Map as `consumer — update required` or `consumer — excluded (reason)`. If no consumers exist, note `consumer — none found`.
 2. Read `./spec-template.md` fully. Fill it out based on the intent and investigation, and write the result to `{wipFile}`.
 3. Self-review against READY FOR DEVELOPMENT standard.
 4. If intent gaps exist, do not fantasize, do not leave open questions, HALT and ask the human.

--- a/src/bmm-skills/4-implementation/bmad-quick-dev/step-03-implement.md
+++ b/src/bmm-skills/4-implementation/bmad-quick-dev/step-03-implement.md
@@ -14,7 +14,7 @@
 
 Verify `{spec_file}` resolves to a non-empty path and the file exists on disk. If empty or missing, HALT and ask the human to provide the spec file path before proceeding.
 
-If the spec introduces new type variants, error codes, or DB values and the Code Map has no `consumer —` annotations, HALT — consumer tracing was missed in planning.
+If the spec introduces new type variants, error codes, or DB values and the Code Map has no `consumer —` annotations, perform consumer tracing now before proceeding.
 
 ## INSTRUCTIONS
 

--- a/src/bmm-skills/4-implementation/bmad-quick-dev/step-03-implement.md
+++ b/src/bmm-skills/4-implementation/bmad-quick-dev/step-03-implement.md
@@ -14,8 +14,6 @@
 
 Verify `{spec_file}` resolves to a non-empty path and the file exists on disk. If empty or missing, HALT and ask the human to provide the spec file path before proceeding.
 
-If the spec introduces new type variants, error codes, or DB values and the Code Map has no `consumer —` annotations, perform consumer tracing now before proceeding.
-
 ## INSTRUCTIONS
 
 ### Baseline

--- a/src/bmm-skills/4-implementation/bmad-quick-dev/step-03-implement.md
+++ b/src/bmm-skills/4-implementation/bmad-quick-dev/step-03-implement.md
@@ -14,7 +14,7 @@
 
 Verify `{spec_file}` resolves to a non-empty path and the file exists on disk. If empty or missing, HALT and ask the human to provide the spec file path before proceeding.
 
-If the spec introduces new type variants, error codes, or DB values and the Code Map has no consumer annotations, HALT — consumer tracing was missed in planning.
+If the spec introduces new type variants, error codes, or DB values and the Code Map has no `consumer —` annotations, HALT — consumer tracing was missed in planning.
 
 ## INSTRUCTIONS
 

--- a/src/bmm-skills/4-implementation/bmad-quick-dev/step-03-implement.md
+++ b/src/bmm-skills/4-implementation/bmad-quick-dev/step-03-implement.md
@@ -14,6 +14,8 @@
 
 Verify `{spec_file}` resolves to a non-empty path and the file exists on disk. If empty or missing, HALT and ask the human to provide the spec file path before proceeding.
 
+If the spec introduces new type variants, error codes, or DB values and the Code Map has no consumer annotations, HALT — consumer tracing was missed in planning.
+
 ## INSTRUCTIONS
 
 ### Baseline


### PR DESCRIPTION
## What

Adds consumer propagation tracing to the bmad-quick-dev workflow. Two additions (~388 chars) across step-02 and step-03.

## Why

When introducing new type variants, error codes, or DB values, the workflow's Code Map only covers files being directly modified. Consumers of the parent type/column in other modules are missed during planning, leading to regressions that the review step misclassifies as pre-existing issues. Discovered during a real bugfix where a new error variant (`FETCH_NOT_PRINTABLE`) broke an untraced consumer's error mapping.

## How

- **step-02-plan.md**: Consumer tracing instruction — grep all consumers of new types/columns during investigation, annotate in Code Map as `consumer — update required` or `consumer — excluded (reason)`.
- **step-03-implement.md**: Precondition gate — HALT if spec introduces new values but Code Map has no consumer annotations (catches missed step-02 tracing).

## Testing

Validated against the incident that exposed the gap. With these changes, step-02 would have enumerated 4 missing consumers, and step-03 would have HALTed if step-02 was skipped.

Fixes #2122