### PR TITLE
feat: AgentVibes TTS integration — install prompt + core skill

### DIFF
--- a/src/core-skills/bmad-install-agentvibes/SKILL.md
+++ b/src/core-skills/bmad-install-agentvibes/SKILL.md
@@ -1,0 +1,65 @@
+---
+name: bmad-install-agentvibes
+description: 'Install AgentVibes TTS voice system for BMAD agents. Gives each agent a unique voice, personality, and audio effects. Use when user wants to add voice/TTS to their BMAD setup, or when bmad-party-mode is active and agents are silent.'
+---
+
+# Install AgentVibes
+
+AgentVibes is an open-source Text-to-Speech system that gives BMAD agents unique voices, personalities, and audio effects. Once installed, party mode agents speak aloud — each with their own voice.
+
+## What AgentVibes Provides
+
+- **Per-agent voices** — each BMAD agent gets a distinct voice via `bmad-voice-map.json`
+- **Cross-platform** — Windows (SAPI + Piper), macOS, Linux, WSL
+- **Personalities & effects** — reverb, background music, speed, sentiment
+- **Party mode integration** — agents introduce themselves and speak sequentially
+
+## Installation
+
+Run the installer in the terminal:
+
+```bash
+npx agentvibes install
+```
+
+Or if you prefer a global install first:
+
+```bash
+npm install -g agentvibes
+agentvibes install
+```
+
+**The installer will:**
+1. Detect your platform (Windows/Mac/Linux/WSL)
+2. Install the appropriate TTS provider (Piper recommended for best quality, SAPI as zero-dependency fallback on Windows)
+3. Configure Claude Code hooks so agents speak automatically
+4. Set up `bmad-speak.sh` / `bmad-speak.ps1` integration for party mode
+
+## Post-Install: Configure Agent Voices
+
+After installing, configure per-agent voices for party mode:
+
+```
+/agent-vibes:bmad
+```
+
+This opens the BMAD voice configuration where you can assign each agent a distinct voice, personality, and effects profile.
+
+## Verify Installation
+
+```bash
+agentvibes whoami
+```
+
+Should display the active voice and provider. If party mode is active, agents will now speak when you run `/bmad-party-mode`.
+
+## Troubleshooting
+
+- **Agents still silent after install**: Run `agentvibes install` again — it is idempotent
+- **Windows users**: Ensure PowerShell execution policy allows scripts: `Set-ExecutionPolicy -Scope CurrentUser RemoteSigned`
+- **Voice quality**: Install Piper for neural TTS — `agentvibes install` will prompt you
+
+## More Info
+
+- GitHub: https://github.com/paulpreibisch/AgentVibes
+- Docs: `agentvibes --help`

--- a/src/core-skills/module-help.csv
+++ b/src/core-skills/module-help.csv
@@ -1,6 +1,7 @@
 module,skill,display-name,menu-code,description,action,args,phase,after,before,required,output-location,outputs
 Core,bmad-brainstorming,Brainstorming,BSP,Use early in ideation or when stuck generating ideas.,,anytime,,,false,{output_folder}/brainstorming,brainstorming session
 Core,bmad-party-mode,Party Mode,PM,Orchestrate multi-agent discussions when you need multiple perspectives or want agents to collaborate.,,anytime,,,false,,
+Core,bmad-install-agentvibes,Install AgentVibes,AV,Install AgentVibes TTS so party mode agents speak with unique voices. Run once after BMAD setup.,,anytime,,,false,,
 Core,bmad-help,BMad Help,BH,,,anytime,,,false,,
 Core,bmad-index-docs,Index Docs,ID,Use when LLM needs to understand available docs without loading everything.,,anytime,,,false,,
 Core,bmad-shard-doc,Shard Document,SD,Use when doc becomes too large (>500 lines) to manage effectively.,[path],anytime,,,false,,

