### PR TITLE
feat(skills): wire on_complete into terminal steps; add full customize.toml comments

### DIFF
--- a/src/bmm-skills/1-analysis/bmad-document-project/workflows/deep-dive-instructions.md
+++ b/src/bmm-skills/1-analysis/bmad-document-project/workflows/deep-dive-instructions.md
@@ -291,6 +291,7 @@ These comprehensive docs are now ready for:
 
 Thank you for using the document-project workflow!
 </action>
+<action>Run: `python3 {project-root}/_bmad/scripts/resolve_customization.py --skill {skill-root} --key workflow.on_complete` — if the resolved value is non-empty, follow it as the final terminal instruction before exiting.</action>
 <action>Exit workflow</action>
 </action>
 </step>

--- a/src/bmm-skills/1-analysis/bmad-document-project/workflows/full-scan-instructions.md
+++ b/src/bmm-skills/1-analysis/bmad-document-project/workflows/full-scan-instructions.md
@@ -1103,5 +1103,6 @@ When ready to plan new features, run the PRD workflow and provide this index as 
   </action>
 
 <action>Display: "State file saved: {{project_knowledge}}/project-scan-report.json"</action>
+<action>Run: `python3 {project-root}/_bmad/scripts/resolve_customization.py --skill {skill-root} --key workflow.on_complete` — if the resolved value is non-empty, follow it as the final terminal instruction before exiting.</action>
 
 </workflow>

--- a/src/bmm-skills/1-analysis/bmad-prfaq/customize.toml
+++ b/src/bmm-skills/1-analysis/bmad-prfaq/customize.toml
@@ -9,11 +9,33 @@
 #   scalars: override wins • arrays (persistent_facts, activation_steps_*): append
 #   arrays-of-tables with `code`/`id`: replace matching items, append new ones.
 
+# Steps to run before the standard activation (config load, greet).
+# Overrides append. Use for pre-flight loads, compliance checks, etc.
+
 activation_steps_prepend = []
+
+# Steps to run after greet but before the workflow begins.
+# Overrides append. Use for context-heavy setup that should happen
+# once the user has been acknowledged.
+
 activation_steps_append = []
+
+# Persistent facts the workflow keeps in mind for the whole run
+# (standards, compliance constraints, stylistic guardrails).
+# Distinct from the runtime memory sidecar — these are static context
+# loaded on activation. Overrides append.
+#
+# Each entry is either:
+#   - a literal sentence, e.g. "All briefs must include a regulatory-risk section."
+#   - a file reference prefixed with `file:`, e.g. "file:{project-root}/docs/standards.md"
+#     (glob patterns are supported; the file's contents are loaded and treated as facts).
 
 persistent_facts = [
   "file:{project-root}/**/project-context.md",
 ]
+
+# Scalar: executed when the workflow reaches its terminal stage (Stage 5: The Verdict),
+# after the PRFAQ and distillate have been delivered. Override wins. Leave empty for
+# no custom post-completion behavior.
 
 on_complete = ""

--- a/src/bmm-skills/1-analysis/bmad-prfaq/references/verdict.md
+++ b/src/bmm-skills/1-analysis/bmad-prfaq/references/verdict.md
@@ -77,3 +77,7 @@ purpose: "Token-efficient context for downstream PRD creation"
 ## Stage Complete
 
 This is the terminal stage. If the user wants to revise, loop back to the relevant stage. Otherwise, the workflow is done.
+
+Run: `python3 {project-root}/_bmad/scripts/resolve_customization.py --skill {skill-root} --key workflow.on_complete`
+
+If the resolved `workflow.on_complete` is non-empty, follow it as the final terminal instruction before exiting.

--- a/src/bmm-skills/1-analysis/research/bmad-domain-research/customize.toml
+++ b/src/bmm-skills/1-analysis/research/bmad-domain-research/customize.toml
@@ -9,11 +9,33 @@
 #   scalars: override wins • arrays (persistent_facts, activation_steps_*): append
 #   arrays-of-tables with `code`/`id`: replace matching items, append new ones.
 
+# Steps to run before the standard activation (config load, greet).
+# Overrides append. Use for pre-flight loads, compliance checks, etc.
+
 activation_steps_prepend = []
+
+# Steps to run after greet but before the workflow begins.
+# Overrides append. Use for context-heavy setup that should happen
+# once the user has been acknowledged.
+
 activation_steps_append = []
+
+# Persistent facts the workflow keeps in mind for the whole run
+# (standards, compliance constraints, stylistic guardrails).
+# Distinct from the runtime memory sidecar — these are static context
+# loaded on activation. Overrides append.
+#
+# Each entry is either:
+#   - a literal sentence, e.g. "All briefs must include a regulatory-risk section."
+#   - a file reference prefixed with `file:`, e.g. "file:{project-root}/docs/standards.md"
+#     (glob patterns are supported; the file's contents are loaded and treated as facts).
 
 persistent_facts = [
   "file:{project-root}/**/project-context.md",
 ]
+
+# Scalar: executed when the workflow reaches its terminal stage (Step 6: Research Synthesis),
+# after the domain research document has been saved and the user selects [C] Complete.
+# Override wins. Leave empty for no custom post-completion behavior.
 
 on_complete = ""

--- a/src/bmm-skills/1-analysis/research/bmad-domain-research/domain-steps/step-06-research-synthesis.md
+++ b/src/bmm-skills/1-analysis/research/bmad-domain-research/domain-steps/step-06-research-synthesis.md
@@ -441,4 +441,10 @@ Complete authoritative research document on {{research_topic}} that:
 - Serves as reference document for continued use
 - Maintains highest research quality standards
 
