### PR TITLE
docs: add v6.5.0 changelog entry

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,12 @@
 # Changelog
 
+## v6.5.0 - 2026-04-26
+
+### 🎁 Features
+
+* Support for 18 new agent platforms: AdaL, Sourcegraph Amp, IBM Bob, Command Code, Snowflake Cortex Code, Factory Droid, Firebender, Block Goose, Kode, Mistral Vibe, Mux, Neovate, OpenClaw, OpenHands, Pochi, Replit Agent, Warp, Zencoder — bringing total supported platforms to 42 (#2313)
+* All platforms that support the cross-tool `.agents/skills/` standard now use it (#2313)
+
 ## v6.4.0 - 2026-04-24
 
 ### ✨ Headline


### PR DESCRIPTION
## Summary

Adds the v6.5.0 changelog entry for the platform expansion + shared `.agents/skills/` coordination work that landed in #2313.

## Test plan

- [x] `npm run lint:md` clean