### PR TITLE
fix(installer): remove pre-v6.2.0 wrapper skills on update

### DIFF
--- a/removals.txt
+++ b/removals.txt
@@ -15,3 +15,40 @@ bmad-quick-spec
 bmad-quick-flow
 bmad-quick-dev-new-preview
 bmad-init
+
+# Pre-v6.2.0 wrapper skills (module-prefixed naming, dropped in v6.2.0).
+# Users upgrading from v6.0.x / v6.1.x had these installed and the cleanup
+# never knew to remove them; they remained alongside the new self-contained
+# skills causing duplicates and broken-file errors. See issue #2309.
+bmad-agent-bmm-analyst
+bmad-agent-bmm-architect
+bmad-agent-bmm-dev
+bmad-agent-bmm-pm
+bmad-agent-bmm-qa
+bmad-agent-bmm-quick-flow-solo-dev
+bmad-agent-bmm-sm
+bmad-agent-bmm-tech-writer
+bmad-agent-bmm-ux-designer
+bmad-bmm-check-implementation-readiness
+bmad-bmm-code-review
+bmad-bmm-correct-course
+bmad-bmm-create-architecture
+bmad-bmm-create-epics-and-stories
+bmad-bmm-create-prd
+bmad-bmm-create-product-brief
+bmad-bmm-create-story
+bmad-bmm-create-ux-design
+bmad-bmm-dev-story
+bmad-bmm-document-project
+bmad-bmm-domain-research
+bmad-bmm-edit-prd
+bmad-bmm-generate-project-context
+bmad-bmm-market-research
+bmad-bmm-qa-generate-e2e-tests
+bmad-bmm-quick-dev
+bmad-bmm-quick-spec
+bmad-bmm-retrospective
+bmad-bmm-sprint-planning
+bmad-bmm-sprint-status
+bmad-bmm-technical-research
+bmad-bmm-validate-prd


### PR DESCRIPTION
## Summary

Closes #2309. Adds 32 entries to `removals.txt` covering the module-prefixed wrapper skill names from before v6.2.0 (`bmad-bmm-*` and `bmad-agent-bmm-*`).

## Background

In v6.0.x / v6.1.x, BMAD installed BMM-module skills with module-prefixed canonical IDs like `bmad-bmm-create-prd` and `bmad-agent-bmm-pm`. v6.2.0 dropped the module prefix because BMM is the default — the same skill is now `bmad-create-prd`. The architecture overhaul in v6.4.0 also made these wrappers point at deleted source files.

## The bug

When a user upgrades from v6.0.x / v6.1.x, the installer's cleanup builds its removal set from the current `skill-manifest.csv` and `removals.txt`. The pre-v6.2.0 wrapper names are in neither, so cleanup skips them. The new self-contained skills get installed alongside, leaving 32 stale entries that fail at activation with "missing-file" errors when invoked.

Verified against `npx bmad-method@6.0.4 install --tools codex` — 32 wrappers present.

## Fix

Adds the 32 wrapper names to `removals.txt` under a new section. The cleanup adds `removals.txt` entries to the `removalSet` on every install/update, so the next install for an upgrading user removes the stale wrappers automatically. No code changes needed — the existing cleanup mechanism handles it once the names are known.

## Test plan

- [x] `npm run test:install` — 290 tests pass
- [x] `npm run lint` / `format:check` — clean
- [ ] Reviewer: install v6.0.4, then update to head — confirm `.agents/skills/bmad-bmm-*` are gone after update