+## On Complete
+
+Run: `python3 {project-root}/_bmad/scripts/resolve_customization.py --skill {skill-root} --key workflow.on_complete`
+
+If the resolved `workflow.on_complete` is non-empty, follow it as the final terminal instruction before exiting.
+
 Congratulations on completing comprehensive domain research! 🎉

--- a/src/bmm-skills/1-analysis/research/bmad-market-research/customize.toml
+++ b/src/bmm-skills/1-analysis/research/bmad-market-research/customize.toml
@@ -5,11 +5,37 @@
 
 [workflow]
 
+# --- Configurable below. Overrides merge per BMad structural rules: ---
+#   scalars: override wins • arrays (persistent_facts, activation_steps_*): append
+#   arrays-of-tables with `code`/`id`: replace matching items, append new ones.
+
+# Steps to run before the standard activation (config load, greet).
+# Overrides append. Use for pre-flight loads, compliance checks, etc.
+
 activation_steps_prepend = []
+
+# Steps to run after greet but before the workflow begins.
+# Overrides append. Use for context-heavy setup that should happen
+# once the user has been acknowledged.
+
 activation_steps_append = []
+
+# Persistent facts the workflow keeps in mind for the whole run
+# (standards, compliance constraints, stylistic guardrails).
+# Distinct from the runtime memory sidecar — these are static context
+# loaded on activation. Overrides append.
+#
+# Each entry is either:
+#   - a literal sentence, e.g. "All briefs must include a regulatory-risk section."
+#   - a file reference prefixed with `file:`, e.g. "file:{project-root}/docs/standards.md"
+#     (glob patterns are supported; the file's contents are loaded and treated as facts).
 
 persistent_facts = [
   "file:{project-root}/**/project-context.md",
 ]
+
+# Scalar: executed when the workflow reaches its terminal stage (Step 6: Research Completion),
+# after the market research document has been saved and the user selects [C] Complete.
+# Override wins. Leave empty for no custom post-completion behavior.
 
 on_complete = ""

--- a/src/bmm-skills/1-analysis/research/bmad-market-research/steps/step-06-research-completion.md
+++ b/src/bmm-skills/1-analysis/research/bmad-market-research/steps/step-06-research-completion.md
@@ -475,4 +475,10 @@ Comprehensive market research workflow complete. User may:
 - Combine market research with other research types for comprehensive insights
 - Move forward with implementation based on strategic market recommendations
 
+## On Complete
+
+Run: `python3 {project-root}/_bmad/scripts/resolve_customization.py --skill {skill-root} --key workflow.on_complete`
+
+If the resolved `workflow.on_complete` is non-empty, follow it as the final terminal instruction before exiting.
+
 Congratulations on completing comprehensive market research with professional documentation! 🎉

--- a/src/bmm-skills/1-analysis/research/bmad-technical-research/customize.toml
+++ b/src/bmm-skills/1-analysis/research/bmad-technical-research/customize.toml
@@ -5,11 +5,37 @@
 
 [workflow]
 
+# --- Configurable below. Overrides merge per BMad structural rules: ---
+#   scalars: override wins • arrays (persistent_facts, activation_steps_*): append
+#   arrays-of-tables with `code`/`id`: replace matching items, append new ones.
+
+# Steps to run before the standard activation (config load, greet).
+# Overrides append. Use for pre-flight loads, compliance checks, etc.
+
 activation_steps_prepend = []
+
+# Steps to run after greet but before the workflow begins.
+# Overrides append. Use for context-heavy setup that should happen
+# once the user has been acknowledged.
+
 activation_steps_append = []
+
+# Persistent facts the workflow keeps in mind for the whole run
+# (standards, compliance constraints, stylistic guardrails).
+# Distinct from the runtime memory sidecar — these are static context
+# loaded on activation. Overrides append.
+#
+# Each entry is either:
+#   - a literal sentence, e.g. "All briefs must include a regulatory-risk section."
+#   - a file reference prefixed with `file:`, e.g. "file:{project-root}/docs/standards.md"
+#     (glob patterns are supported; the file's contents are loaded and treated as facts).
 
 persistent_facts = [
   "file:{project-root}/**/project-context.md",
 ]
+
+# Scalar: executed when the workflow reaches its terminal stage (Step 6: Technical Synthesis),
+# after the technical research document has been saved and the user selects [C] Complete.
+# Override wins. Leave empty for no custom post-completion behavior.
 
 on_complete = ""

--- a/src/bmm-skills/1-analysis/research/bmad-technical-research/technical-steps/step-06-research-synthesis.md
+++ b/src/bmm-skills/1-analysis/research/bmad-technical-research/technical-steps/step-06-research-synthesis.md
@@ -484,4 +484,10 @@ Complete authoritative technical research document on {{research_topic}} that:
 - Serves as technical reference document for continued use
 - Maintains highest technical research quality standards with current verification
 
+## On Complete
+
+Run: `python3 {project-root}/_bmad/scripts/resolve_customization.py --skill {skill-root} --key workflow.on_complete`
+
+If the resolved `workflow.on_complete` is non-empty, follow it as the final terminal instruction before exiting.
+
 Congratulations on completing comprehensive technical research with professional documentation! 🎉

--- a/src/bmm-skills/2-plan-workflows/bmad-create-prd/customize.toml
+++ b/src/bmm-skills/2-plan-workflows/bmad-create-prd/customize.toml
@@ -1,14 +1,41 @@
 # DO NOT EDIT -- overwritten on every update.
 #
-# Workflow customization surface for bmad-create-prd.
+# Workflow customization surface for bmad-create-prd. Mirrors the
+# agent customization shape under the [workflow] namespace.
 
 [workflow]
 
