### PR TITLE
chore: add v6.2.2 changelog and use CHANGELOG.md for GH release notes

### DIFF
--- a/.github/workflows/publish.yaml
+++ b/.github/workflows/publish.yaml
@@ -120,7 +120,18 @@ jobs:
         if: github.event_name == 'workflow_dispatch' && inputs.channel == 'latest'
         run: |
           TAG="v$(node -p 'require("./package.json").version')"
-          gh release create "$TAG" --generate-notes
+          VERSION="${TAG#v}"
+          # Extract the current version's section from CHANGELOG.md
+          BODY=$(awk -v ver="$VERSION" '
+            /^## v/ { if (found) exit; if (index($0, "## v" ver)) found=1; next }
+            found { print }
+          ' CHANGELOG.md)
+          if [ -z "$BODY" ]; then
+            echo "::warning::No CHANGELOG.md entry for $TAG — falling back to auto-generated notes"
+            gh release create "$TAG" --generate-notes
+          else
+            gh release create "$TAG" --notes "$BODY"
+          fi
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,21 @@
 # Changelog
 
+## v6.2.2 - 2026-03-25
+
+### ♻️ Refactoring
+
+* Modernize module-help CSV to 13-column format with `after`/`before` dependency graph replacing sequence numbers (#2120)
+* Rewrite bmad-help from procedural 8-step execution to outcome-based skill design (~50% shorter) (#2120)
+
+### 🐛 Bug Fixes
+
+* Update bmad-builder module-definition path from `src/module.yaml` to `skills/module.yaml` for bmad-builder v1.2.0 compatibility (#2126)
+* Fix eslint config to ignore gitignored lock files (#2120)
+
+### 📚 Documentation
+
+* Close Epic 4.5 explanation gaps in Chinese (zh-CN): normalize command naming to current `bmad-*` convention and add cross-links across 9 explanation pages (#2102)
+
 ## v6.2.1 - 2026-03-24
 
 ### 🎁 Highlights


### PR DESCRIPTION
## Summary

- Add v6.2.2 changelog entry covering #2120, #2126, #2102
- Update publish workflow to extract release notes from CHANGELOG.md instead of `--generate-notes`, with fallback if no entry found

This ensures GitHub Releases always use the curated changelog content rather than auto-generated commit lists.

## Test plan

- [x] All existing tests pass (243/243)
- [ ] Verify `awk` extraction logic against CHANGELOG.md format
- [ ] Trigger a `latest` publish and confirm GH release body matches changelog