### PR TITLE
fix: revert bmb module-definition path to src/module.yaml

### DIFF
--- a/tools/installer/external-official-modules.yaml
+++ b/tools/installer/external-official-modules.yaml
@@ -4,7 +4,7 @@
 modules:
   bmad-builder:
     url: https://github.com/bmad-code-org/bmad-builder
-    module-definition: skills/module.yaml
+    module-definition: src/module.yaml
     code: bmb
     name: "BMad Builder"
     description: "Agent and Builder"


### PR DESCRIPTION
## Summary

- Reverts bmb module-definition path from `skills/module.yaml` back to `src/module.yaml` in the external modules manifest

bmad-builder reverted its `skills/` directory back to `src/` for installer compatibility (bmad-code-org/bmad-builder#40, bmad-code-org/bmad-builder#43). This updates the manifest to match.

## Test plan

- [ ] Run installer with bmb module selected — should find `src/module.yaml` in the cloned repo

🤖 Generated with [Claude Code](https://claude.com/claude-code)