### PR TITLE
fix: update bmb module-definition path

### DIFF
--- a/tools/cli/external-official-modules.yaml
+++ b/tools/cli/external-official-modules.yaml
@@ -4,7 +4,7 @@
 modules:
   bmad-builder:
     url: https://github.com/bmad-code-org/bmad-builder
-    module-definition: src/module.yaml
+    module-definition: skills/module.yaml
     code: bmb
     name: "BMad Builder"
     description: "Agent and Builder"


### PR DESCRIPTION
## Summary

- Update `module-definition` for bmad-builder from `src/module.yaml` to `skills/module.yaml`

bmad-builder v1.2.0 moved skills from `src/skills/` to `skills/` at repo root for Claude Code plugin and Vercel Skills CLI compatibility (bmad-code-org/bmad-builder#39).

## Test plan

- [ ] `npx bmad-method install` with bmb module selected resolves skills correctly