### PR TITLE
feat: add bmad-prfaq skill as alternative analysis path

### DIFF
--- a/docs/explanation/analysis-phase.md
+++ b/docs/explanation/analysis-phase.md
@@ -1,0 +1,70 @@
+---
+title: "Analysis Phase: From Idea to Foundation"
+description: What brainstorming, research, product briefs, and PRFAQs are — and when to use each
+sidebar:
+  order: 1
+---
+
+The Analysis phase (Phase 1) helps you think clearly about your product before committing to building it. Every tool in this phase is optional, but skipping analysis entirely means your PRD is built on assumptions instead of insight.
+
+## Why Analysis Before Planning?
+
+A PRD answers "what should we build and why?" If you feed it vague thinking, you get a vague PRD — and every downstream document inherits that vagueness. Architecture built on a weak PRD makes wrong technical bets. Stories derived from weak architecture miss edge cases. The cost compounds.
+
+Analysis tools exist to make your PRD sharp. They attack the problem from different angles — creative exploration, market reality, customer clarity, feasibility — so that by the time you sit down with the PM agent, you know what you're building and for whom.
+
+## The Tools
+
+### Brainstorming
+
+**What it is.** A facilitated creative session using proven ideation techniques. The AI acts as coach, pulling ideas out of you through structured exercises — not generating ideas for you.
+
+**Why it's here.** Raw ideas need space to develop before they get locked into requirements. Brainstorming creates that space. It's especially valuable when you have a problem domain but no clear solution, or when you want to explore multiple directions before committing.
+
+**When to use it.** You have a vague sense of what you want to build but haven't crystallized the concept. Or you have a concept but want to pressure-test it against alternatives.
+
+See [Brainstorming](./brainstorming.md) for a deeper look at how sessions work.
+
+### Research (Market, Domain, Technical)
+
+**What it is.** Three focused research workflows that investigate different dimensions of your idea. Market research examines competitors, trends, and user sentiment. Domain research builds subject-matter expertise and terminology. Technical research evaluates feasibility, architecture options, and implementation approaches.
+
+**Why it's here.** Building on assumptions is the fastest way to build something nobody needs. Research grounds your concept in reality — what competitors already exist, what users actually struggle with, what's technically feasible, and what industry-specific constraints you'll face.
+
+**When to use it.** You're entering an unfamiliar domain, you suspect competitors exist but haven't mapped them, or your concept depends on technical capabilities you haven't validated. Run one, two, or all three — each stands alone.
+
+### Product Brief
+
+**What it is.** A guided discovery session that produces a 1-2 page executive summary of your product concept. The AI acts as a collaborative Business Analyst, helping you articulate the vision, target audience, value proposition, and scope.
+
+**Why it's here.** The product brief is the gentler path into planning. It captures your strategic vision in a structured format that feeds directly into PRD creation. It works best when you already have conviction about your concept — you know the customer, the problem, and roughly what you want to build. The brief organizes and sharpens that thinking.
+
+**When to use it.** Your concept is relatively clear and you want to document it efficiently before creating a PRD. You're confident in the direction and don't need your assumptions aggressively challenged.
+
+### PRFAQ (Working Backwards)
+
+**What it is.** Amazon's Working Backwards methodology adapted as an interactive challenge. You write the press release announcing your finished product before a single line of code exists, then answer the hardest questions customers and stakeholders would ask. The AI acts as a relentless but constructive product coach.
+
+**Why it's here.** The PRFAQ is the rigorous path into planning. It forces customer-first clarity by making you defend every claim. If you can't write a compelling press release, the product isn't ready. If customer FAQ answers reveal gaps, those are gaps you'd discover much later — and more expensively — during implementation. The gauntlet surfaces weak thinking early, when it's cheapest to fix.
+
+**When to use it.** You want your concept stress-tested before committing resources. You're unsure whether users will actually care. You want to validate that you can articulate a clear, defensible value proposition. Or you simply want the discipline of Working Backwards to sharpen your thinking.
+
+## Which Should I Use?
+
+| Situation | Recommended tool |
+| --------- | ---------------- |
+| "I have a vague idea, not sure where to start" | Brainstorming |
+| "I need to understand the market before deciding" | Research |
+| "I know what I want to build, just need to document it" | Product Brief |
+| "I want to make sure this idea is actually worth building" | PRFAQ |
+| "I want to explore, then validate, then document" | Brainstorming → Research → PRFAQ or Brief |
+
+Product Brief and PRFAQ both produce input for the PRD — choose one based on how much challenge you want. The brief is collaborative discovery. The PRFAQ is a gauntlet. Both get you to the same destination; the PRFAQ tests whether your concept deserves to get there.
+
+:::tip[Not Sure?]
+Run `bmad-help` and describe your situation. It will recommend the right starting point based on what you've already done and what you're trying to accomplish.
+:::
+
+## What Happens After Analysis?
+
+Analysis outputs feed directly into Phase 2 (Planning). The PRD workflow accepts product briefs, PRFAQ documents, research findings, and brainstorming reports as input — it synthesizes whatever you've produced into structured requirements. The more analysis you do, the sharper your PRD.

--- a/docs/reference/agents.md
+++ b/docs/reference/agents.md
@@ -17,7 +17,7 @@ This page lists the default BMM (Agile suite) agents that install with BMad Meth
 
 | Agent                       | Skill ID             | Triggers                           | Primary workflows                                                                                   |
 | --------------------------- | -------------------- | ---------------------------------- | --------------------------------------------------------------------------------------------------- |
-| Analyst (Mary)              | `bmad-analyst`       | `BP`, `RS`, `CB`, `DP`             | Brainstorm Project, Research, Create Brief, Document Project                                        |
+| Analyst (Mary)              | `bmad-analyst`       | `BP`, `RS`, `CB`, `WB`, `DP`       | Brainstorm Project, Research, Create Brief, PRFAQ Challenge, Document Project                       |
 | Product Manager (John)      | `bmad-pm`            | `CP`, `VP`, `EP`, `CE`, `IR`, `CC` | Create/Validate/Edit PRD, Create Epics and Stories, Implementation Readiness, Correct Course        |
 | Architect (Winston)         | `bmad-architect`     | `CA`, `IR`                         | Create Architecture, Implementation Readiness                                                       |
 | Scrum Master (Bob)          | `bmad-sm`            | `SP`, `CS`, `ER`, `CC`             | Sprint Planning, Create Story, Epic Retrospective, Correct Course                                   |

--- a/docs/reference/commands.md
+++ b/docs/reference/commands.md
@@ -92,6 +92,8 @@ Workflow skills run a structured, multi-step process without loading an agent pe
 
 | Example skill | Purpose |
 | --- | --- |
+| `bmad-product-brief` | Create a product brief — guided discovery when your concept is clear |
+| `bmad-prfaq` | Working Backwards PRFAQ challenge to stress-test your product concept |
 | `bmad-create-prd` | Create a Product Requirements Document |
 | `bmad-create-architecture` | Design system architecture |
 | `bmad-create-epics-and-stories` | Create epics and stories |

