### PR TITLE
feat(agents): set team to software-development on BMM agents

### DIFF
--- a/src/bmm-skills/module.yaml
+++ b/src/bmm-skills/module.yaml
@@ -60,34 +60,40 @@ agents:
     name: Mary
     title: Business Analyst
     icon: "📊"
+    team: software-development
     description: "Channels Porter's strategic rigor and Minto's Pyramid Principle, grounds every finding in verifiable evidence, represents every stakeholder voice. Speaks like a treasure hunter narrating the find: thrilled by every clue, precise once the pattern emerges."
 
   - code: bmad-agent-tech-writer
     name: Paige
     title: Technical Writer
     icon: "📚"
+    team: software-development
     description: "Master of CommonMark, DITA, and OpenAPI; turns complex concepts into accessible structured docs, favors diagrams over walls of text, every word earning its place. Speaks like the patient teacher you wish you'd had, using analogies that make complex things feel simple."
 
   - code: bmad-agent-pm
     name: John
     title: Product Manager
     icon: "📋"
+    team: software-development
     description: "Drives Jobs-to-be-Done over template filling, user value first, technical feasibility is a constraint not the driver. Speaks like a detective interrogating a cold case: short questions, sharper follow-ups, every 'why?' tightening the net."
 
   - code: bmad-agent-ux-designer
     name: Sally
     title: UX Designer
     icon: "🎨"
+    team: software-development
     description: "Balances empathy with edge-case rigor, starts simple and evolves through feedback, every decision serves a genuine user need. Speaks like a filmmaker pitching the scene before the code exists, painting user stories that make you feel the problem."
 
   - code: bmad-agent-architect
     name: Winston
     title: System Architect
     icon: "🏗️"
+    team: software-development
     description: "Favors boring technology for stability, developer productivity as architecture, ties every decision to business value. Speaks like a seasoned engineer at the whiteboard: measured, always laying out trade-offs rather than verdicts."
 
   - code: bmad-agent-dev
     name: Amelia
     title: Senior Software Engineer
     icon: "💻"
+    team: software-development
     description: "Test-first discipline (red, green, refactor), 100% pass before review, no fluff all precision. Speaks like a terminal prompt: exact file paths, AC IDs, and commit-message brevity — every statement citable."

--- a/test/test-installation-components.js
+++ b/test/test-installation-components.js
@@ -2083,7 +2083,7 @@ async function runTests() {
       assert(maryEntry && maryEntry.icon === '📊', 'Agent entry carries icon field');
       assert(maryEntry && maryEntry.description.length > 0, 'Agent entry carries description field');
       assert(maryEntry && maryEntry.module === 'bmm', 'Agent entry module derives from owning module');
-      assert(maryEntry && maryEntry.team === 'bmm', 'Agent entry team defaults to module code');
+      assert(maryEntry && maryEntry.team === 'software-development', 'Agent entry carries explicit team from module.yaml');
 
       // writeCentralConfig produces the two root files
       const [teamPath, userPath] = await generator35.writeCentralConfig(tempBmadDir35, moduleConfigs);
@@ -2139,7 +2139,7 @@ async function runTests() {
       assert(teamContent.includes('[agents.bmad-agent-analyst]'), 'config.toml has [agents.bmad-agent-analyst] table');
       assert(teamContent.includes('[agents.bmad-agent-dev]'), 'config.toml has [agents.bmad-agent-dev] table');
       assert(teamContent.includes('module = "bmm"'), 'Agent entry serializes module field');
-      assert(teamContent.includes('team = "bmm"'), 'Agent entry serializes team field');
+      assert(teamContent.includes('team = "software-development"'), 'Agent entry serializes team field');
       assert(teamContent.includes('name = "Mary"'), 'Agent entry serializes name');
       assert(teamContent.includes('icon = "📊"'), 'Agent entry serializes icon');
       assert(!userContent.includes('[agents.'), '[agents.*] tables are never written to config.user.toml');


### PR DESCRIPTION
## Summary

All six BMM agents (analyst, tech-writer, PM, UX designer, architect, dev) now explicitly declare `team: software-development` in the `module.yaml` roster instead of falling back to the module-code default of `bmm`.

This matches the BMad-wide team convention where agents across modules that collaborate on software delivery share one named team.

## Paired PR

- `bmad-method-test-architecture-enterprise` ships the same change for Murat (Tea) so the full software-delivery roster routes as a single team for party-mode, retrospective, and help catalog skills.

## Test plan

- [ ] Fresh install: party-mode and retrospective skills read `team: software-development` from the agent roster and include all six BMM agents (+ Tea's Murat once the paired PR lands) under one team grouping.
- [ ] Override file test: a user customization setting `team: ["software-development", "custom-team"]` still resolves correctly if/when multi-team support is added.