### PR TITLE
docs: remove Bob from workflow map diagrams

### DIFF
--- a/website/public/workflow-map-diagram-fr.html
+++ b/website/public/workflow-map-diagram-fr.html
@@ -93,7 +93,6 @@
         .agent-icon.john { background: linear-gradient(135deg, #60a5fa, #3b82f6); }
         .agent-icon.sally { background: linear-gradient(135deg, #fbbf24, #f59e0b); color: #000; }
         .agent-icon.winston { background: linear-gradient(135deg, #a78bfa, #8b5cf6); }
-        .agent-icon.bob { background: linear-gradient(135deg, #34d399, #10b981); color: #000; }
         .agent-icon.amelia { background: linear-gradient(135deg, #fb7185, #ef4444); }
 
         .agent-name { font-size: 0.65rem; }
@@ -261,7 +260,7 @@
                         <span class="workflow-name">sprint-planning</span>
                     </div>
                     <div class="workflow-meta">
-                        <div class="agent"><div class="agent-icon bob">B</div><span class="agent-name">Bob</span></div>
+                        <div class="agent"><div class="agent-icon amelia">A</div><span class="agent-name">Amelia</span></div>
                         <span class="output">sprint-status.yaml →</span>
                     </div>
                 </div>
@@ -270,7 +269,7 @@
                         <span class="workflow-name">create-story</span>
                     </div>
                     <div class="workflow-meta">
-                        <div class="agent"><div class="agent-icon bob">B</div><span class="agent-name">Bob</span></div>
+                        <div class="agent"><div class="agent-icon amelia">A</div><span class="agent-name">Amelia</span></div>
                         <span class="output">story-[slug].md →</span>
                     </div>
                 </div>
@@ -308,7 +307,7 @@
                         <span class="badge adhoc">par Epic</span>
                     </div>
                     <div class="workflow-meta">
-                        <div class="agent"><div class="agent-icon bob">B</div><span class="agent-name">Bob</span></div>
+                        <div class="agent"><div class="agent-icon amelia">A</div><span class="agent-name">Amelia</span></div>
                         <span class="output">leçons</span>
                     </div>
                 </div>

--- a/website/public/workflow-map-diagram.html
+++ b/website/public/workflow-map-diagram.html
@@ -93,7 +93,6 @@
         .agent-icon.john { background: linear-gradient(135deg, #60a5fa, #3b82f6); }
         .agent-icon.sally { background: linear-gradient(135deg, #fbbf24, #f59e0b); color: #000; }
         .agent-icon.winston { background: linear-gradient(135deg, #a78bfa, #8b5cf6); }
-        .agent-icon.bob { background: linear-gradient(135deg, #34d399, #10b981); color: #000; }
         .agent-icon.amelia { background: linear-gradient(135deg, #fb7185, #ef4444); }
 
         .agent-name { font-size: 0.65rem; }
@@ -272,7 +271,7 @@
                         <span class="workflow-name">sprint-planning</span>
                     </div>
                     <div class="workflow-meta">
-                        <div class="agent"><div class="agent-icon bob">B</div><span class="agent-name">Bob</span></div>
+                        <div class="agent"><div class="agent-icon amelia">A</div><span class="agent-name">Amelia</span></div>
                         <span class="output">sprint-status.yaml →</span>
                     </div>
                 </div>
@@ -281,7 +280,7 @@
                         <span class="workflow-name">create-story</span>
                     </div>
                     <div class="workflow-meta">
-                        <div class="agent"><div class="agent-icon bob">B</div><span class="agent-name">Bob</span></div>
+                        <div class="agent"><div class="agent-icon amelia">A</div><span class="agent-name">Amelia</span></div>
                         <span class="output">story-[slug].md →</span>
                     </div>
                 </div>
@@ -319,7 +318,7 @@
                         <span class="badge adhoc">per epic</span>
                     </div>
                     <div class="workflow-meta">
-                        <div class="agent"><div class="agent-icon bob">B</div><span class="agent-name">Bob</span></div>
+                        <div class="agent"><div class="agent-icon amelia">A</div><span class="agent-name">Amelia</span></div>
                         <span class="output">lessons</span>
                     </div>
                 </div>


### PR DESCRIPTION
## Summary

- Bob (Scrum Master) was consolidated into Amelia (Developer) in v6.3.0 (#2186) but the workflow map diagrams were not updated
- Replaced Bob with Amelia on sprint-planning, create-story, and retrospective workflows in both English and French diagrams
- Removed unused `.agent-icon.bob` CSS class

Closes #2249

## Test plan

- [ ] Verify https://docs.bmad-method.org/reference/workflow-map/ shows Amelia instead of Bob after deploy