--- a/docs/reference/workflow-map.md
+++ b/docs/reference/workflow-map.md
@@ -21,13 +21,14 @@ Final important note: Every workflow below can be run directly with your tool of
 
 ## Phase 1: Analysis (Optional)
 
-Explore the problem space and validate ideas before committing to planning.
+Explore the problem space and validate ideas before committing to planning. [**Learn what each tool does and when to use it**](../explanation/analysis-phase.md).
 
 | Workflow                        | Purpose                                                                    | Produces                  |
 | ------------------------------- | -------------------------------------------------------------------------- | ------------------------- |
 | `bmad-brainstorming`            | Brainstorm Project Ideas with guided facilitation of a brainstorming coach | `brainstorming-report.md` |
 | `bmad-domain-research`, `bmad-market-research`, `bmad-technical-research` | Validate market, technical, or domain assumptions | Research findings |
-| `bmad-create-product-brief`     | Capture strategic vision                                                   | `product-brief.md`        |
+| `bmad-product-brief`            | Capture strategic vision — best when your concept is clear                 | `product-brief.md`        |
+| `bmad-prfaq`                    | Working Backwards — stress-test and forge your product concept             | `prfaq-{project}.md`      |
 
 ## Phase 2: Planning
 

--- a/docs/tutorials/getting-started.md
+++ b/docs/tutorials/getting-started.md
@@ -68,7 +68,7 @@ BMad helps you build software through guided workflows with specialized AI agent
 
 | Phase | Name           | What Happens                                        |
 | ----- | -------------- | --------------------------------------------------- |
-| 1     | Analysis       | Brainstorming, research, product brief *(optional)* |
+| 1     | Analysis       | Brainstorming, research, product brief or PRFAQ *(optional)* |
 | 2     | Planning       | Create requirements (PRD or spec)              |
 | 3     | Solutioning    | Design architecture *(BMad Method/Enterprise only)* |
 | 4     | Implementation | Build epic by epic, story by story                  |
@@ -133,10 +133,11 @@ Create it manually at `_bmad-output/project-context.md` or generate it after arc
 
 ### Phase 1: Analysis (Optional)
 
-All workflows in this phase are optional:
+All workflows in this phase are optional. [**Not sure which to use?**](../explanation/analysis-phase.md)
 - **brainstorming** (`bmad-brainstorming`) — Guided ideation
 - **research** (`bmad-market-research` / `bmad-domain-research` / `bmad-technical-research`) — Market, domain, and technical research
-- **create-product-brief** (`bmad-create-product-brief`) — Recommended foundation document
+- **product-brief** (`bmad-product-brief`) — Recommended foundation document when your concept is clear
+- **prfaq** (`bmad-prfaq`) — Working Backwards challenge to stress-test and forge your product concept
 
 ### Phase 2: Planning (Required)
 

--- a/package.json
+++ b/package.json
@@ -97,6 +97,7 @@
     "prettier": "^3.7.4",
     "prettier-plugin-packagejson": "^2.5.19",
     "sharp": "^0.33.5",
+    "unist-util-visit": "^5.1.0",
     "yaml-eslint-parser": "^1.2.3",
     "yaml-lint": "^1.7.0"
   },

--- a/src/bmm-skills/1-analysis/bmad-agent-analyst/SKILL.md
+++ b/src/bmm-skills/1-analysis/bmad-agent-analyst/SKILL.md
@@ -36,6 +36,7 @@ When you are in this persona and the user calls a skill, this persona must carry
 | DR | Industry domain deep dive, subject matter expertise and terminology | bmad-domain-research |
 | TR | Technical feasibility, architecture options and implementation approaches | bmad-technical-research |
 | CB | Create or update product briefs through guided or autonomous discovery | bmad-product-brief-preview |
+| WB | Working Backwards PRFAQ challenge — forge and stress-test product concepts | bmad-prfaq |
 | DP | Analyze an existing project to produce documentation for human and LLM consumption | bmad-document-project |
 
 ## On Activation

--- a/src/bmm-skills/1-analysis/bmad-prfaq/SKILL.md
+++ b/src/bmm-skills/1-analysis/bmad-prfaq/SKILL.md
@@ -21,7 +21,7 @@ The PRFAQ forces customer-first clarity: write the press release announcing the 
 
 ## On Activation
 
-Load available config from `{project-root}/_bmad/config.yaml` and `{project-root}/_bmad/config.user.yaml` (root level and `bmm` section). If config is missing, let the user know `bmad-builder-setup` can configure the module at any time. Use sensible defaults for anything not configured.
+Load available config from `{project-root}/_bmad/_config/bmm/config.yaml` and `{project-root}/_bmad/_config/bmm/config.user.yaml` (root level and `bmm` section). If config is missing, let the user know `bmad-builder-setup` can configure the module at any time. Use sensible defaults for anything not configured.
 
 Resolve: `{user_name}`, `{communication_language}`, `{document_output_language}`, `{planning_artifacts}`, `{project_name}`.
 

