### PR TITLE
fix: read deferred-work.md in create-story, sprint-status, and retrospective

### DIFF
--- a/src/bmm-skills/4-implementation/bmad-create-story/workflow.md
+++ b/src/bmm-skills/4-implementation/bmad-create-story/workflow.md
@@ -34,6 +34,7 @@ Load config from `{project-root}/_bmad/bmm/config.yaml` and resolve:
 - `ux_file` = `{planning_artifacts}/*ux*.md`
 - `story_title` = "" (will be elicited if not derivable)
 - `project_context` = `**/project-context.md` (load if exists)
+- `deferred_work_file` = `{implementation_artifacts}/deferred-work.md`
 - `default_output_file` = `{implementation_artifacts}/{{story_key}}.md`
 
 ### Input Files
@@ -232,6 +233,43 @@ Load config from `{project-root}/_bmad/bmm/config.yaml` and resolve:
   all learnings that could impact current story implementation</action>
   </check>
 
+  <!-- Deferred work items analysis -->
+  <check if="{deferred_work_file} exists AND has content">
+    <action>Load {deferred_work_file} completely</action>
+    <action>Parse all deferred items, extracting for each:
+      - File paths mentioned (e.g., [src/foo.ts:42])
+      - Category (bug, security, tech-debt, style, etc.)
+      - Originating review (e.g., "Deferred from: code review of story-2.3")
+      - Description text
+    </action>
+
+    <action>From epics content and architecture analysis, build a list of files this story will likely touch:
+      - Files explicitly mentioned in story requirements
+      - Files in modules/directories related to the story's feature area
+      - Files that share dependencies with story components
+    </action>
+
+    <action>Match deferred items against the story's file list:
+      - EXACT match: deferred item references a file the story will modify
+      - DIRECTORY match: deferred item is in the same directory/module
+      - COMPONENT match: deferred item affects a component the story depends on
+    </action>
+
+    <check if="overlapping deferred items found">
+      <action>Store {{matched_deferred_items}} for inclusion in the story file</action>
+      <action>Classify matches by priority:
+        - HIGH: security fixes, bugs in files this story will modify
+        - MEDIUM: tech-debt in the same module, performance issues in touched code
+        - LOW: style issues, minor refactors in adjacent files
+      </action>
+      <output>📋 Found {{matched_count}} deferred work items relevant to this story from previous code reviews</output>
+    </check>
+
+    <check if="no overlapping deferred items found">
+      <action>Set {{matched_deferred_items}} = empty</action>
+    </check>
+  </check>
+
   <!-- Git intelligence for previous work patterns -->
   <check
     if="previous story exists AND git repository detected">
@@ -322,6 +360,24 @@ Load config from `{project-root}/_bmad/bmm/config.yaml` and resolve:
   <check
     if="git analysis completed">
     <template-output file="{default_output_file}">git_intelligence_summary</template-output>
