### PR TITLE
fix: quick-dev self-review verifies AC coverage against parent requirements

### DIFF
--- a/src/bmm-skills/4-implementation/bmad-quick-dev/spec-template.md
+++ b/src/bmm-skills/4-implementation/bmad-quick-dev/spec-template.md
@@ -54,7 +54,8 @@ context: [] # optional: max 3 project-wide standards/docs. NO source code files.
 
 <!-- Tasks: backtick-quoted file path -- action -- rationale. Prefer one task per file; group tightly-coupled changes when splitting would be artificial. -->
 <!-- If an I/O Matrix is present, include a task to unit-test its edge cases. -->
-<!-- AC covers system-level behaviors not captured by the I/O Matrix. Do not duplicate I/O scenarios here. -->
+<!-- AC covers system-level behaviors not captured by the I/O Matrix. Do not duplicate I/O scenarios here.
+     If requirements were assigned from a parent artifact, every assigned requirement must have an AC here. -->
 
 **Execution:**
 - [ ] `FILE` -- ACTION -- RATIONALE

--- a/src/bmm-skills/4-implementation/bmad-quick-dev/step-02-plan.md
+++ b/src/bmm-skills/4-implementation/bmad-quick-dev/step-02-plan.md
@@ -14,7 +14,7 @@ deferred_work_file: '{implementation_artifacts}/deferred-work.md'
 
 1. Investigate codebase. _Isolate deep exploration in sub-agents/tasks where available. To prevent context snowballing, instruct subagents to give you distilled summaries only._
 2. Read `./spec-template.md` fully. Fill it out based on the intent and investigation, and write the result to `{wipFile}`.
-3. Self-review against READY FOR DEVELOPMENT standard.
+3. Self-review against READY FOR DEVELOPMENT standard. If the intent derives from a parent artifact (epic plan, PRD, story brief), verify that every requirement assigned to this scope has a corresponding AC — architectural mechanisms do not substitute for testable acceptance criteria.
 4. If intent gaps exist, do not fantasize, do not leave open questions, HALT and ask the human.
 5. Token count check (see SCOPE STANDARD). If spec exceeds 1600 tokens:
    - Show user the token count.


### PR DESCRIPTION
## What

Adds a general-purpose safeguard to `quick-dev` so that specs derived from parent artifacts (epics, PRDs) don't silently drop assigned requirements during AC decomposition.

## Why

When a story derives from an epic with requirement mappings, `quick-dev` can omit ACs for assigned requirements — particularly when annotations describe architectural mechanisms rather than explicit test expectations. The self-review and adversarial review steps validate internal consistency but not completeness against upstream requirements.

Fixes #2165

## How

- **step-02-plan.md**: Extend self-review instruction to verify every upstream-assigned requirement has a corresponding AC
- **spec-template.md**: Add comment hint in AC section reminding that parent-assigned requirements need ACs

Both changes are one line each — no project-specific logic, preserves quick-dev's speed philosophy.

## Testing

Validated against a real postmortem where FR18/FR19 were correctly assigned at the epic level but dropped during spec writing, causing a false PASS on traceability.