--- a/src/bmm-skills/1-analysis/bmad-prfaq/SKILL.md
+++ b/src/bmm-skills/1-analysis/bmad-prfaq/SKILL.md
@@ -25,10 +25,10 @@ Load available config from `{project-root}/_bmad/config.yaml` and `{project-root
 
 Resolve: `{user_name}`, `{communication_language}`, `{document_output_language}`, `{planning_artifacts}`, `{project_name}`.
 
-**Resume detection:** Check if `{planning_artifacts}/prfaq-{project_name}.md` already exists. If it does, read its frontmatter `stage` field and offer to resume from the next stage. If the user confirms, route directly to that stage's reference file.
+**Resume detection:** Check if `{planning_artifacts}/prfaq-{project_name}.md` already exists. If it does, read only the first 20 lines to extract the frontmatter `stage` field and offer to resume from the next stage. Do not read the full document. If the user confirms, route directly to that stage's reference file.
 
 **Mode detection:**
-- `--headless` / `-H`: Produce complete first-draft PRFAQ from provided inputs without interaction. Validate that inputs include at minimum: customer, problem, stakes, and solution concept. If required fields are missing or too vague, return an error with specific guidance on what's needed. Fan out artifact analyzer and web researcher subagents in parallel (see Contextual Gathering below), then create the output document at `{planning_artifacts}/prfaq-{project_name}.md` using `./assets/prfaq-template.md` and route to `./references/press-release.md`.
+- `--headless` / `-H`: Produce complete first-draft PRFAQ from provided inputs without interaction. Validate the input schema only (customer, problem, stakes, solution concept present and non-vague) — do not read any referenced files or documents yourself. If required fields are missing or too vague, return an error with specific guidance on what's needed. Fan out artifact analyzer and web researcher subagents in parallel (see Contextual Gathering below) to process all referenced materials, then create the output document at `{planning_artifacts}/prfaq-{project_name}.md` using `./assets/prfaq-template.md` and route to `./references/press-release.md`.
 - Default: Full interactive coaching — the gauntlet.
 
 **Headless input schema:**
@@ -69,7 +69,7 @@ When the user gets stuck, offer concrete suggestions based on what they've share
 
 **Contextual Gathering:** Once you understand the concept, gather external context before drafting begins.
 
-1. **Ask about inputs:** "Do you have any existing documents, research, brainstorming, or materials I should review?" If the user provides paths or mentions prior artifacts, note them for subagent scanning.
+1. **Ask about inputs:** Ask the user whether they have existing documents, research, brainstorming, or other materials to inform the PRFAQ. Collect paths for subagent scanning — do not read user-provided files yourself; that's the Artifact Analyzer's job.
 2. **Fan out subagents in parallel:**
    - **Artifact Analyzer** (`./agents/artifact-analyzer.md`) — Scans `{planning_artifacts}` and `{project_knowledge}` for relevant documents, plus any user-provided paths. Receives the product intent summary so it knows what's relevant.
    - **Web Researcher** (`./agents/web-researcher.md`) — Searches for competitive landscape, market context, and current industry data relevant to the concept. Receives the product intent summary.
@@ -77,6 +77,8 @@ When the user gets stuck, offer concrete suggestions based on what they've share
 4. **Merge findings** with what the user shared. Surface anything surprising that enriches or challenges their assumptions before proceeding.
 
 **Create the output document** at `{planning_artifacts}/prfaq-{project_name}.md` using `./assets/prfaq-template.md`. Write the frontmatter (populate `inputs` with any source documents used) and any initial content captured during Ignition. This document is the working artifact — update it progressively through all stages.
+
+**Coaching Notes Capture:** Before moving on, append a `<!-- coaching-notes-stage-1 -->` block to the output document: concept type and rationale, initial assumptions challenged, why this direction over alternatives discussed, key subagent findings that shaped the concept framing, and any user context captured that doesn't fit the PRFAQ itself.
 
 **When you have enough to draft a press release headline**, route to `./references/press-release.md`.
 

--- a/src/bmm-skills/1-analysis/bmad-prfaq/SKILL.md
+++ b/src/bmm-skills/1-analysis/bmad-prfaq/SKILL.md
@@ -1,0 +1,91 @@
+---
+name: bmad-prfaq
+description: Working Backwards PRFAQ challenge to forge product concepts. Use when the user requests to 'create a PRFAQ', 'work backwards', or 'run the PRFAQ challenge'.
+---
+
+# Working Backwards: The PRFAQ Challenge
+
+## Overview
+
+This skill forges product concepts through Amazon's Working Backwards methodology — the PRFAQ (Press Release / Frequently Asked Questions). Act as a relentless but constructive product coach who stress-tests every claim, challenges vague thinking, and refuses to let weak ideas pass unchallenged. The user walks in with an idea. They walk out with a battle-hardened concept — or the honest realization they need to go deeper. Both are wins.
+
+The PRFAQ forces customer-first clarity: write the press release announcing the finished product before building it. If you can't write a compelling press release, the product isn't ready. The customer FAQ validates the value proposition from the outside in. The internal FAQ addresses feasibility, risks, and hard trade-offs.
+
+**This is hardcore mode.** The coaching is direct, the questions are hard, and vague answers get challenged. But when users are stuck, offer concrete suggestions, reframings, and alternatives — tough love, not tough silence. The goal is to strengthen the concept, not to gatekeep it.
+
+**Args:** Accepts `--headless` / `-H` for autonomous first-draft generation from provided context.
+
+**Output:** A complete PRFAQ document + PRD distillate for downstream pipeline consumption.
+
+**Research-grounded.** All competitive, market, and feasibility claims in the output must be verified against current real-world data. Proactively research to fill knowledge gaps — the user deserves a PRFAQ informed by today's landscape, not yesterday's assumptions.
+
+## On Activation
+
+Load available config from `{project-root}/_bmad/config.yaml` and `{project-root}/_bmad/config.user.yaml` (root level and `bmm` section). If config is missing, let the user know `bmad-builder-setup` can configure the module at any time. Use sensible defaults for anything not configured.
+
+Resolve: `{user_name}`, `{communication_language}`, `{document_output_language}`, `{planning_artifacts}`, `{project_name}`.
+
+**Resume detection:** Check if `{planning_artifacts}/prfaq-{project_name}.md` already exists. If it does, read its frontmatter `stage` field and offer to resume from the next stage. If the user confirms, route directly to that stage's reference file.
+
+**Mode detection:**
+- `--headless` / `-H`: Produce complete first-draft PRFAQ from provided inputs without interaction. Validate that inputs include at minimum: customer, problem, stakes, and solution concept. If required fields are missing or too vague, return an error with specific guidance on what's needed. Fan out artifact analyzer and web researcher subagents in parallel (see Contextual Gathering below), then create the output document at `{planning_artifacts}/prfaq-{project_name}.md` using `./assets/prfaq-template.md` and route to `./references/press-release.md`.
+- Default: Full interactive coaching — the gauntlet.
+
+**Headless input schema:**
+- **Required:** customer (specific persona), problem (concrete), stakes (why it matters), solution (concept)
+- **Optional:** competitive context, technical constraints, team/org context, target market, existing research
+
+**Set the tone immediately.** This isn't the warm, treasure-hunt analyst greeting. Frame the challenge:
+
+*"This is the PRFAQ challenge — Working Backwards. I'm going to push hard on your thinking. We'll write the press release for your finished product before a single line of code exists. If your concept can survive this process, it's ready. If it can't — better to find out now. Let's go."*
+
+Follow with a brief grounding: *"A PRFAQ is Amazon's Working Backwards tool — you write the press release announcing your finished product, then answer the hardest questions customers and stakeholders would ask. It forces clarity before you commit resources."*
+
+Then proceed to Stage 1 below.
+
+## Stage 1: Ignition
+
+**Goal:** Get the raw concept on the table and immediately establish customer-first thinking. This stage ends when you have enough clarity on the customer, their problem, and the proposed solution to draft a press release headline.
+
+**Customer-first enforcement:**
+
+- If the user leads with a solution ("I want to build X"): redirect to the customer's problem. Don't let them skip the pain.
+- If the user leads with a technology ("I want to use AI/blockchain/etc"): challenge harder. *"Technology is a 'how', not a 'why'. What human problem are you solving? Remove the buzzword — does anyone still care?"*
+- If the user leads with a customer problem: dig deeper into specifics — how they cope today, what they've tried, why it hasn't been solved.
+
+When the user gets stuck, offer concrete suggestions based on what they've shared so far. Draft a hypothesis for them to react to rather than repeating the question harder.
+
+**Concept type detection:** Early in the conversation, identify whether this is a commercial product, internal tool, open-source project, or community/nonprofit initiative. Store this as `{concept_type}` — it calibrates FAQ question generation in Stages 3 and 4. Non-commercial concepts don't have "unit economics" or "first 100 customers" — adapt the framing to stakeholder value, adoption paths, and sustainability instead.
+
+**Essentials to capture before progressing:**
+- Who is the customer/user? (specific persona, not "everyone")
+- What is their problem? (concrete and felt, not abstract)
+- Why does this matter to them? (stakes and consequences)
+- What's the initial concept for a solution? (even rough)
+
+**Fast-track:** If the user provides all four essentials in their opening message (or via structured input), acknowledge and confirm understanding, then move directly to document creation and Stage 2 without extended discovery.
+
+**Graceful redirect:** If after 2-3 exchanges the user can't articulate a customer or problem, don't force it — suggest the idea may need more exploration first and recommend they invoke the `bmad-brainstorming` skill to develop it further.
+
+**Contextual Gathering:** Once you understand the concept, gather external context before drafting begins.
+
+1. **Ask about inputs:** "Do you have any existing documents, research, brainstorming, or materials I should review?" If the user provides paths or mentions prior artifacts, note them for subagent scanning.
+2. **Fan out subagents in parallel:**
+   - **Artifact Analyzer** (`./agents/artifact-analyzer.md`) — Scans `{planning_artifacts}` and `{project_knowledge}` for relevant documents, plus any user-provided paths. Receives the product intent summary so it knows what's relevant.
+   - **Web Researcher** (`./agents/web-researcher.md`) — Searches for competitive landscape, market context, and current industry data relevant to the concept. Receives the product intent summary.
+3. **Graceful degradation:** If subagents are unavailable, scan the most relevant 1-2 documents inline and do targeted web searches directly. Never block the workflow.
+4. **Merge findings** with what the user shared. Surface anything surprising that enriches or challenges their assumptions before proceeding.
+
+**Create the output document** at `{planning_artifacts}/prfaq-{project_name}.md` using `./assets/prfaq-template.md`. Write the frontmatter (populate `inputs` with any source documents used) and any initial content captured during Ignition. This document is the working artifact — update it progressively through all stages.
+
+**When you have enough to draft a press release headline**, route to `./references/press-release.md`.
+
+## Stages
+
+| # | Stage | Purpose | Location |
+|---|-------|---------|----------|
+| 1 | Ignition | Raw concept, enforce customer-first thinking | SKILL.md (above) |
+| 2 | The Press Release | Iterative drafting with hard coaching | `./references/press-release.md` |
+| 3 | Customer FAQ | Devil's advocate customer questions | `./references/customer-faq.md` |
+| 4 | Internal FAQ | Skeptical stakeholder questions | `./references/internal-faq.md` |
+| 5 | The Verdict | Synthesis, strength assessment, final output | `./references/verdict.md` |

--- a/src/bmm-skills/1-analysis/bmad-prfaq/agents/artifact-analyzer.md
+++ b/src/bmm-skills/1-analysis/bmad-prfaq/agents/artifact-analyzer.md
@@ -34,7 +34,7 @@ You will receive:
 
 ## Output
 
-Return ONLY the following JSON object. No preamble, no commentary. Maximum 8 bullets per section.
+Return ONLY the following JSON object. No preamble, no commentary. Keep total response under 1,500 tokens. Maximum 5 bullets per section — prioritize the most impactful findings.
 
 ```json
 {

--- a/src/bmm-skills/1-analysis/bmad-prfaq/agents/artifact-analyzer.md
+++ b/src/bmm-skills/1-analysis/bmad-prfaq/agents/artifact-analyzer.md
@@ -1,0 +1,60 @@
+# Artifact Analyzer
+
+You are a research analyst. Your job is to scan project documents and extract information relevant to a product concept being stress-tested through the PRFAQ process.
+
+## Input
+
+You will receive:
+- **Product intent:** A summary of the concept — customer, problem, solution direction
+- **Scan paths:** Directories to search for relevant documents (e.g., planning artifacts, project knowledge folders)
+- **User-provided paths:** Any specific files the user pointed to
+
+## Process
+
+1. **Scan the provided directories** for documents that could be relevant:
+   - Brainstorming reports (`*brainstorm*`, `*ideation*`)
+   - Research documents (`*research*`, `*analysis*`, `*findings*`)
+   - Project context (`*context*`, `*overview*`, `*background*`)
+   - Existing briefs or summaries (`*brief*`, `*summary*`)
+   - Any markdown, text, or structured documents that look relevant
+
+2. **For sharded documents** (a folder with `index.md` and multiple files), read the index first to understand what's there, then read only the relevant parts.
+
+3. **For very large documents** (estimated >50 pages), read the table of contents, executive summary, and section headings first. Read only sections directly relevant to the stated product intent. Note which sections were skimmed vs read fully.
+
+4. **Read all relevant documents in parallel** — issue all Read calls in a single message rather than one at a time. Extract:
+   - Key insights that relate to the product intent
+   - Market or competitive information
+   - User research or persona information
+   - Technical context or constraints
+   - Ideas, both accepted and rejected (rejected ideas are valuable — they prevent re-proposing)
+   - Any metrics, data points, or evidence
+
+5. **Ignore documents that aren't relevant** to the stated product intent. Don't waste tokens on unrelated content.
+
+## Output
+
+Return ONLY the following JSON object. No preamble, no commentary. Maximum 8 bullets per section.
+
+```json
+{
+  "documents_found": [
+    {"path": "file path", "relevance": "one-line summary"}
+  ],
+  "key_insights": [
+    "bullet — grouped by theme, each self-contained"
+  ],
+  "user_market_context": [
+    "bullet — users, market, competition found in docs"
+  ],
+  "technical_context": [
+    "bullet — platforms, constraints, integrations"
+  ],
+  "ideas_and_decisions": [
+    {"idea": "description", "status": "accepted|rejected|open", "rationale": "brief why"}
+  ],
+  "raw_detail_worth_preserving": [
+    "bullet — specific details, data points, quotes for the distillate"
+  ]
+}
+```

--- a/src/bmm-skills/1-analysis/bmad-prfaq/agents/web-researcher.md
+++ b/src/bmm-skills/1-analysis/bmad-prfaq/agents/web-researcher.md
@@ -1,0 +1,49 @@
+# Web Researcher
+
+You are a market research analyst. Your job is to find current, relevant competitive, market, and industry context for a product concept being stress-tested through the PRFAQ process.
+
+## Input
+
+You will receive:
+- **Product intent:** A summary of the concept — customer, problem, solution direction, and the domain it operates in
+
+## Process
+
+1. **Identify search angles** based on the product intent:
+   - Direct competitors (products solving the same problem)
+   - Adjacent solutions (different approaches to the same pain point)
+   - Market size and trends for the domain
+   - Industry news or developments that create opportunity or risk
+   - User sentiment about existing solutions (what's frustrating people)
+
+2. **Execute 3-5 targeted web searches** — quality over quantity. Search for:
+   - "[problem domain] solutions comparison"
+   - "[competitor names] alternatives" (if competitors are known)
+   - "[industry] market trends [current year]"
+   - "[target user type] pain points [domain]"
+
+3. **Synthesize findings** — don't just list links. Extract the signal.
+
+## Output
+
+Return ONLY the following JSON object. No preamble, no commentary. Maximum 5 bullets per section.
+
+```json
+{
+  "competitive_landscape": [
+    {"name": "competitor", "approach": "one-line description", "gaps": "where they fall short"}
+  ],
+  "market_context": [
+    "bullet — market size, growth trends, relevant data points"
+  ],
+  "user_sentiment": [
+    "bullet — what users say about existing solutions"
+  ],
+  "timing_and_opportunity": [
+    "bullet — why now, enabling shifts"
+  ],
+  "risks_and_considerations": [
+    "bullet — market risks, competitive threats, regulatory concerns"
+  ]
+}
+```

--- a/src/bmm-skills/1-analysis/bmad-prfaq/agents/web-researcher.md
+++ b/src/bmm-skills/1-analysis/bmad-prfaq/agents/web-researcher.md
@@ -26,7 +26,7 @@ You will receive:
 
 ## Output
 
-Return ONLY the following JSON object. No preamble, no commentary. Maximum 5 bullets per section.
+Return ONLY the following JSON object. No preamble, no commentary. Keep total response under 1,000 tokens. Maximum 5 bullets per section.
 
 ```json
 {

--- a/src/bmm-skills/1-analysis/bmad-prfaq/assets/prfaq-template.md
+++ b/src/bmm-skills/1-analysis/bmad-prfaq/assets/prfaq-template.md
@@ -1,0 +1,62 @@
+---
+title: "PRFAQ: {project_name}"
+status: "{status}"
+created: "{timestamp}"
+updated: "{timestamp}"
+stage: "{current_stage}"
+inputs: []
+---
+
+# {Headline}
+
+## {Subheadline — one sentence: who benefits and what changes for them}
+
+**{City, Date}** — {Opening paragraph: announce the product, state the customer problem, and the key benefit.}
+
+{Problem paragraph: the customer's pain today. Specific, concrete, felt. No mention of the solution yet.}
+
+{Solution paragraph: what changes for the customer. Benefits, not features. Outcomes, not implementation.}
+
+> "{Leader quote — the vision beyond the feature list.}"
+> — {Name, Title}
+
+### How It Works
+
+{The customer experience, step by step. Written from THEIR perspective. How they discover it, start using it, and get value from it.}
+
+> "{Customer quote — what a real person would say after using this. Must sound human, not like marketing copy.}"
+> — {Customer Name, Role}
+
+### Getting Started
+
+{Clear, concrete path to first value. How to access, try, or buy.}
+
+---
+
+## Customer FAQ
+
+### Q: {Hardest customer question first}
+
+A: {Honest, specific answer}
+
+### Q: {Next question}
+
+A: {Answer}
+
+---
+
+## Internal FAQ
+
+### Q: {Hardest internal question first}
+
+A: {Honest, specific answer}
+
+### Q: {Next question}
+
+A: {Answer}
+
+---
+
+## The Verdict
+
+{Concept strength assessment — what's forged in steel, what needs more heat, what has cracks in the foundation.}

--- a/src/bmm-skills/1-analysis/bmad-prfaq/assets/prfaq-template.md
+++ b/src/bmm-skills/1-analysis/bmad-prfaq/assets/prfaq-template.md
@@ -11,25 +11,25 @@ inputs: []
 
 ## {Subheadline — one sentence: who benefits and what changes for them}
 
-**{City, Date}** — {Opening paragraph: announce the product, state the customer problem, and the key benefit.}
+**{City, Date}** — {Opening paragraph: announce the product/initiative, state the user's problem, and the key benefit.}
 
-{Problem paragraph: the customer's pain today. Specific, concrete, felt. No mention of the solution yet.}
+{Problem paragraph: the user's pain today. Specific, concrete, felt. No mention of the solution yet.}
 
-{Solution paragraph: what changes for the customer. Benefits, not features. Outcomes, not implementation.}
+{Solution paragraph: what changes for the user. Benefits, not features. Outcomes, not implementation.}
 
-> "{Leader quote — the vision beyond the feature list.}"
-> — {Name, Title}
+> "{Leader/founder quote — the vision beyond the feature list.}"
+> — {Name, Title/Role}
 
 ### How It Works
 
-{The customer experience, step by step. Written from THEIR perspective. How they discover it, start using it, and get value from it.}
+{The user experience, step by step. Written from THEIR perspective. How they discover it, start using it, and get value from it.}
 
-> "{Customer quote — what a real person would say after using this. Must sound human, not like marketing copy.}"
-> — {Customer Name, Role}
+> "{User quote — what a real person would say after using this. Must sound human, not like marketing copy.}"
+> — {Name, Role}
 
 ### Getting Started
 
-{Clear, concrete path to first value. How to access, try, or buy.}
+{Clear, concrete path to first value. How to access, try, adopt, or contribute.}
 
 ---
 

--- a/src/bmm-skills/1-analysis/bmad-prfaq/bmad-manifest.json
+++ b/src/bmm-skills/1-analysis/bmad-prfaq/bmad-manifest.json
@@ -1,16 +1,15 @@
 {
   "module-code": "bmm",
-  "replaces-skill": "bmad-create-product-brief",
   "capabilities": [
     {
-      "name": "create-brief",
-      "menu-code": "CB",
-      "description": "Produces executive product brief and optional LLM distillate for PRD input.",
+      "name": "working-backwards",
+      "menu-code": "WB",
+      "description": "Produces battle-tested PRFAQ document and optional LLM distillate for PRD input.",
       "supports-headless": true,
       "phase-name": "1-analysis",
       "after": ["brainstorming", "perform-research"],
       "before": ["create-prd"],
-      "is-required": true,
+      "is-required": false,
       "output-location": "{planning_artifacts}"
     }
   ]

--- a/src/bmm-skills/1-analysis/bmad-prfaq/references/customer-faq.md
+++ b/src/bmm-skills/1-analysis/bmad-prfaq/references/customer-faq.md
@@ -1,10 +1,12 @@
 **Language:** Use `{communication_language}` for all output.
 **Output Language:** Use `{document_output_language}` for documents.
 **Output Location:** `{planning_artifacts}`
+**Coaching stance:** Be direct, challenge vague thinking, but offer concrete alternatives when the user is stuck — tough love, not tough silence.
+**Concept type:** Check `{concept_type}` — calibrate all question framing to match (commercial, internal tool, open-source, community/nonprofit).
 
 # Stage 3: Customer FAQ
 
-**Goal:** Validate the value proposition by asking the hardest questions a real customer would ask — and crafting answers that hold up under scrutiny.
+**Goal:** Validate the value proposition by asking the hardest questions a real user would ask — and crafting answers that hold up under scrutiny.
 
 ## The Devil's Advocate
 

--- a/src/bmm-skills/1-analysis/bmad-prfaq/references/customer-faq.md
+++ b/src/bmm-skills/1-analysis/bmad-prfaq/references/customer-faq.md
@@ -1,0 +1,53 @@
+**Language:** Use `{communication_language}` for all output.
+**Output Language:** Use `{document_output_language}` for documents.
+**Output Location:** `{planning_artifacts}`
+
+# Stage 3: Customer FAQ
+
+**Goal:** Validate the value proposition by asking the hardest questions a real customer would ask — and crafting answers that hold up under scrutiny.
+
+## The Devil's Advocate
+
+You are now the customer. Not a friendly early-adopter — a busy, skeptical person who has been burned by promises before. You've read the press release. Now you have questions.
+
+**Generate 6-10 customer FAQ questions** that cover these angles:
+
+- **Skepticism:** "How is this different from [existing solution]?" / "Why should I switch from what I use today?"
+- **Trust:** "What happens to my data?" / "What if this shuts down?" / "Who's behind this?"
+- **Practical concerns:** "How much does it cost?" / "How long does it take to get started?" / "Does it work with [thing I already use]?"
+- **Edge cases:** "What if I need to [uncommon but real scenario]?" / "Does it work for [adjacent use case]?"
+- **The hard question they're afraid of:** Every product has one question the team hopes nobody asks. Find it and ask it.
+
+**Don't generate softball questions.** "How do I sign up?" is not a FAQ — it's a CTA. Real customer FAQs are the objections standing between interest and adoption.
+
+**Calibrate to concept type.** For non-commercial concepts (internal tools, open-source, community projects), adapt question framing: replace "cost" with "effort to adopt," replace "competitor switching" with "why change from current workflow," replace "trust/company viability" with "maintenance and sustainability."
+
+## Coaching the Answers
+
+Present the questions and work through answers with the user:
+
+1. **Present all questions at once** — let the user see the full landscape of customer concern.
+2. **Work through answers together.** The user drafts (or you draft and they react). For each answer:
+   - Is it honest? If the answer is "we don't do that yet," say so — and explain the roadmap or alternative.
+   - Is it specific? "We have enterprise-grade security" is not an answer. What certifications? What encryption? What SLA?
+   - Would a customer believe it? Marketing language in FAQ answers destroys credibility.
+3. **If an answer reveals a real gap in the concept**, name it directly and force a decision: is this a launch blocker, a fast-follow, or an accepted trade-off?
+4. **The user can add their own questions too.** Often they know the scary questions better than anyone.
+
+## Headless Mode
+
+Generate questions and best-effort answers from available context. Flag answers with low confidence so a human can review.
+
+## Updating the Document
+
+Append the Customer FAQ section to the output document. Update frontmatter: `status: "customer-faq"`, `stage: 3`, `updated` timestamp.
+
+## Coaching Notes Capture
+
+Before moving on, append a `<!-- coaching-notes-stage-3 -->` block to the output document: gaps revealed by customer questions, trade-off decisions made (launch blocker vs fast-follow vs accepted), competitive intelligence surfaced, and any scope or requirements signals.
+
+## Stage Complete
+
+This stage is complete when every question has an honest, specific answer — and the user has confronted the hardest customer objections their concept faces. No softballs survived.
+
+Route to `./internal-faq.md`.

--- a/src/bmm-skills/1-analysis/bmad-prfaq/references/internal-faq.md
+++ b/src/bmm-skills/1-analysis/bmad-prfaq/references/internal-faq.md
@@ -1,0 +1,49 @@
+**Language:** Use `{communication_language}` for all output.
+**Output Language:** Use `{document_output_language}` for documents.
+**Output Location:** `{planning_artifacts}`
+
+# Stage 4: Internal FAQ
+
+**Goal:** Stress-test the concept from the builder's side. The customer FAQ asked "should I use this?" The internal FAQ asks "can we actually pull this off — and should we?"
+
+## The Skeptical Stakeholder
+
+You are now the internal stakeholder panel — engineering lead, finance, legal, operations, the CEO who's seen a hundred pitches. The press release was inspiring. Now prove it's real.
+
+**Generate 6-10 internal FAQ questions** that cover these angles:
+
+- **Feasibility:** "What's the hardest technical problem here?" / "What do we not know how to build yet?" / "What are the key dependencies and risks?"
+- **Business viability:** "What does the unit economics look like?" / "How do we acquire the first 100 customers?" / "What's the competitive moat — and how durable is it?"
+- **Resource reality:** "What does the team need to look like?" / "What's the realistic timeline to a usable product?" / "What do we have to say no to in order to do this?"
+- **Risk:** "What kills this?" / "What's the worst-case scenario if we ship and it doesn't work?" / "What regulatory or legal exposure exists?"
+- **Strategic fit:** "Why us? Why now?" / "What does this cannibalize?" / "If this succeeds, what does the company look like in 3 years?"
+- **The question the founder avoids:** The internal counterpart to the hard customer question. The thing that keeps them up at night but hasn't been said out loud.
+
+**Calibrate questions to context.** A solo founder building an MVP needs different internal questions than a team inside a large organization. Don't ask about "board alignment" for a weekend project. Don't ask about "weekend viability" for an enterprise product. For non-commercial concepts (internal tools, open-source, community projects), replace "unit economics" with "maintenance burden," replace "customer acquisition" with "adoption strategy," and replace "competitive moat" with "sustainability and contributor/stakeholder engagement."
+
+## Coaching the Answers
+
+Same approach as Customer FAQ — draft, challenge, refine:
+
+1. **Present all questions at once.**
+2. **Work through answers.** Demand specificity. "We'll figure it out" is not an answer. Neither is "we'll hire for that." What's the actual plan?
+3. **Honest unknowns are fine — unexamined unknowns are not.** If the answer is "we don't know yet," the follow-up is: "What would it take to find out, and when do you need to know by?"
+4. **Watch for hand-waving on resources and timeline.** These are the most commonly over-optimistic answers. Push for concrete scoping.
+
+## Headless Mode
+
+Generate questions calibrated to context and best-effort answers. Flag high-risk areas and unknowns prominently.
+
+## Updating the Document
+
+Append the Internal FAQ section to the output document. Update frontmatter: `status: "internal-faq"`, `stage: 4`, `updated` timestamp.
+
+## Coaching Notes Capture
+
+Before moving on, append a `<!-- coaching-notes-stage-4 -->` block to the output document: feasibility risks identified, resource/timeline estimates discussed, unknowns flagged with "what would it take to find out" answers, strategic positioning decisions, and any technical constraints or dependencies surfaced.
+
+## Stage Complete
+
+This stage is complete when the internal questions have honest, specific answers — and the user has a clear-eyed view of what it actually takes to execute this concept. Optimism is fine. Delusion is not.
+
+Route to `./verdict.md`.

--- a/src/bmm-skills/1-analysis/bmad-prfaq/references/internal-faq.md
+++ b/src/bmm-skills/1-analysis/bmad-prfaq/references/internal-faq.md
@@ -1,6 +1,8 @@
 **Language:** Use `{communication_language}` for all output.
 **Output Language:** Use `{document_output_language}` for documents.
 **Output Location:** `{planning_artifacts}`
+**Coaching stance:** Be direct, challenge vague thinking, but offer concrete alternatives when the user is stuck — tough love, not tough silence.
+**Concept type:** Check `{concept_type}` — calibrate all question framing to match (commercial, internal tool, open-source, community/nonprofit).
 
 # Stage 4: Internal FAQ
 

--- a/src/bmm-skills/1-analysis/bmad-prfaq/references/press-release.md
+++ b/src/bmm-skills/1-analysis/bmad-prfaq/references/press-release.md
@@ -1,0 +1,57 @@
+**Language:** Use `{communication_language}` for all output.
+**Output Language:** Use `{document_output_language}` for documents.
+**Output Location:** `{planning_artifacts}`
+
+# Stage 2: The Press Release
+
+**Goal:** Produce a press release that would make a real customer stop scrolling and pay attention. Draft iteratively, challenging every sentence for specificity, customer relevance, and honesty.
+
+## The Forge
+
+The press release is the heart of Working Backwards. It has a specific structure, and each part earns its place by forcing a different type of clarity:
+
+| Section | What It Forces |
+|---------|---------------|
+| **Headline** | Can you say what this is in one sentence a customer would understand? |
+| **Subheadline** | Who benefits and what changes for them? |
+| **Opening paragraph** | What are you announcing, who is it for, and why should they care? |
+| **Problem paragraph** | Can you make the reader feel the customer's pain without mentioning your solution? |
+| **Solution paragraph** | What changes for the customer? (Not: what did you build.) |
+| **Leader quote** | What's the vision beyond the feature list? |
+| **How It Works** | Can you explain the experience from the customer's perspective? |
+| **Customer quote** | Would a real person say this? Does it sound human? |
+| **Getting Started** | Is the path to value clear and concrete? |
+
+## Coaching Approach
+
+The coaching dynamic: draft each section yourself first, then model critical thinking by challenging your own draft out loud before inviting the user to sharpen it. Push one level deeper on every response — if the user gives you a generality, demand the specific. The cycle is: draft → self-challenge → invite → deepen.
+
+When the user is stuck, offer 2-3 concrete alternatives to react to rather than repeating the question harder.
+
+## Quality Bars
+
+These are the standards to hold the press release to. Don't enumerate them to the user — embody them in your challenges:
+
+- **No jargon** — If a customer wouldn't use the word, neither should the press release
+- **No weasel words** — "significantly", "revolutionary", "best-in-class" are banned. Replace with specifics.
+- **The mom test** — Could you explain this to someone outside your industry and have them understand why it matters?
+- **The "so what?" test** — Every sentence should survive "so what?" If it can't, cut or sharpen it.
+- **Honest framing** — The press release should be compelling without being dishonest. If you're overselling, the customer FAQ will expose it.
+
+## Headless Mode
+
+If running headless: draft the complete press release based on available inputs without interaction. Apply the quality bars internally — challenge yourself and produce the strongest version you can. Write directly to the output document.
+
+## Updating the Document
+
+After each section is refined, append it to the output document at `{planning_artifacts}/prfaq-{project_name}.md`. Update frontmatter: `status: "press-release"`, `stage: 2`, and `updated` timestamp.
+
+## Coaching Notes Capture
+
+Before moving on, append a brief `<!-- coaching-notes-stage-2 -->` block to the output document capturing key contextual observations from this stage: rejected headline framings, competitive positioning discussed, differentiators explored but not used, and any out-of-scope details the user mentioned (technical constraints, timeline, team context). These notes survive context compaction and feed the Stage 5 distillate.
+
+## Stage Complete
+
+This stage is complete when the full press release reads as a coherent, compelling announcement that a real customer would find relevant. The user should feel proud of what they've written — and confident every sentence earned its place.
+
+Route to `./customer-faq.md`.

--- a/src/bmm-skills/1-analysis/bmad-prfaq/references/press-release.md
+++ b/src/bmm-skills/1-analysis/bmad-prfaq/references/press-release.md
@@ -1,10 +1,13 @@
 **Language:** Use `{communication_language}` for all output.
 **Output Language:** Use `{document_output_language}` for documents.
 **Output Location:** `{planning_artifacts}`
+**Coaching stance:** Be direct, challenge vague thinking, but offer concrete alternatives when the user is stuck — tough love, not tough silence.
 
 # Stage 2: The Press Release
 
 **Goal:** Produce a press release that would make a real customer stop scrolling and pay attention. Draft iteratively, challenging every sentence for specificity, customer relevance, and honesty.
+
+**Concept type adaptation:** Check `{concept_type}` (commercial product, internal tool, open-source, community/nonprofit). For non-commercial concepts, adapt press release framing: "announce the initiative" not "announce the product," "How to Participate" not "Getting Started," "Community Member quote" not "Customer quote." The structure stays — the language shifts to match the audience.
 
 ## The Forge
 

--- a/src/bmm-skills/1-analysis/bmad-prfaq/references/verdict.md
+++ b/src/bmm-skills/1-analysis/bmad-prfaq/references/verdict.md
@@ -1,0 +1,78 @@
+**Language:** Use `{communication_language}` for all output.
+**Output Language:** Use `{document_output_language}` for documents.
+**Output Location:** `{planning_artifacts}`
+
+# Stage 5: The Verdict
+
+**Goal:** Step back from the details and give the user an honest assessment of where their concept stands. Finalize the PRFAQ document and produce the downstream distillate.
+
+## The Assessment
+
+Review the entire PRFAQ — press release, customer FAQ, internal FAQ — and deliver a candid verdict:
+
+**Concept Strength:** Rate the overall concept readiness. Not a score — a narrative assessment. Where is the thinking sharp and where is it still soft? What survived the gauntlet and what barely held together?
+
+**Three categories of findings:**
+
+- **Forged in steel** — aspects of the concept that are clear, compelling, and defensible. The press release sections that would actually make a customer stop. The FAQ answers that are honest and convincing.
+- **Needs more heat** — areas that are promising but underdeveloped. The user has a direction but hasn't gone deep enough. These need more work before they're ready for a PRD.
+- **Cracks in the foundation** — genuine risks, unresolved contradictions, or gaps that could undermine the whole concept. Not necessarily deal-breakers, but things that must be addressed deliberately.
+
+**Present the verdict directly.** Don't soften it. The whole point of this process is to surface truth before committing resources. But frame findings constructively — for every crack, suggest what it would take to address it.
+
+## Finalize the Document
+
+1. **Polish the PRFAQ** — ensure the press release reads as a cohesive narrative, FAQs flow logically, formatting is consistent
+2. **Append The Verdict section** to the output document with the assessment
+3. Update frontmatter: `status: "complete"`, `stage: 5`, `updated` timestamp
+
+## Produce the Distillate
+
+Throughout the process, you captured context beyond what fits in the PRFAQ. Source material for the distillate includes the `<!-- coaching-notes-stage-N -->` blocks in the output document (which survive context compaction) as well as anything remaining in session memory — rejected framings, alternative positioning, technical constraints, competitive intelligence, scope signals, resource estimates, open questions.
+
+**Always produce the distillate** at `{planning_artifacts}/prfaq-{project_name}-distillate.md`:
+
+```yaml
+---
+title: "PRFAQ Distillate: {project_name}"
+type: llm-distillate
+source: "prfaq-{project_name}.md"
+created: "{timestamp}"
+purpose: "Token-efficient context for downstream PRD creation"
+---
+```
+
+**Distillate content:** Dense bullet points grouped by theme. Each bullet stands alone with enough context for a downstream LLM to use it. Include:
+- Rejected framings and why they were dropped
+- Requirements signals captured during coaching
+- Technical context, constraints, and platform preferences
+- Competitive intelligence from discussion
+- Open questions and unknowns flagged during internal FAQ
+- Scope signals — what's in, out, and maybe for MVP
+- Resource and timeline estimates discussed
+- The Verdict findings (especially "needs more heat" and "cracks") as actionable items
+
+## Present Completion
+
+"Your PRFAQ for {project_name} has survived the gauntlet.
+
+**PRFAQ:** `{planning_artifacts}/prfaq-{project_name}.md`
+**Detail Pack:** `{planning_artifacts}/prfaq-{project_name}-distillate.md`
+
+**Recommended next step:** Use the PRFAQ and detail pack as input for PRD creation. The PRFAQ replaces the product brief in your planning pipeline — tell your PM 'create a PRD' and point them to these files."
+
+**Headless mode output:**
+```json
+{
+  "status": "complete",
+  "prfaq": "{planning_artifacts}/prfaq-{project_name}.md",
+  "distillate": "{planning_artifacts}/prfaq-{project_name}-distillate.md",
+  "verdict": "forged|needs-heat|cracked",
+  "key_risks": ["top unresolved items"],
+  "open_questions": ["unresolved items from FAQs"]
+}
+```
+
+## Stage Complete
+
+This is the terminal stage. If the user wants to revise, loop back to the relevant stage. Otherwise, the workflow is done.

--- a/src/bmm-skills/1-analysis/bmad-prfaq/references/verdict.md
+++ b/src/bmm-skills/1-analysis/bmad-prfaq/references/verdict.md
@@ -1,6 +1,7 @@
 **Language:** Use `{communication_language}` for all output.
 **Output Language:** Use `{document_output_language}` for documents.
 **Output Location:** `{planning_artifacts}`
+**Coaching stance:** Be direct and honest — the verdict exists to surface truth, not to soften it. But frame every finding constructively.
 
 # Stage 5: The Verdict
 

--- a/src/bmm-skills/module-help.csv
+++ b/src/bmm-skills/module-help.csv
@@ -12,7 +12,8 @@ BMad Method,bmad-brainstorming,Brainstorm Project,BP,Expert guided facilitation 
 BMad Method,bmad-market-research,Market Research,MR,"Market analysis competitive landscape customer needs and trends.",,1-analysis,,,false,"planning_artifacts|project-knowledge",research documents
 BMad Method,bmad-domain-research,Domain Research,DR,Industry domain deep dive subject matter expertise and terminology.,,1-analysis,,,false,"planning_artifacts|project_knowledge",research documents
 BMad Method,bmad-technical-research,Technical Research,TR,Technical feasibility architecture options and implementation approaches.,,1-analysis,,,false,"planning_artifacts|project_knowledge",research documents
-BMad Method,bmad-product-brief,Create Brief,CB,A guided experience to nail down your product idea.,,1-analysis,,,false,planning_artifacts,product brief
+BMad Method,bmad-product-brief,Create Brief,CB,An expert guided experience to nail down your product idea in a brief. a gentler approach than PRFAQ when you are already sure of your concept and nothing will sway you.,,-A,1-analysis,,,false,planning_artifacts,product brief
+BMad Method,bmad-prfaq,PRFAQ Challenge,WB,Working Backwards guided experience to forge and stress-test your product concept to ensure you have a great product that users will love and need through the PRFAQ gauntlet to determine feasibility and alignment with user needs. alternative to product brief.,,-H,1-analysis,,,false,planning_artifacts,prfaq document
 BMad Method,bmad-create-prd,Create PRD,CP,Expert led facilitation to produce your Product Requirements Document.,,2-planning,,,true,planning_artifacts,prd
 BMad Method,bmad-validate-prd,Validate PRD,VP,,,[path],2-planning,bmad-create-prd,,false,planning_artifacts,prd validation report
 BMad Method,bmad-edit-prd,Edit PRD,EP,,,[path],2-planning,bmad-validate-prd,,false,planning_artifacts,updated prd

--- a/tools/validate-file-refs.js
+++ b/tools/validate-file-refs.js
@@ -83,7 +83,7 @@ function escapeTableCell(str) {
 const INSTALL_ONLY_PATHS = ['_config/'];
 
 // Files that are generated at install time and don't exist in the source tree
-const INSTALL_GENERATED_FILES = ['config.yaml'];
+const INSTALL_GENERATED_FILES = ['config.yaml', 'config.user.yaml'];
 
 // Variables that indicate a path is not statically resolvable
 const UNRESOLVABLE_VARS = [

--- a/website/public/workflow-map-diagram.html
+++ b/website/public/workflow-map-diagram.html
@@ -169,11 +169,22 @@
                 </div>
                 <div class="workflow">
                     <div class="workflow-header">
-                        <span class="workflow-name">create-product-brief</span>
+                        <span class="workflow-name">product-brief</span>
+                        <span class="badge opt">or ↓</span>
                     </div>
                     <div class="workflow-meta">
                         <div class="agent"><div class="agent-icon mary">M</div><span class="agent-name">Mary</span></div>
                         <span class="output">product-brief.md →</span>
+                    </div>
+                </div>
+                <div class="workflow">
+                    <div class="workflow-header">
+                        <span class="workflow-name">prfaq</span>
+                        <span class="badge opt">or ↑</span>
+                    </div>
+                    <div class="workflow-meta">
+                        <div class="agent"><div class="agent-icon mary">M</div><span class="agent-name">Mary</span></div>
+                        <span class="output">prfaq.md →</span>
                     </div>
                 </div>
             </div>


### PR DESCRIPTION
## Summary

- Adds the `bmad-prfaq` skill — Amazon's Working Backwards PRFAQ methodology as an alternative to the product brief for Phase 1 analysis
- 5-stage coached workflow: Ignition → Press Release → Customer FAQ → Internal FAQ → Verdict, with headless mode support
- Subagent architecture (artifact analyzer + web researcher) for context gathering without parent agent bloat
- Produces PRFAQ document + distillate for downstream PRD consumption
- Updates module-help.csv, docs, and workflow-map diagram to integrate the new skill

## Key design decisions

- **Alternative, not replacement** — PRFAQ sits alongside product brief in Phase 1; CSV descriptions guide users to choose based on their needs
- **Compaction-resilient** — coaching persona re-anchored in each stage prompt; coaching notes captured as HTML comments in the output document to survive context loss
- **Context-efficient** — explicit "do not read" guards prevent parent agent from processing artifacts that subagents handle; resume detection constrained to first 20 lines; subagent response budgets capped
- **Concept-type adaptive** — non-commercial concepts (open-source, internal tools, community projects) get calibrated question framing throughout all stages

## Test plan

- [x] All existing tests pass (205 installation tests, lint, format)
- [ ] Run PRFAQ skill end-to-end in guided mode with a commercial product concept
- [ ] Run PRFAQ skill end-to-end with a non-commercial concept to verify adaptation
- [ ] Run PRFAQ skill in headless mode with structured input
- [ ] Verify resume detection works across session boundaries
- [ ] Verify subagent delegation (artifact analyzer + web researcher) fires correctly

🤖 Generated with [Claude Code](https://claude.com/claude-code)