### PR TITLE
feat(review): enforce model parity for all review subagents

### DIFF
--- a/src/bmm-skills/4-implementation/bmad-code-review/steps/step-02-review.md
+++ b/src/bmm-skills/4-implementation/bmad-code-review/steps/step-02-review.md
@@ -10,6 +10,7 @@ failed_layers: '' # set at runtime: comma-separated list of layers that failed o
 - The Blind Hunter subagent receives NO project context — diff only.
 - The Edge Case Hunter subagent receives diff and project read access.
 - The Acceptance Auditor subagent receives diff, spec, and context docs.
+- All review subagents must run at the same model capability as the current session.
 
 ## INSTRUCTIONS
 

--- a/src/bmm-skills/4-implementation/bmad-quick-dev/step-04-review.md
+++ b/src/bmm-skills/4-implementation/bmad-quick-dev/step-04-review.md
@@ -9,6 +9,7 @@ specLoopIteration: 1
 
 - YOU MUST ALWAYS SPEAK OUTPUT in your Agent communication style with the config `{communication_language}`
 - Review subagents get NO conversation context.
+- All review subagents must run at the same model capability as the current session.
 
 ## INSTRUCTIONS
 

--- a/src/bmm-skills/4-implementation/bmad-quick-dev/step-oneshot.md
+++ b/src/bmm-skills/4-implementation/bmad-quick-dev/step-oneshot.md
@@ -17,7 +17,7 @@ Implement the clarified intent directly.
 
 ### Review
 
-Invoke the `bmad-review-adversarial-general` skill in a subagent with the changed files. The subagent gets NO conversation context — to avoid anchoring bias. If no sub-agents are available, write the changed files to a review prompt file in `{implementation_artifacts}` and HALT. Ask the human to run the review in a separate session and paste back the findings.
+Invoke the `bmad-review-adversarial-general` skill in a subagent with the changed files. The subagent gets NO conversation context — to avoid anchoring bias. Launch at the same model capability as the current session. If no sub-agents are available, write the changed files to a review prompt file in `{implementation_artifacts}` and HALT. Ask the human to run the review in a separate session and paste back the findings.
 
 ### Classify
 


### PR DESCRIPTION
## Summary

- Adds a single-line rule to each review step file requiring all review subagents to run at the same model capability as the orchestrator session
- Applies to bmad-quick-dev (step-04-review, step-oneshot) and bmad-code-review (step-02-review)
- Motivated by research showing smaller models have measurably worse recall on rare-event detection, and the Acceptance Auditor rare findings tend to be high-severity

## Test plan

- [ ] Verify npm run quality passes
- [ ] Run quick-dev on a small change and confirm review subagents launch without model downgrade
- [ ] Run bmad-code-review and confirm the same behavior