--- a/tools/installer/core/installer.js
+++ b/tools/installer/core/installer.js
@@ -1134,15 +1134,40 @@ class Installer {
     // Optional AgentVibes install prompt
     if (!this._silentConfig) {
       try {
-        const { default: prompts2 } = await import('@clack/prompts');
-        const installAgentVibes = await prompts2.confirm({
-          message: '🎙  Install AgentVibes now for agent TTS voices?',
-          initialValue: false,
+        const agentVibesChoice = await prompts.select({
+          message: '🎙  Give your BMAD agents a voice? (AgentVibes TTS)',
+          choices: [
+            {
+              name: 'Yes — install AgentVibes now',
+              value: 'install',
+              hint: 'runs npx agentvibes install',
+            },
+            {
+              name: 'No — I\'ll do it later',
+              value: 'skip',
+              hint: 'npx agentvibes install',
+            },
+            {
+              name: 'Tell me more',
+              value: 'info',
+              hint: 'github.com/paulpreibisch/AgentVibes',
+            },
+          ],
+          default: 'skip',
         });
-        if (installAgentVibes) {
-          const { execSync } = await import('node:child_process');
-          prompts2.log.step('Running npx agentvibes install...');
+
+        if (agentVibesChoice === 'install') {
+          const { execSync } = require('node:child_process');
+          await prompts.log.step('Running npx agentvibes install...');
           execSync('npx agentvibes install', { stdio: 'inherit' });
+        } else if (agentVibesChoice === 'info') {
+          await prompts.log.info(
+            'AgentVibes gives each BMAD agent a unique TTS voice, personality, and audio effects.\n' +
+            '  Works on Windows (SAPI + Piper), macOS, Linux, and WSL.\n' +
+            '  Party mode agents speak with their own voice — no more silent roundtables.\n\n' +
+            '  GitHub:  https://github.com/paulpreibisch/AgentVibes\n' +
+            '  Install: npx agentvibes install'
+          );
         }
       } catch {
         // Prompt cancelled or AgentVibes install failed — non-fatal

--- a/tools/installer/core/installer.js
+++ b/tools/installer/core/installer.js
@@ -1121,7 +1121,33 @@ class Installer {
       lines.push(`    Invoke the ${color.cyan('bmad-help')} skill in your IDE Agent to get started`);
     }
 
+    // AgentVibes TTS suggestion
+    lines.push(
+      '',
+      `  ${color.cyan('🎙  Want your BMAD agents to speak?')}`,
+      `    Install AgentVibes TTS: ${color.dim('npx agentvibes install')}`,
+      `    Gives each agent a unique voice in party mode and beyond.`,
+    );
+
     await prompts.note(lines.join('\n'), 'BMAD is ready to use!');
+
+    // Optional AgentVibes install prompt
+    if (!this._silentConfig) {
+      try {
+        const { default: prompts2 } = await import('@clack/prompts');
+        const installAgentVibes = await prompts2.confirm({
+          message: '🎙  Install AgentVibes now for agent TTS voices?',
+          initialValue: false,
+        });
+        if (installAgentVibes) {
+          const { execSync } = await import('node:child_process');
+          prompts2.log.step('Running npx agentvibes install...');
+          execSync('npx agentvibes install', { stdio: 'inherit' });
+        }
+      } catch {
+        // Prompt cancelled or AgentVibes install failed — non-fatal
+      }
+    }
   }
 
   /**


### PR DESCRIPTION
## Summary

Adds optional AgentVibes TTS integration to the BMAD install flow, giving users an easy path to voice-enable their agents (especially party mode).

### Changes

**`src/core-skills/bmad-install-agentvibes/`** (new skill)
- Guides users through `npx agentvibes install` post-BMAD-setup
- Documents per-agent voice config, platform support, and troubleshooting
- Registered in `module-help.csv` with menu code `AV`

**`tools/installer/core/installer.js`**
- After the install summary, shows a 3-option select prompt:
  - **Yes** — runs `npx agentvibes install` inline
  - **No** — skip, reminder shown in Next Steps
  - **Tell me more** — displays description + GitHub link without leaving the installer
- Non-fatal: cancelled prompt or install failure doesn't affect the BMAD install result
- Default is **No** so it's fully opt-in and non-intrusive

## Why

Party mode agents are currently silent unless users independently discover and install AgentVibes. This surfaces the integration at exactly the right moment — right after BMAD is set up.

## Testing

\`\`\`bash
npm link   # from BMAD-METHOD root
mkdir ~/test-project && cd ~/test-project
bmad install
# AgentVibes prompt appears after install summary
\`\`\`

🤖 Generated with [Claude Code](https://claude.com/claude-code)