+# --- Configurable below. Overrides merge per BMad structural rules: ---
+#   scalars: override wins • arrays (persistent_facts, activation_steps_*): append
+#   arrays-of-tables with `code`/`id`: replace matching items, append new ones.
+
+# Steps to run before the standard activation (config load, greet).
+# Overrides append. Use for pre-flight loads, compliance checks, etc.
+
 activation_steps_prepend = []
+
+# Steps to run after greet but before the workflow begins.
+# Overrides append. Use for context-heavy setup that should happen
+# once the user has been acknowledged.
+
 activation_steps_append = []
+
+# Persistent facts the workflow keeps in mind for the whole run
+# (standards, compliance constraints, stylistic guardrails).
+# Distinct from the runtime memory sidecar — these are static context
+# loaded on activation. Overrides append.
+#
+# Each entry is either:
+#   - a literal sentence, e.g. "All PRDs must include a regulatory-risk section."
+#   - a file reference prefixed with `file:`, e.g. "file:{project-root}/docs/standards.md"
+#     (glob patterns are supported; the file's contents are loaded and treated as facts).
 
 persistent_facts = [
   "file:{project-root}/**/project-context.md",
 ]
+
+# Scalar: executed when the workflow reaches Step 12 (Workflow Completion),
+# after the PRD is finalized and workflow status is updated. Override wins.
+# Leave empty for no custom post-completion behavior.
 
 on_complete = ""

--- a/src/bmm-skills/2-plan-workflows/bmad-create-prd/steps-c/step-12-complete.md
+++ b/src/bmm-skills/2-plan-workflows/bmad-create-prd/steps-c/step-12-complete.md
@@ -113,3 +113,9 @@ PRD complete. Invoke the `bmad-help` skill.
 The polished PRD serves as the foundation for all subsequent product development activities. All design, architecture, and development work should trace back to the requirements and vision documented in this PRD - update it also as needed as you continue planning.
 
 **Congratulations on completing the Product Requirements Document for {{project_name}}!** 🎉
+
+## On Complete
+
+Run: `python3 {project-root}/_bmad/scripts/resolve_customization.py --skill {skill-root} --key workflow.on_complete`
+
+If the resolved `workflow.on_complete` is non-empty, follow it as the final terminal instruction before exiting.

--- a/src/bmm-skills/2-plan-workflows/bmad-create-ux-design/customize.toml
+++ b/src/bmm-skills/2-plan-workflows/bmad-create-ux-design/customize.toml
@@ -1,14 +1,41 @@
 # DO NOT EDIT -- overwritten on every update.
 #
-# Workflow customization surface for bmad-create-ux-design.
+# Workflow customization surface for bmad-create-ux-design. Mirrors the
+# agent customization shape under the [workflow] namespace.
 
 [workflow]
 
+# --- Configurable below. Overrides merge per BMad structural rules: ---
+#   scalars: override wins • arrays (persistent_facts, activation_steps_*): append
+#   arrays-of-tables with `code`/`id`: replace matching items, append new ones.
+
+# Steps to run before the standard activation (config load, greet).
+# Overrides append. Use for pre-flight loads, compliance checks, etc.
+
 activation_steps_prepend = []
+
+# Steps to run after greet but before the workflow begins.
+# Overrides append. Use for context-heavy setup that should happen
+# once the user has been acknowledged.
+
 activation_steps_append = []
+
+# Persistent facts the workflow keeps in mind for the whole run
+# (standards, compliance constraints, stylistic guardrails).
+# Distinct from the runtime memory sidecar — these are static context
+# loaded on activation. Overrides append.
+#
+# Each entry is either:
+#   - a literal sentence, e.g. "All designs must meet WCAG 2.1 AA accessibility standards."
+#   - a file reference prefixed with `file:`, e.g. "file:{project-root}/docs/standards.md"
+#     (glob patterns are supported; the file's contents are loaded and treated as facts).
 
 persistent_facts = [
   "file:{project-root}/**/project-context.md",
 ]
+
+# Scalar: executed when the workflow reaches Step 14 (Workflow Completion),
+# after the UX design specification is finalized and status is updated. Override wins.
+# Leave empty for no custom post-completion behavior.
 
 on_complete = ""

--- a/src/bmm-skills/2-plan-workflows/bmad-create-ux-design/steps/step-14-complete.md
+++ b/src/bmm-skills/2-plan-workflows/bmad-create-ux-design/steps/step-14-complete.md
@@ -169,3 +169,9 @@ This UX design workflow is now complete. The specification serves as the foundat
 - ✅ UX Design Specification: `{planning_artifacts}/ux-design-specification.md`
 - ✅ Color Themes Visualizer: `{planning_artifacts}/ux-color-themes.html`
 - ✅ Design Directions: `{planning_artifacts}/ux-design-directions.html`
+
+## On Complete
+
+Run: `python3 {project-root}/_bmad/scripts/resolve_customization.py --skill {skill-root} --key workflow.on_complete`
+
+If the resolved `workflow.on_complete` is non-empty, follow it as the final terminal instruction before exiting.

--- a/src/bmm-skills/2-plan-workflows/bmad-edit-prd/customize.toml
+++ b/src/bmm-skills/2-plan-workflows/bmad-edit-prd/customize.toml
@@ -1,14 +1,42 @@
 # DO NOT EDIT -- overwritten on every update.
 #
-# Workflow customization surface for bmad-edit-prd.
+# Workflow customization surface for bmad-edit-prd. Mirrors the
+# agent customization shape under the [workflow] namespace.
 
 [workflow]
 
