### PR TITLE
fix(publish): advance @next dist-tag after stable release

### DIFF
--- a/.github/workflows/publish.yaml
+++ b/.github/workflows/publish.yaml
@@ -7,6 +7,7 @@ on:
       - "src/**"
       - "tools/installer/**"
       - "package.json"
+      - "removals.txt"
   workflow_dispatch:
     inputs:
       channel:
@@ -137,6 +138,10 @@ jobs:
 
       - name: Advance @next dist-tag to stable
         if: github.event_name == 'workflow_dispatch' && inputs.channel == 'latest'
+        # Failure here leaves @next stale until the next push-driven prerelease
+        # republishes — annoying but not release-breaking. Don't fail the job
+        # after a successful stable publish + tag + GH release.
+        continue-on-error: true
         run: |
           # Without this, @latest can leapfrog @next (e.g. latest=6.5.0 while
           # next=6.4.1-next.0) and `npx bmad-method@next install` silently
@@ -145,6 +150,7 @@ jobs:
           # bump from this base via the existing derive step above.
           VERSION=$(node -p 'require("./package.json").version')
           npm dist-tag add "bmad-method@${VERSION}" next
+          echo "Advanced @next dist-tag to ${VERSION}"
 
       - name: Notify Discord
         if: github.event_name == 'workflow_dispatch' && inputs.channel == 'latest'

--- a/.github/workflows/publish.yaml
+++ b/.github/workflows/publish.yaml
@@ -135,6 +135,17 @@ jobs:
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 
+      - name: Advance @next dist-tag to stable
+        if: github.event_name == 'workflow_dispatch' && inputs.channel == 'latest'
+        run: |
+          # Without this, @latest can leapfrog @next (e.g. latest=6.5.0 while
+          # next=6.4.1-next.0) and `npx bmad-method@next install` silently
+          # downgrades users. Point @next at the just-published stable so
+          # @next >= @latest always holds; the next push-driven prerelease will
+          # bump from this base via the existing derive step above.
+          VERSION=$(node -p 'require("./package.json").version')
+          npm dist-tag add "bmad-method@${VERSION}" next
+
       - name: Notify Discord
         if: github.event_name == 'workflow_dispatch' && inputs.channel == 'latest'
         continue-on-error: true

--- a/tools/installer/bmad-cli.js
+++ b/tools/installer/bmad-cli.js
@@ -23,13 +23,10 @@ checkForUpdate().catch(() => {
 
 async function checkForUpdate() {
   try {
-    // For beta versions, check the beta tag; otherwise check latest
-    const isBeta =
-      packageJson.version.includes('Beta') ||
-      packageJson.version.includes('beta') ||
-      packageJson.version.includes('alpha') ||
-      packageJson.version.includes('rc');
-    const tag = isBeta ? 'beta' : 'latest';
+    // Prereleases (e.g. 6.5.1-next.0) live on the `next` dist-tag; stable
+    // releases live on `latest`. semver.prerelease() returns null for stable,
+    // so this correctly routes pre-1.0-next/rc/etc. without string matching.
+    const tag = semver.prerelease(packageJson.version) ? 'next' : 'latest';
 
     const result = execSync(`npm view ${packageName}@${tag} version`, {
       encoding: 'utf8',


### PR DESCRIPTION
## Summary

Reported by Sallvain in Discord: `npx bmad-method@next install` is currently a downgrade — it pulls `v6.4.1-next.0` over `v6.5.0`.

**Root cause:** the stable-channel branch in `publish.yaml` publishes `--tag latest` but never advances the `next` dist-tag. Once `latest` leapfrogs `next` (`6.5.0 > 6.4.1-next.0`), `@next` is left pointing at the older version. Compounded by the push trigger's path filter (`src/**`, `tools/installer/**`, `package.json`) — the post-6.5.0 installer fix only touched `removals.txt` so it didn't republish either.

**Bonus bug:** `bmad-cli.js`'s `checkForUpdate` queries the `beta` dist-tag, but this package uses `next` — so prerelease users never see update notifications.

## Changes

- `publish.yaml`: after stable publish, run `npm dist-tag add bmad-method@<version> next` to repoint `@next` at the just-published stable. The existing "Derive next prerelease version" step already picks `max(latest, next)` as its base, so subsequent push-driven prereleases bump from there.
- `bmad-cli.js`: replaced string-matching beta detection with `semver.prerelease(version)` and route prereleases to the `next` dist-tag.

## Test plan
- [ ] Next stable workflow_dispatch run advances `npm view bmad-method dist-tags` so `next == latest` immediately after publish
- [ ] Subsequent push to main produces a fresh `<latest>-next.0` greater than `latest`
- [ ] `npx bmad-method@next install` no longer downgrades a `@latest` install
- [ ] Prerelease users see update notifications in `checkForUpdate`