### PR TITLE
fix(checkpoint): add explicit HALT before decision menu

### DIFF
--- a/src/bmm-skills/4-implementation/bmad-checkpoint-preview/step-05-wrapup.md
+++ b/src/bmm-skills/4-implementation/bmad-checkpoint-preview/step-05-wrapup.md
@@ -15,6 +15,8 @@ Review complete. What's the call on this {change_type}?
 - **Discuss** — something's still on your mind
 ```
 
+HALT — do not proceed until the user makes their choice.
+
 ## ACT ON DECISION
 
 - **Approve**: Acknowledge briefly. If the human wants to patch something before shipping, help apply the fix interactively. If reviewing a PR, offer to approve via `gh pr review --approve` — but confirm with the human before executing, since this is a visible action on a shared resource.


### PR DESCRIPTION
## Summary

- Skill validator (STEP-04) flagged `step-05-wrapup.md` for presenting a decision menu (Approve/Rework/Discuss) without an explicit HALT instruction
- Added `HALT — do not proceed until the user makes their choice.` between the menu and `## ACT ON DECISION` to prevent LLM auto-advance

## Test plan

- [x] `npm run quality` passes (all 204 tests, linting, markdown lint, skill validation, ref validation)
- [ ] Run checkpoint-preview skill and verify step-05 halts at the decision menu