+# --- Configurable below. Overrides merge per BMad structural rules: ---
+#   scalars: override wins • arrays (persistent_facts, activation_steps_*): append
+#   arrays-of-tables with `code`/`id`: replace matching items, append new ones.
+
+# Steps to run before the standard activation (config load, greet).
+# Overrides append. Use for pre-flight loads, compliance checks, etc.
+
 activation_steps_prepend = []
+
+# Steps to run after greet but before the workflow begins.
+# Overrides append. Use for context-heavy setup that should happen
+# once the user has been acknowledged.
+
 activation_steps_append = []
+
+# Persistent facts the workflow keeps in mind for the whole run
+# (standards, compliance constraints, stylistic guardrails).
+# Distinct from the runtime memory sidecar — these are static context
+# loaded on activation. Overrides append.
+#
+# Each entry is either:
+#   - a literal sentence, e.g. "All PRDs must include a regulatory-risk section."
+#   - a file reference prefixed with `file:`, e.g. "file:{project-root}/docs/standards.md"
+#     (glob patterns are supported; the file's contents are loaded and treated as facts).
 
 persistent_facts = [
   "file:{project-root}/**/project-context.md",
 ]
+
+# Scalar: executed when the workflow reaches Step E-4 (Complete & Validate) and the
+# user exits via [S] Summary or [X] Exit — not on [V] Validate (which chains to
+# bmad-validate-prd) or [E] Edit More (which loops back). Override wins.
+# Leave empty for no custom post-completion behavior.
 
 on_complete = ""

--- a/src/bmm-skills/2-plan-workflows/bmad-edit-prd/steps-e/step-e-04-complete.md
+++ b/src/bmm-skills/2-plan-workflows/bmad-edit-prd/steps-e/step-e-04-complete.md
@@ -130,11 +130,13 @@ Display:
     - Before/after comparison (key improvements)
     - Recommendations for next steps
   - Display: "**Edit Workflow Complete**"
+  - Run: `python3 {project-root}/_bmad/scripts/resolve_customization.py --skill {skill-root} --key workflow.on_complete` — if the resolved value is non-empty, follow it as the final terminal instruction before exiting.
   - Exit
 
 - **IF X (Exit):**
   - Display summary
   - Display: "**Edit Workflow Complete**"
+  - Run: `python3 {project-root}/_bmad/scripts/resolve_customization.py --skill {skill-root} --key workflow.on_complete` — if the resolved value is non-empty, follow it as the final terminal instruction before exiting.
   - Exit
 
 - **IF Any other:** Help user, then redisplay menu

--- a/src/bmm-skills/2-plan-workflows/bmad-validate-prd/customize.toml
+++ b/src/bmm-skills/2-plan-workflows/bmad-validate-prd/customize.toml
@@ -1,14 +1,42 @@
 # DO NOT EDIT -- overwritten on every update.
 #
-# Workflow customization surface for bmad-validate-prd.
+# Workflow customization surface for bmad-validate-prd. Mirrors the
+# agent customization shape under the [workflow] namespace.
 
 [workflow]
 
+# --- Configurable below. Overrides merge per BMad structural rules: ---
+#   scalars: override wins • arrays (persistent_facts, activation_steps_*): append
+#   arrays-of-tables with `code`/`id`: replace matching items, append new ones.
+
+# Steps to run before the standard activation (config load, greet).
+# Overrides append. Use for pre-flight loads, compliance checks, etc.
+
 activation_steps_prepend = []
+
+# Steps to run after greet but before the workflow begins.
+# Overrides append. Use for context-heavy setup that should happen
+# once the user has been acknowledged.
+
 activation_steps_append = []
+
+# Persistent facts the workflow keeps in mind for the whole run
+# (standards, compliance constraints, stylistic guardrails).
+# Distinct from the runtime memory sidecar — these are static context
+# loaded on activation. Overrides append.
+#
+# Each entry is either:
+#   - a literal sentence, e.g. "All PRDs must include a regulatory-risk section."
+#   - a file reference prefixed with `file:`, e.g. "file:{project-root}/docs/standards.md"
+#     (glob patterns are supported; the file's contents are loaded and treated as facts).
 
 persistent_facts = [
   "file:{project-root}/**/project-context.md",
 ]
+
+# Scalar: executed when the workflow reaches Step 13 (Validation Report Complete) and
+# the user exits via [X] Exit — not on [E] Use Edit Workflow (which chains to
+# bmad-edit-prd), [R] Review (which loops within), or [F] Fix (which loops within).
+# Override wins. Leave empty for no custom post-completion behavior.
 
 on_complete = ""

--- a/src/bmm-skills/2-plan-workflows/bmad-validate-prd/steps-v/step-v-13-report-complete.md
+++ b/src/bmm-skills/2-plan-workflows/bmad-validate-prd/steps-v/step-v-13-report-complete.md
@@ -196,6 +196,7 @@ Display:
   - Display: "**Validation Report Saved:** {validationReportPath}"
   - Display: "**Summary:** {overall status} - {recommendation}"
   - PRD Validation complete. Invoke the `bmad-help` skill.
+  - Run: `python3 {project-root}/_bmad/scripts/resolve_customization.py --skill {skill-root} --key workflow.on_complete` — if the resolved value is non-empty, follow it as the final terminal instruction before exiting.
 
 - **IF Any other:** Help user, then redisplay menu
 

--- a/src/bmm-skills/3-solutioning/bmad-check-implementation-readiness/customize.toml
+++ b/src/bmm-skills/3-solutioning/bmad-check-implementation-readiness/customize.toml
@@ -1,14 +1,41 @@
 # DO NOT EDIT -- overwritten on every update.
 #
