### PR TITLE
fix(publish): keep @next ahead of @latest; fix checkForUpdate dist-tag

### DIFF
--- a/.github/workflows/publish.yaml
+++ b/.github/workflows/publish.yaml
@@ -150,3 +150,29 @@ jobs:
           jq -n --arg content "$MSG" '{content: $content}' | curl -sf --retry 2 -X POST "$WEBHOOK" -H "Content-Type: application/json" -d @-
         env:
           WEBHOOK: ${{ secrets.DISCORD_WEBHOOK }}
+
+      # After cutting a stable release, also publish a follow-on prerelease
+      # so the @next dist-tag never lags behind @latest. Without this, a
+      # stable that leapfrogs the current @next head leaves @next pointing at
+      # an older version, and `npx bmad-method@next install` becomes a
+      # downgrade. Reuses the proven `npm publish --provenance` flow rather
+      # than mutating dist-tags directly. Runs last so the GitHub Release and
+      # Discord notify steps above still see the stable version in package.json.
+      - name: Cut follow-on prerelease so @next stays ahead of @latest
+        if: github.event_name == 'workflow_dispatch' && inputs.channel == 'latest'
+        run: |
+          NEXT_VER=$(npm view bmad-method@next version 2>/dev/null || echo "")
+          LATEST_VER=$(node -p 'require("./package.json").version')
+
+          BASE=$(node -e "
+            const semver = require('semver');
+            const next = process.argv[1] || null;
+            const latest = process.argv[2];
+            if (!next) { console.log(latest); process.exit(0); }
+            const nextBase = next.replace(/-next\.\d+$/, '');
+            console.log(semver.gt(latest, nextBase) ? latest : next);
+          " "$NEXT_VER" "$LATEST_VER")
+
+          npm version "$BASE" --no-git-tag-version --allow-same-version
+          npm version prerelease --preid=next --no-git-tag-version
+          npm publish --tag next --provenance

--- a/tools/installer/bmad-cli.js
+++ b/tools/installer/bmad-cli.js
@@ -23,27 +23,37 @@ checkForUpdate().catch(() => {
 
 async function checkForUpdate() {
   try {
-    // For beta versions, check the beta tag; otherwise check latest
-    const isBeta =
-      packageJson.version.includes('Beta') ||
-      packageJson.version.includes('beta') ||
-      packageJson.version.includes('alpha') ||
-      packageJson.version.includes('rc');
-    const tag = isBeta ? 'beta' : 'latest';
+    // Prereleases are tracked under @next; stable releases under @latest.
+    // Check both for prerelease users so they're prompted to switch tracks
+    // if @latest has surpassed their current prerelease.
+    const isPrerelease = semver.prerelease(packageJson.version) !== null;
+    const tagsToCheck = isPrerelease ? ['next', 'latest'] : ['latest'];
 
-    const result = execSync(`npm view ${packageName}@${tag} version`, {
-      encoding: 'utf8',
-      stdio: 'pipe',
-      timeout: 5000,
-    }).trim();
+    let bestVersion = null;
+    let bestTag = null;
+    for (const tag of tagsToCheck) {
+      try {
+        const v = execSync(`npm view ${packageName}@${tag} version`, {
+          encoding: 'utf8',
+          stdio: 'pipe',
+          timeout: 5000,
+        }).trim();
+        if (v && (!bestVersion || semver.gt(v, bestVersion))) {
+          bestVersion = v;
+          bestTag = tag;
+        }
+      } catch {
+        // Skip this tag — registry may not have it or network may be flaky.
+      }
+    }
 
-    if (result && semver.gt(result, packageJson.version)) {
+    if (bestVersion && semver.gt(bestVersion, packageJson.version)) {
       const color = await prompts.getColor();
       const updateMsg = [
-        `You are using version ${packageJson.version} but ${result} is available.`,
+        `You are using version ${packageJson.version} but ${bestVersion} is available.`,
         '',
         'To update, exit and first run:',
-        `  npm cache clean --force && npx bmad-method@${tag} install`,
+        `  npm cache clean --force && npx bmad-method@${bestTag} install`,
       ].join('\n');
       await prompts.box(updateMsg, 'Update Available', {
         rounded: true,


### PR DESCRIPTION
Fixes #2317.

## Problem

Today `npm view bmad-method dist-tags` returns `{ latest: '6.5.0', next: '6.4.1-next.0' }` — `@next` is older than `@latest`. So `npx bmad-method@next install` is currently a downgrade for any user already on 6.5.0.

The root cause is in the publish workflow: when a stable release is cut via `workflow_dispatch` with `channel=latest`, the `latest` dist-tag advances but `next` is never moved forward. As soon as `latest` leapfrogs the current `@next` head (which is exactly what 6.5.0 did), `@next` is left pointing at an older version with no mechanism to catch up.

## Changes

Two commits, separable by maintainer preference:

### `ci(publish): cut follow-on prerelease after stable to keep @next ahead`

After `Publish stable release to npm` succeeds (and after the GitHub Release + Discord notify steps so they still see the stable version in `package.json`), runs the same derive-prerelease logic the existing prerelease step uses, then publishes `--tag next --provenance`.

Chose this over `npm dist-tag add` because the existing OIDC trusted-publishing flow has only been exercised for `npm publish`. Reusing the proven path avoids any uncertainty about whether the trusted-publishing token authorizes dist-tag mutation.

After the next stable release ships, `@next` will land on `<new-stable>.<patch+1>-next.0`, restoring the invariant `next ≥ latest`.

### `fix(installer): check correct dist-tag in checkForUpdate`

Pre-existing bug in `tools/installer/bmad-cli.js` `checkForUpdate`:

```js
const isBeta = packageJson.version.includes('Beta')
  || packageJson.version.includes('beta')
  || packageJson.version.includes('alpha')
  || packageJson.version.includes('rc');
const tag = isBeta ? 'beta' : 'latest';
```

This package's dist-tags are `latest` and `next` — there is no `beta` tag — and the substring match misses the actual prerelease format (`-next.N`). For prerelease users this meant either a silently-failing `npm view @beta` or a fall-through to `@latest`.

Replaced with `semver.prerelease()` for detection, and for prerelease users we now check **both** `@next` and `@latest` and recommend whichever is higher. That way a user stuck on a stale `@next` is still steered to `@latest` if it has surpassed them.

## Verification

- `npm test` passes (290 install component tests + 83 channel tests + lint + format)
- 5 unit-test scenarios exercised for `checkForUpdate` tag selection: stable-on-latest, stable-behind-latest, prerelease-on-stale-next (current bug situation → correctly steered to `@latest`), stable-with-next-ahead (no prompt), prerelease-with-healthy-next (steered to `@next`)
- Workflow change cannot be exercised locally; structurally it appends one step to the latest-channel branch using the same publish primitives the existing prerelease step already uses

## Out of scope

The push trigger's narrow `paths:` filter (mentioned in #2317) is a separate issue and not addressed here.