+  </check>
+
+  <!-- Deferred work items from previous code reviews -->
+  <check if="{{matched_deferred_items}} is not empty">
+    <action>In the Dev Notes section, add a subsection:</action>
+    <template-output file="{default_output_file}">
+### Deferred Items to Address
+
+The following items were deferred from previous code reviews and overlap with files/modules this story will touch. Address these during implementation where practical.
+
+{{#each matched_deferred_items}}
+- **[{{priority}}]** {{description}} `[{{file_ref}}]` — _from {{origin_review}}_
+{{/each}}
+    </template-output>
+
+    <action>In the Tasks/Subtasks section, add corresponding subtasks for HIGH-priority deferred items:
+      - [ ] [Deferred] {{item_title}} [{{file_ref}}] (from previous review)
+    </action>
   </check>
 
   <!-- Latest technical specifics -->

--- a/src/bmm-skills/4-implementation/bmad-create-story/workflow.md
+++ b/src/bmm-skills/4-implementation/bmad-create-story/workflow.md
@@ -45,6 +45,7 @@ Load config from `{project-root}/_bmad/bmm/config.yaml` and resolve:
 | architecture | Architecture (fallback - epics file should have relevant sections) | whole: `{planning_artifacts}/*architecture*.md`, sharded: `{planning_artifacts}/*architecture*/*.md` | SELECTIVE_LOAD |
 | ux | UX design (fallback - epics file should have relevant sections) | whole: `{planning_artifacts}/*ux*.md`, sharded: `{planning_artifacts}/*ux*/*.md` | SELECTIVE_LOAD |
 | epics | Enhanced epics+stories file with BDD and source hints | whole: `{planning_artifacts}/*epic*.md`, sharded: `{planning_artifacts}/*epic*/*.md` | SELECTIVE_LOAD |
+| deferred_work | Deferred items from code reviews (optional) | `{deferred_work_file}` | FULL_LOAD (optional) |
 
 ---
 
@@ -236,11 +237,21 @@ Load config from `{project-root}/_bmad/bmm/config.yaml` and resolve:
   <!-- Deferred work items analysis -->
   <check if="{deferred_work_file} exists AND has content">
     <action>Load {deferred_work_file} completely</action>
-    <action>Parse all deferred items, extracting for each:
+    <action>Parse all deferred items. The file uses level-2 headings produced by bmad-code-review:
+      `## Deferred from: code review of story-X.Y (YYYY-MM-DD)`
+      Each heading is followed by bullet items (one per deferred finding).
+
+      For each bullet item extract:
       - File paths mentioned (e.g., [src/foo.ts:42])
-      - Category (bug, security, tech-debt, style, etc.)
-      - Originating review (e.g., "Deferred from: code review of story-2.3")
-      - Description text
+      - Originating review: the heading text above the bullet (e.g., "code review of story-2.3 (2026-03-18)")
+      - Description text: the bullet content
+      - Category: if the producer included an explicit category, use it; otherwise derive heuristically from keywords in the description:
+        - "security" / "auth" / "injection" / "XSS" / "CSRF" → security
+        - "bug" / "crash" / "error" / "null" / "undefined" / "NaN" → bug
+        - "performance" / "slow" / "N+1" / "cache" → performance
+        - "style" / "lint" / "formatting" / "naming" → style
+        - otherwise → tech-debt
+      - Set `inferred_category = true` when the category was derived heuristically
     </action>
 
     <action>From epics content and architecture analysis, build a list of files this story will likely touch:
@@ -257,6 +268,7 @@ Load config from `{project-root}/_bmad/bmm/config.yaml` and resolve:
 
     <check if="overlapping deferred items found">
       <action>Store {{matched_deferred_items}} for inclusion in the story file</action>
+      <action>Set {{matched_count}} = number of items in {{matched_deferred_items}}</action>
       <action>Classify matches by priority:
         - HIGH: security fixes, bugs in files this story will modify
         - MEDIUM: tech-debt in the same module, performance issues in touched code
@@ -376,7 +388,7 @@ The following items were deferred from previous code reviews and overlap with fi
     </template-output>
 
     <action>In the Tasks/Subtasks section, add corresponding subtasks for HIGH-priority deferred items:
-      - [ ] [Deferred] {{item_title}} [{{file_ref}}] (from previous review)
+      - [ ] [Deferred] {{description}} [{{file_ref}}] (from previous review)
     </action>
   </check>
 

--- a/src/bmm-skills/4-implementation/bmad-retrospective/workflow.md
+++ b/src/bmm-skills/4-implementation/bmad-retrospective/workflow.md
@@ -38,6 +38,7 @@ Load config from `{project-root}/_bmad/bmm/config.yaml` and resolve:
 ### Paths
 
 - `sprint_status_file` = `{implementation_artifacts}/sprint-status.yaml`
+- `deferred_work_file` = `{implementation_artifacts}/deferred-work.md`
 
 ### Input Files
 
@@ -48,6 +49,7 @@ Load config from `{project-root}/_bmad/bmm/config.yaml` and resolve:
 | architecture | System architecture for context | whole: `{planning_artifacts}/*architecture*.md`, sharded: `{planning_artifacts}/*architecture*/*.md` | FULL_LOAD |
 | prd | Product requirements for context | whole: `{planning_artifacts}/*prd*.md`, sharded: `{planning_artifacts}/*prd*/*.md` | FULL_LOAD |
 | document_project | Brownfield project documentation (optional) | sharded: `{planning_artifacts}/*.md` | INDEX_GUIDED |
+| deferred_work | Deferred items from code reviews | `{deferred_work_file}` | FULL_LOAD (optional) |
 
 ### Required Inputs
 
@@ -246,6 +248,41 @@ Charlie (Senior Dev): "Good idea - those dev notes always have gold in them."
 - Note testing challenges or surprises
 - Track bug patterns or regression issues
 - Document test coverage gaps
+
+**Deferred Work Backlog Analysis:**
+
+<check if="{deferred_work_file} exists AND has content">
+  <action>Load {deferred_work_file} completely</action>
+  <action>Parse all deferred items and compute:</action>
+
+  - Total items deferred across all reviews
+  - Items originating from this epic's stories (match by "Deferred from: code review of story-{{epic_number}}.*")
+  - Items originating from previous epics (carried forward)
+  - Items that were addressed during this epic (cross-reference with story file lists and git history)
+  - Items still outstanding
+
+  <action>Classify outstanding items by severity:</action>
+
+  - Security issues: count and list
+  - Bugs: count and list
+  - Tech-debt: count and list
+  - Style/minor: count and list
+
+  <action>Store deferred work stats:</action>
+
+  - {{deferred_created_this_epic}}: items deferred during this epic's reviews
+  - {{deferred_resolved_this_epic}}: items addressed during this epic
+  - {{deferred_carried_forward}}: items still outstanding
+  - {{deferred_high_priority}}: security + bug items still outstanding
+
+  <action>IF {{deferred_carried_forward}} > 0: flag for discussion in retrospective as a quality concern</action>
+  <action>IF {{deferred_high_priority}} > 0: flag as critical — high-priority items are aging without resolution</action>
+</check>
+
+<check if="{deferred_work_file} does NOT exist or is empty">
+  <action>Set {{deferred_created_this_epic}} = 0, {{deferred_resolved_this_epic}} = 0, {{deferred_carried_forward}} = 0</action>
+  <action>Note: no deferred work file found — either no code reviews ran or all findings were resolved inline</action>
+</check>
 
 <action>Synthesize patterns across all stories:</action>
 
@@ -506,6 +543,13 @@ Quality and Technical:
 - Technical debt items: {{debt_count}}
 - Test coverage: {{coverage_info}}
 - Production incidents: {{incident_count}}
+
+Deferred Work (from code reviews):
+
+- Created this epic: {{deferred_created_this_epic}}
+- Resolved this epic: {{deferred_resolved_this_epic}}
+- Carried forward: {{deferred_carried_forward}}{{#if deferred_high_priority}}
+- ⚠️ High-priority outstanding: {{deferred_high_priority}} (security/bugs){{/if}}
 
 Business Outcomes:
 
@@ -1352,6 +1396,7 @@ Bob (Scrum Master): "See you all when prep work is done. Meeting adjourned!"
 - Action items with owners and timelines
 - Preparation tasks for next epic
 - Critical path items
+- Deferred work summary (items created, resolved, carried forward, high-priority outstanding)
 - Significant discoveries and epic update recommendations (if any)
 - Readiness assessment
 - Commitments and next steps

--- a/src/bmm-skills/4-implementation/bmad-retrospective/workflow.md
+++ b/src/bmm-skills/4-implementation/bmad-retrospective/workflow.md
@@ -256,12 +256,12 @@ Charlie (Senior Dev): "Good idea - those dev notes always have gold in them."
   <action>Parse all deferred items and compute:</action>
 
   - Total items deferred across all reviews
-  - Items originating from this epic's stories (match by "Deferred from: code review of story-{{epic_number}}.*")
-  - Items originating from previous epics (carried forward)
+  - Items originating from this epic's stories (match by level-2 headings: `## Deferred from: code review of story-{{epic_number}}.* (YYYY-MM-DD)`)
+  - Items originating from previous epics (carried forward — headings referencing other epic numbers)
   - Items that were addressed during this epic (cross-reference with story file lists and git history)
   - Items still outstanding
 
-  <action>Classify outstanding items by severity:</action>
+  <action>Classify outstanding items by severity. If the producer included an explicit category use it; otherwise derive heuristically from description keywords (security/auth/injection → security; bug/crash/error/null → bug; performance/slow/cache → performance; style/lint/naming → style; default → tech-debt):</action>
 
   - Security issues: count and list
   - Bugs: count and list

--- a/src/bmm-skills/4-implementation/bmad-sprint-status/workflow.md
+++ b/src/bmm-skills/4-implementation/bmad-sprint-status/workflow.md
@@ -21,12 +21,14 @@ Load config from `{project-root}/_bmad/bmm/config.yaml` and resolve:
 ### Paths
 
 - `sprint_status_file` = `{implementation_artifacts}/sprint-status.yaml`
+- `deferred_work_file` = `{implementation_artifacts}/deferred-work.md`
 
 ### Input Files
 
 | Input | Path | Load Strategy |
 |-------|------|---------------|
 | Sprint status | `{sprint_status_file}` | FULL_LOAD |
+| Deferred work | `{deferred_work_file}` | FULL_LOAD (optional) |
 
 ### Context
 
@@ -118,6 +120,18 @@ Enter corrections (e.g., "1=in-progress, 2=backlog") or "skip" to continue witho
 - IF `last_updated` timestamp is more than 7 days old (or `last_updated` is missing, fall back to `generated`): warn "sprint-status.yaml may be stale"
 - IF any story key doesn't match an epic pattern (e.g., story "5-1-..." but no "epic-5"): warn "orphaned story detected"
 - IF any epic has status in-progress but has no associated stories: warn "in-progress epic has no stories"
+
+<action>Analyze deferred work backlog (if {deferred_work_file} exists):</action>
+
+  <check if="{deferred_work_file} exists AND has content">
+    <action>Parse all deferred items from {deferred_work_file}</action>
+    <action>Count total deferred items</action>
+    <action>Group items by originating review/story</action>
+    <action>Classify items by severity if identifiable (security, bug, tech-debt, style)</action>
+    <action>Store counts: {{deferred_total}}, {{deferred_high}} (security/bug), {{deferred_medium}} (tech-debt), {{deferred_low}} (style/minor)</action>
+    <action>IF {{deferred_total}} > 20: add risk "Deferred work backlog is large ({{deferred_total}} items) — consider triaging with SM agent"</action>
+    <action>IF {{deferred_high}} > 0: add risk "{{deferred_high}} high-priority deferred items (security/bugs) need attention"</action>
+  </check>
   </step>
 
 <step n="3" goal="Select next action recommendation">
@@ -143,6 +157,10 @@ Enter corrections (e.g., "1=in-progress, 2=backlog") or "skip" to continue witho
 **Stories:** backlog {{count_backlog}}, ready-for-dev {{count_ready}}, in-progress {{count_in_progress}}, review {{count_review}}, done {{count_done}}
 
 **Epics:** backlog {{epic_backlog}}, in-progress {{epic_in_progress}}, done {{epic_done}}
+
+{{#if deferred_total}}
+**Deferred Work:** {{deferred_total}} items ({{deferred_high}} high, {{deferred_medium}} medium, {{deferred_low}} low)
+{{/if}}
 
 **Next Recommendation:** /bmad:bmm:workflows:{{next_workflow_id}} ({{next_story_id}})
 
@@ -208,6 +226,10 @@ If the command targets a story, set `story_key={{next_story_id}}` when prompted.
   <template-output>epic_in_progress = {{epic_in_progress}}</template-output>
   <template-output>epic_done = {{epic_done}}</template-output>
   <template-output>risks = {{risks}}</template-output>
+  <template-output>deferred_total = {{deferred_total}}</template-output>
+  <template-output>deferred_high = {{deferred_high}}</template-output>
+  <template-output>deferred_medium = {{deferred_medium}}</template-output>
+  <template-output>deferred_low = {{deferred_low}}</template-output>
   <action>Return to caller</action>
 </step>
 

--- a/src/bmm-skills/4-implementation/bmad-sprint-status/workflow.md
+++ b/src/bmm-skills/4-implementation/bmad-sprint-status/workflow.md
@@ -124,13 +124,20 @@ Enter corrections (e.g., "1=in-progress, 2=backlog") or "skip" to continue witho
 <action>Analyze deferred work backlog (if {deferred_work_file} exists):</action>
 
   <check if="{deferred_work_file} exists AND has content">
-    <action>Parse all deferred items from {deferred_work_file}</action>
-    <action>Count total deferred items</action>
-    <action>Group items by originating review/story</action>
-    <action>Classify items by severity if identifiable (security, bug, tech-debt, style)</action>
-    <action>Store counts: {{deferred_total}}, {{deferred_high}} (security/bug), {{deferred_medium}} (tech-debt), {{deferred_low}} (style/minor)</action>
+    <action>Parse all deferred items from {deferred_work_file}. The file uses level-2 headings produced by bmad-code-review:
+      `## Deferred from: code review of story-X.Y (YYYY-MM-DD)`
+      Each heading is followed by bullet items (one per deferred finding).
+    </action>
+    <action>Count total deferred items (bullet items, not headings)</action>
+    <action>Group items by originating review/story (derived from the heading above each group)</action>
+    <action>Classify items by severity: if the item includes an explicit category use it; otherwise derive heuristically from description keywords (security/auth/injection → security; bug/crash/error/null → bug; performance/slow/cache → performance; style/lint/naming → style; default → tech-debt)</action>
+    <action>Store counts: {{deferred_total}}, {{deferred_high}} (security/bug), {{deferred_medium}} (tech-debt/performance), {{deferred_low}} (style/minor)</action>
     <action>IF {{deferred_total}} > 20: add risk "Deferred work backlog is large ({{deferred_total}} items) — consider triaging with SM agent"</action>
     <action>IF {{deferred_high}} > 0: add risk "{{deferred_high}} high-priority deferred items (security/bugs) need attention"</action>
+  </check>
+
+  <check if="{deferred_work_file} does NOT exist OR is empty">
+    <action>Set {{deferred_total}} = 0, {{deferred_high}} = 0, {{deferred_medium}} = 0, {{deferred_low}} = 0</action>
   </check>
   </step>
 
@@ -213,7 +220,7 @@ If the command targets a story, set `story_key={{next_story_id}}` when prompted.
 <!-- ========================= -->
 
 <step n="20" goal="Data mode output">
-  <action>Load and parse {sprint_status_file} same as Step 2</action>
+  <action>Load and parse {sprint_status_file} same as Step 2 (including deferred work analysis — set deferred counts to 0 when file is missing/empty)</action>
   <action>Compute recommendation same as Step 3</action>
   <template-output>next_workflow_id = {{next_workflow_id}}</template-output>
   <template-output>next_story_id = {{next_story_id}}</template-output>


### PR DESCRIPTION
## Summary

Closes #2199.

Code reviews write deferred findings to `deferred-work.md` via `bmad-code-review/step-04-present.md`, but no downstream workflow ever reads that file back. This creates a write-only data sink where tech debt accumulates silently.

This PR integrates `deferred-work.md` into the three workflows that should consume it:

- **`bmad-create-story`** — Loads deferred-work.md during step 2 (artifact analysis), matches items by file path against the new story's scope, and folds overlapping items into the story file as a "Deferred Items to Address" Dev Notes subsection plus Tasks subtasks for high-priority items
- **`bmad-sprint-status`** — Parses the deferred backlog, displays severity-grouped counts in the status summary, and raises risks when the backlog is large or contains high-priority (security/bug) items
- **`bmad-retrospective`** — Analyzes deferred items created vs. resolved during the epic, surfaces carried-forward stats in the metrics display, and includes a deferred work summary in the saved retrospective document

## Test plan

- [ ] Run `bmad-create-story` on a project with an existing `deferred-work.md` containing items that reference files the target story will touch — verify the story file includes a "Deferred Items to Address" section and corresponding task subtasks
- [ ] Run `bmad-create-story` on a project with no `deferred-work.md` — verify workflow proceeds normally with no errors
- [ ] Run `bmad-sprint-status` with an existing deferred backlog — verify the "Deferred Work" line appears in the status summary and high-priority items trigger risk warnings
- [ ] Run `bmad-sprint-status` without a deferred-work.md — verify no deferred section appears and no errors occur
- [ ] Run `bmad-retrospective` after completing an epic with deferred items — verify the metrics display includes "Deferred Work (from code reviews)" stats and the saved retro document includes a deferred work summary section
- [ ] Verify all existing tests pass (`npm test`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)