-# Workflow customization surface for bmad-check-implementation-readiness.
+# Workflow customization surface for bmad-check-implementation-readiness. Mirrors the
+# agent customization shape under the [workflow] namespace.
 
 [workflow]
 
+# --- Configurable below. Overrides merge per BMad structural rules: ---
+#   scalars: override wins • arrays (persistent_facts, activation_steps_*): append
+#   arrays-of-tables with `code`/`id`: replace matching items, append new ones.
+
+# Steps to run before the standard activation (config load, greet).
+# Overrides append. Use for pre-flight loads, compliance checks, etc.
+
 activation_steps_prepend = []
+
+# Steps to run after greet but before the workflow begins.
+# Overrides append. Use for context-heavy setup that should happen
+# once the user has been acknowledged.
+
 activation_steps_append = []
+
+# Persistent facts the workflow keeps in mind for the whole run
+# (standards, compliance constraints, stylistic guardrails).
+# Distinct from the runtime memory sidecar — these are static context
+# loaded on activation. Overrides append.
+#
+# Each entry is either:
+#   - a literal sentence, e.g. "All artifacts must follow org naming conventions."
+#   - a file reference prefixed with `file:`, e.g. "file:{project-root}/docs/standards.md"
+#     (glob patterns are supported; the file's contents are loaded and treated as facts).
 
 persistent_facts = [
   "file:{project-root}/**/project-context.md",
 ]
+
+# Scalar: executed when the workflow reaches Step 6 (Final Assessment),
+# after the readiness report has been saved and presented. Override wins.
+# Leave empty for no custom post-completion behavior.
 
 on_complete = ""

--- a/src/bmm-skills/3-solutioning/bmad-check-implementation-readiness/steps/step-06-final-assessment.md
+++ b/src/bmm-skills/3-solutioning/bmad-check-implementation-readiness/steps/step-06-final-assessment.md
@@ -124,3 +124,9 @@ Implementation Readiness complete. Invoke the `bmad-help` skill.
 - Not reviewing previous findings
 - Incomplete summary
 - No clear recommendations
+
+## On Complete
+
+Run: `python3 {project-root}/_bmad/scripts/resolve_customization.py --skill {skill-root} --key workflow.on_complete`
+
+If the resolved `workflow.on_complete` is non-empty, follow it as the final terminal instruction before exiting.

--- a/src/bmm-skills/3-solutioning/bmad-create-architecture/customize.toml
+++ b/src/bmm-skills/3-solutioning/bmad-create-architecture/customize.toml
@@ -1,14 +1,41 @@
 # DO NOT EDIT -- overwritten on every update.
 #
-# Workflow customization surface for bmad-create-architecture.
+# Workflow customization surface for bmad-create-architecture. Mirrors the
+# agent customization shape under the [workflow] namespace.
 
 [workflow]
 
+# --- Configurable below. Overrides merge per BMad structural rules: ---
+#   scalars: override wins • arrays (persistent_facts, activation_steps_*): append
+#   arrays-of-tables with `code`/`id`: replace matching items, append new ones.
+
+# Steps to run before the standard activation (config load, greet).
+# Overrides append. Use for pre-flight loads, compliance checks, etc.
+
 activation_steps_prepend = []
+
+# Steps to run after greet but before the workflow begins.
+# Overrides append. Use for context-heavy setup that should happen
+# once the user has been acknowledged.
+
 activation_steps_append = []
+
+# Persistent facts the workflow keeps in mind for the whole run
+# (standards, compliance constraints, stylistic guardrails).
+# Distinct from the runtime memory sidecar — these are static context
+# loaded on activation. Overrides append.
+#
+# Each entry is either:
+#   - a literal sentence, e.g. "Our org is AWS-only -- do not propose GCP or Azure."
+#   - a file reference prefixed with `file:`, e.g. "file:{project-root}/docs/standards.md"
+#     (glob patterns are supported; the file's contents are loaded and treated as facts).
 
 persistent_facts = [
   "file:{project-root}/**/project-context.md",
 ]
+
+# Scalar: executed when the workflow reaches Step 8 (Architecture Completion & Handoff),
+# after the architecture document frontmatter is updated and next-steps guidance is given.
+# Override wins. Leave empty for no custom post-completion behavior.
 
 on_complete = ""

--- a/src/bmm-skills/3-solutioning/bmad-create-architecture/steps/step-08-complete.md
+++ b/src/bmm-skills/3-solutioning/bmad-create-architecture/steps/step-08-complete.md
@@ -74,3 +74,9 @@ Upon Completion of task output: offer to answer any questions about the Architec
 This is the final step of the Architecture workflow. The user now has a complete, validated architecture document ready for AI agent implementation.
 
 The architecture will serve as the single source of truth for all technical decisions, ensuring consistent implementation across the entire project development lifecycle.
+
+## On Complete
+
+Run: `python3 {project-root}/_bmad/scripts/resolve_customization.py --skill {skill-root} --key workflow.on_complete`
+
+If the resolved `workflow.on_complete` is non-empty, follow it as the final terminal instruction before exiting.

--- a/src/bmm-skills/3-solutioning/bmad-create-epics-and-stories/customize.toml
+++ b/src/bmm-skills/3-solutioning/bmad-create-epics-and-stories/customize.toml
@@ -1,14 +1,41 @@
 # DO NOT EDIT -- overwritten on every update.
 #
-# Workflow customization surface for bmad-create-epics-and-stories.
+# Workflow customization surface for bmad-create-epics-and-stories. Mirrors the
+# agent customization shape under the [workflow] namespace.
 
 [workflow]
 
