### PR TITLE
fix: support skills/ folder as module source location

### DIFF
--- a/tools/installer/external-official-modules.yaml
+++ b/tools/installer/external-official-modules.yaml
@@ -4,7 +4,7 @@
 modules:
   bmad-builder:
     url: https://github.com/bmad-code-org/bmad-builder
-    module-definition: src/module.yaml
+    module-definition: skills/module.yaml
     code: bmb
     name: "BMad Builder"
     description: "Agent and Builder"

--- a/tools/installer/modules/external-manager.js
+++ b/tools/installer/modules/external-manager.js
@@ -313,10 +313,41 @@ class ExternalModuleManager {
 
     // The module-definition specifies the path to module.yaml relative to repo root
     // We need to return the directory containing module.yaml
-    const moduleDefinitionPath = moduleInfo.moduleDefinition; // e.g., 'src/module.yaml'
-    const moduleDir = path.dirname(path.join(cloneDir, moduleDefinitionPath));
+    const moduleDefinitionPath = moduleInfo.moduleDefinition; // e.g., 'skills/module.yaml'
+    const configuredPath = path.join(cloneDir, moduleDefinitionPath);
 
-    return moduleDir;
+    if (await fs.pathExists(configuredPath)) {
+      return path.dirname(configuredPath);
+    }
+
+    // Fallback: search skills/ and src/ (root level and one level deep for subfolders)
+    for (const dir of ['skills', 'src']) {
+      const rootCandidate = path.join(cloneDir, dir, 'module.yaml');
+      if (await fs.pathExists(rootCandidate)) {
+        return path.dirname(rootCandidate);
+      }
+      const dirPath = path.join(cloneDir, dir);
+      if (await fs.pathExists(dirPath)) {
+        const entries = await fs.readdir(dirPath, { withFileTypes: true });
+        for (const entry of entries) {
+          if (entry.isDirectory()) {
+            const subCandidate = path.join(dirPath, entry.name, 'module.yaml');
+            if (await fs.pathExists(subCandidate)) {
+              return path.dirname(subCandidate);
+            }
+          }
+        }
+      }
+    }
+
+    // Check repo root as last fallback
+    const rootCandidate = path.join(cloneDir, 'module.yaml');
+    if (await fs.pathExists(rootCandidate)) {
+      return path.dirname(rootCandidate);
+    }
+
+    // Nothing found: return configured path (preserves old behavior for error messaging)
+    return path.dirname(configuredPath);
   }
 }
 


### PR DESCRIPTION
## Summary
- Updates bmb `module-definition` from `src/module.yaml` to `skills/module.yaml` to match its actual repo structure
- Adds fallback discovery in `findExternalModuleSource`: when the configured `module-definition` path doesn't exist, searches `skills/` and `src/` (both root-level and one subdirectory deep) before falling back to repo root
- Fixes bmb installation errors caused by the installer only looking under `src/`

## Test plan
- [x] All 205 existing tests pass
- [ ] Install bmb module via `bmad install` and verify it resolves `skills/module.yaml`
- [ ] Verify other external modules (cis, gds, tea, wds) still resolve via `src/module.yaml`