### PR TITLE
fix(installer): stop skill scanner from recursing into discovered skills

### DIFF
--- a/tools/installer/core/manifest-generator.js
+++ b/tools/installer/core/manifest-generator.js
@@ -193,11 +193,13 @@ class ManifestGenerator {
           }
         }
 
-        // Recurse into subdirectories
-        for (const entry of entries) {
-          if (!entry.isDirectory()) continue;
-          if (entry.name.startsWith('.') || entry.name.startsWith('_')) continue;
-          await walk(path.join(dir, entry.name));
+        // Recurse into subdirectories — but not inside a discovered skill
+        if (!skillMeta) {
+          for (const entry of entries) {
+            if (!entry.isDirectory()) continue;
+            if (entry.name.startsWith('.') || entry.name.startsWith('_')) continue;
+            await walk(path.join(dir, entry.name));
+          }
         }
       };
 


### PR DESCRIPTION
## Summary

- Once the manifest generator finds a valid SKILL.md in a directory, it no longer recurses into that skill's subdirectories
- Skills don't nest; template/asset files inside a skill (like bmb's `setup-skill-template/SKILL.md`) were being incorrectly scanned, producing spurious errors

## Problem

The bmb module's `bmad-module-builder` skill contains a template directory (`assets/setup-skill-template/`) with a SKILL.md that has placeholder frontmatter (`name: "{setup-skill-name}"`). The manifest generator's recursive walk would descend into this directory, find the template SKILL.md, and log:

```
Error: SKILL.md name "{setup-skill-name}" does not match directory name "setup-skill-template" — skipping
```

## Fix

One-line change: wrap the subdirectory recursion in `if (!skillMeta)` so the walker stops descending once it claims a directory as a skill.

## Test plan

- [x] All 229 installation component tests pass
- [x] Verified skill counts match source repos across all 6 modules (core:11, bmm:30, bmb:4, cis:10, gds:35, tea:10 = 100 total)