+# --- Configurable below. Overrides merge per BMad structural rules: ---
+#   scalars: override wins • arrays (persistent_facts, activation_steps_*): append
+#   arrays-of-tables with `code`/`id`: replace matching items, append new ones.
+
+# Steps to run before the standard activation (config load, greet).
+# Overrides append. Use for pre-flight loads, compliance checks, etc.
+
 activation_steps_prepend = []
+
+# Steps to run after greet but before the workflow begins.
+# Overrides append. Use for context-heavy setup that should happen
+# once the user has been acknowledged.
+
 activation_steps_append = []
+
+# Persistent facts the workflow keeps in mind for the whole run
+# (standards, compliance constraints, stylistic guardrails).
+# Distinct from the runtime memory sidecar — these are static context
+# loaded on activation. Overrides append.
+#
+# Each entry is either:
+#   - a literal sentence, e.g. "All epics must deliver complete end-to-end user value."
+#   - a file reference prefixed with `file:`, e.g. "file:{project-root}/docs/standards.md"
+#     (glob patterns are supported; the file's contents are loaded and treated as facts).
 
 persistent_facts = [
   "file:{project-root}/**/project-context.md",
 ]
+
+# Scalar: executed when the workflow reaches Step 4 (Final Validation) and the
+# user confirms [C] Complete — after the epics.md is saved and bmad-help is invoked.
+# Override wins. Leave empty for no custom post-completion behavior.
 
 on_complete = ""

--- a/src/bmm-skills/3-solutioning/bmad-create-epics-and-stories/steps/step-04-final-validation.md
+++ b/src/bmm-skills/3-solutioning/bmad-create-epics-and-stories/steps/step-04-final-validation.md
@@ -129,3 +129,9 @@ When C is selected, the workflow is complete and the epics.md is ready for devel
 Epics and Stories complete. Invoke the `bmad-help` skill.
 
 Upon Completion of task output: offer to answer any questions about the Epics and Stories.
+
+## On Complete
+
+Run: `python3 {project-root}/_bmad/scripts/resolve_customization.py --skill {skill-root} --key workflow.on_complete`
+
+If the resolved `workflow.on_complete` is non-empty, follow it as the final terminal instruction before exiting.

--- a/src/bmm-skills/3-solutioning/bmad-generate-project-context/customize.toml
+++ b/src/bmm-skills/3-solutioning/bmad-generate-project-context/customize.toml
@@ -1,14 +1,41 @@
 # DO NOT EDIT -- overwritten on every update.
 #
-# Workflow customization surface for bmad-generate-project-context.
+# Workflow customization surface for bmad-generate-project-context. Mirrors the
+# agent customization shape under the [workflow] namespace.
 
 [workflow]
 
+# --- Configurable below. Overrides merge per BMad structural rules: ---
+#   scalars: override wins • arrays (persistent_facts, activation_steps_*): append
+#   arrays-of-tables with `code`/`id`: replace matching items, append new ones.
+
+# Steps to run before the standard activation (config load, greet).
+# Overrides append. Use for pre-flight loads, compliance checks, etc.
+
 activation_steps_prepend = []
+
+# Steps to run after greet but before the workflow begins.
+# Overrides append. Use for context-heavy setup that should happen
+# once the user has been acknowledged.
+
 activation_steps_append = []
+
+# Persistent facts the workflow keeps in mind for the whole run
+# (standards, compliance constraints, stylistic guardrails).
+# Distinct from the runtime memory sidecar — these are static context
+# loaded on activation. Overrides append.
+#
+# Each entry is either:
+#   - a literal sentence, e.g. "All artifacts must follow org naming conventions."
+#   - a file reference prefixed with `file:`, e.g. "file:{project-root}/docs/standards.md"
+#     (glob patterns are supported; the file's contents are loaded and treated as facts).
 
 persistent_facts = [
   "file:{project-root}/**/project-context.md",
 ]
+
+# Scalar: executed when the workflow reaches Step 3 (Context Completion & Finalization),
+# after the project-context.md file is optimized and saved. Override wins.
+# Leave empty for no custom post-completion behavior.
 
 on_complete = ""

--- a/src/bmm-skills/3-solutioning/bmad-generate-project-context/steps/step-03-complete.md
+++ b/src/bmm-skills/3-solutioning/bmad-generate-project-context/steps/step-03-complete.md
@@ -276,3 +276,9 @@ Your project context will help ensure high-quality, consistent implementation ac
 This is the final step of the Generate Project Context workflow. The user now has a comprehensive, optimized project context file that will ensure consistent, high-quality implementation across all AI agents working on the project.
 
 The project context file serves as the critical "rules of the road" that agents need to implement code consistently with the project's standards and patterns.
+
+## On Complete
+
+Run: `python3 {project-root}/_bmad/scripts/resolve_customization.py --skill {skill-root} --key workflow.on_complete`
+
+If the resolved `workflow.on_complete` is non-empty, follow it as the final terminal instruction before exiting.

--- a/src/bmm-skills/4-implementation/bmad-correct-course/SKILL.md
+++ b/src/bmm-skills/4-implementation/bmad-correct-course/SKILL.md
@@ -295,6 +295,7 @@ Activation is complete. Begin the workflow below.
 
 <action>Report workflow completion to user with personalized message: "Correct Course workflow complete, {user_name}!"</action>
 <action>Remind user of success criteria and next steps for Developer agent</action>
+<action>Run: `python3 {project-root}/_bmad/scripts/resolve_customization.py --skill {skill-root} --key workflow.on_complete` — if the resolved value is non-empty, follow it as the final terminal instruction before exiting.</action>
 </step>
 
 </workflow>

--- a/src/bmm-skills/4-implementation/bmad-correct-course/customize.toml
+++ b/src/bmm-skills/4-implementation/bmad-correct-course/customize.toml
@@ -1,14 +1,41 @@
 # DO NOT EDIT -- overwritten on every update.
 #
-# Workflow customization surface for bmad-correct-course.
+# Workflow customization surface for bmad-correct-course. Mirrors the
+# agent customization shape under the [workflow] namespace.
 
 [workflow]
 
+# --- Configurable below. Overrides merge per BMad structural rules: ---
+#   scalars: override wins • arrays (persistent_facts, activation_steps_*): append
+#   arrays-of-tables with `code`/`id`: replace matching items, append new ones.
+
+# Steps to run before the standard activation (config load, greet).
+# Overrides append. Use for pre-flight loads, compliance checks, etc.
+
 activation_steps_prepend = []
+
+# Steps to run after greet but before the workflow begins.
+# Overrides append. Use for context-heavy setup that should happen
+# once the user has been acknowledged.
+
 activation_steps_append = []
+
+# Persistent facts the workflow keeps in mind for the whole run
+# (standards, compliance constraints, stylistic guardrails).
+# Distinct from the runtime memory sidecar — these are static context
+# loaded on activation. Overrides append.
+#
+# Each entry is either:
+#   - a literal sentence, e.g. "All sprint changes require PO sign-off before execution."
+#   - a file reference prefixed with `file:`, e.g. "file:{project-root}/docs/standards.md"
+#     (glob patterns are supported; the file's contents are loaded and treated as facts).
 
 persistent_facts = [
   "file:{project-root}/**/project-context.md",
 ]
+
+# Scalar: executed when the workflow reaches Step 6 (Workflow Completion),
+# after the Sprint Change Proposal is finalized and handoff is confirmed. Override wins.
+# Leave empty for no custom post-completion behavior.
 
 on_complete = ""

--- a/src/bmm-skills/4-implementation/bmad-create-story/SKILL.md
+++ b/src/bmm-skills/4-implementation/bmad-create-story/SKILL.md
@@ -411,6 +411,7 @@ Activation is complete. Begin the workflow below.
 
     **The developer now has everything needed for flawless implementation!**
   </output>
+  <action>Run: `python3 {project-root}/_bmad/scripts/resolve_customization.py --skill {skill-root} --key workflow.on_complete` — if the resolved value is non-empty, follow it as the final terminal instruction before exiting.</action>
 </step>
 
 </workflow>

--- a/src/bmm-skills/4-implementation/bmad-create-story/customize.toml
+++ b/src/bmm-skills/4-implementation/bmad-create-story/customize.toml
@@ -1,14 +1,41 @@
 # DO NOT EDIT -- overwritten on every update.
 #
-# Workflow customization surface for bmad-create-story.
+# Workflow customization surface for bmad-create-story. Mirrors the
+# agent customization shape under the [workflow] namespace.
 
 [workflow]
 
+# --- Configurable below. Overrides merge per BMad structural rules: ---
+#   scalars: override wins • arrays (persistent_facts, activation_steps_*): append
+#   arrays-of-tables with `code`/`id`: replace matching items, append new ones.
+
+# Steps to run before the standard activation (config load, greet).
+# Overrides append. Use for pre-flight loads, compliance checks, etc.
+
 activation_steps_prepend = []
+
+# Steps to run after greet but before the workflow begins.
+# Overrides append. Use for context-heavy setup that should happen
+# once the user has been acknowledged.
+
 activation_steps_append = []
+
+# Persistent facts the workflow keeps in mind for the whole run
+# (standards, compliance constraints, stylistic guardrails).
+# Distinct from the runtime memory sidecar — these are static context
+# loaded on activation. Overrides append.
+#
+# Each entry is either:
+#   - a literal sentence, e.g. "All stories must include testable acceptance criteria."
+#   - a file reference prefixed with `file:`, e.g. "file:{project-root}/docs/standards.md"
+#     (glob patterns are supported; the file's contents are loaded and treated as facts).
 
 persistent_facts = [
   "file:{project-root}/**/project-context.md",
 ]
+
+# Scalar: executed when the workflow reaches Step 6 (Update sprint status and finalize),
+# after the story file is saved and sprint-status.yaml is updated. Override wins.
+# Leave empty for no custom post-completion behavior.
 
 on_complete = ""

--- a/src/bmm-skills/4-implementation/bmad-qa-generate-e2e-tests/SKILL.md
+++ b/src/bmm-skills/4-implementation/bmad-qa-generate-e2e-tests/SKILL.md
@@ -168,3 +168,9 @@ If the project needs:
 Save summary to: `{default_output_file}`
 
 **Done!** Tests generated and verified. Validate against `./checklist.md`.
+
+## On Complete
+
+Run: `python3 {project-root}/_bmad/scripts/resolve_customization.py --skill {skill-root} --key workflow.on_complete`
+
+If the resolved `workflow.on_complete` is non-empty, follow it as the final terminal instruction before exiting.

--- a/src/bmm-skills/4-implementation/bmad-qa-generate-e2e-tests/customize.toml
+++ b/src/bmm-skills/4-implementation/bmad-qa-generate-e2e-tests/customize.toml
@@ -1,14 +1,41 @@
 # DO NOT EDIT -- overwritten on every update.
 #
-# Workflow customization surface for bmad-qa-generate-e2e-tests.
+# Workflow customization surface for bmad-qa-generate-e2e-tests. Mirrors the
+# agent customization shape under the [workflow] namespace.
 
 [workflow]
 
+# --- Configurable below. Overrides merge per BMad structural rules: ---
+#   scalars: override wins • arrays (persistent_facts, activation_steps_*): append
+#   arrays-of-tables with `code`/`id`: replace matching items, append new ones.
+
+# Steps to run before the standard activation (config load, greet).
+# Overrides append. Use for pre-flight loads, compliance checks, etc.
+
 activation_steps_prepend = []
+
+# Steps to run after greet but before the workflow begins.
+# Overrides append. Use for context-heavy setup that should happen
+# once the user has been acknowledged.
+
 activation_steps_append = []
+
+# Persistent facts the workflow keeps in mind for the whole run
+# (standards, compliance constraints, stylistic guardrails).
+# Distinct from the runtime memory sidecar — these are static context
+# loaded on activation. Overrides append.
+#
+# Each entry is either:
+#   - a literal sentence, e.g. "All tests must follow the project's existing test framework patterns."
+#   - a file reference prefixed with `file:`, e.g. "file:{project-root}/docs/standards.md"
+#     (glob patterns are supported; the file's contents are loaded and treated as facts).
 
 persistent_facts = [
   "file:{project-root}/**/project-context.md",
 ]
+
+# Scalar: executed when the workflow reaches Step 5 (Create Summary),
+# after all tests pass and the summary document is saved. Override wins.
+# Leave empty for no custom post-completion behavior.
 
 on_complete = ""

--- a/src/bmm-skills/4-implementation/bmad-retrospective/SKILL.md
+++ b/src/bmm-skills/4-implementation/bmad-retrospective/SKILL.md
@@ -1486,7 +1486,7 @@ Alice (Product Owner): "See you at epic planning!"
 Charlie (Senior Dev): "Time to knock out that prep work."
 
 </output>
-
+<action>Run: `python3 {project-root}/_bmad/scripts/resolve_customization.py --skill {skill-root} --key workflow.on_complete` — if the resolved value is non-empty, follow it as the final terminal instruction before exiting.</action>
 </step>
 
 </workflow>

--- a/src/bmm-skills/4-implementation/bmad-retrospective/customize.toml
+++ b/src/bmm-skills/4-implementation/bmad-retrospective/customize.toml
@@ -1,14 +1,41 @@
 # DO NOT EDIT -- overwritten on every update.
 #
-# Workflow customization surface for bmad-retrospective.
+# Workflow customization surface for bmad-retrospective. Mirrors the
+# agent customization shape under the [workflow] namespace.
 
 [workflow]
 
+# --- Configurable below. Overrides merge per BMad structural rules: ---
+#   scalars: override wins • arrays (persistent_facts, activation_steps_*): append
+#   arrays-of-tables with `code`/`id`: replace matching items, append new ones.
+
+# Steps to run before the standard activation (config load, greet).
+# Overrides append. Use for pre-flight loads, compliance checks, etc.
+
 activation_steps_prepend = []
+
+# Steps to run after greet but before the workflow begins.
+# Overrides append. Use for context-heavy setup that should happen
+# once the user has been acknowledged.
+
 activation_steps_append = []
+
+# Persistent facts the workflow keeps in mind for the whole run
+# (standards, compliance constraints, stylistic guardrails).
+# Distinct from the runtime memory sidecar — these are static context
+# loaded on activation. Overrides append.
+#
+# Each entry is either:
+#   - a literal sentence, e.g. "All retrospectives must produce SMART action items with named owners."
+#   - a file reference prefixed with `file:`, e.g. "file:{project-root}/docs/standards.md"
+#     (glob patterns are supported; the file's contents are loaded and treated as facts).
 
 persistent_facts = [
   "file:{project-root}/**/project-context.md",
 ]
+
+# Scalar: executed when the workflow reaches Step 12 (Final Summary and Handoff),
+# after the retrospective document is saved and sprint-status is updated. Override wins.
+# Leave empty for no custom post-completion behavior.
 
 on_complete = ""


### PR DESCRIPTION
## Summary

- All 16 bare workflow `customize.toml` files now carry the same thorough comment block as the well-documented ones (`bmad-document-project`, `bmad-product-brief`), with skill-specific `on_complete` descriptions that name the exact terminal step and exit condition where it fires
- `on_complete` is now executed at the true end of each workflow's terminal step file — not lazily referenced in `SKILL.md`

## What changed

**customize.toml comments** — 16 files updated with full property documentation:
- All arrays (`activation_steps_prepend`, `activation_steps_append`, `persistent_facts`) have comments explaining merge behavior and entry formats
- `on_complete` comment is skill-specific: names the step number, the file, and the exit condition (e.g., edit-prd explains it only fires on S/X, not V/E)

**on_complete integration** — wired into 18 terminal step/instruction files:

| Pattern | Skills |
|---------|--------|
| `## On Complete` block at end of final step file | create-prd (step-12), create-ux-design (step-14), create-architecture (step-08), generate-project-context (step-03), check-implementation-readiness (step-06), epics-and-stories (step-04), domain/market/technical research (step-06 each), prfaq (verdict.md), document-project (both sub-workflow instruction files) |
| Inline on each true exit path only | edit-prd fires on [S] Summary and [X] Exit — not [V] Validate (chains to bmad-validate-prd) or [E] Edit More (loops); validate-prd fires on [X] Exit only — not [R], [E], or [F] |
| `<action>` tag at final step close | correct-course (step-6), create-story (step-6), retrospective (step-12), qa-generate-e2e-tests (SKILL.md end) |

`bmad-product-brief` was already properly integrated and left unchanged.

## Test plan

- [ ] Verify a workflow with empty `on_complete` completes without error
- [ ] Set a non-empty `on_complete` in a team override and confirm it executes as the final instruction
- [ ] Confirm edit-prd [V] path does NOT trigger on_complete (it chains to validate-prd instead)
- [ ] Confirm validate-prd [X] path triggers on_complete; [E] path does not