### PR TITLE
fix(installer): mirror launch channel as default for external modules

### DIFF
--- a/tools/installer/ui.js
+++ b/tools/installer/ui.js
@@ -129,6 +129,24 @@ class UI {
       await prompts.log.warn(warning);
     }
 
+    // When the user launched the installer from a prerelease (npx bmad-method@next),
+    // mirror that intent for external modules: seed the global channel to 'next' so
+    // the module picker's version labels resolve from main HEAD (matching what
+    // actually gets installed) and the interactive channel gate skips — the user
+    // already declared "next" intent by typing @next. Explicit channel flags
+    // override this seed.
+    if (
+      semver.prerelease(installerPackageJson.version) !== null &&
+      !channelOptions.global &&
+      channelOptions.nextSet.size === 0 &&
+      channelOptions.pins.size === 0
+    ) {
+      channelOptions.global = 'next';
+      await prompts.log.info(
+        'Launched from a prerelease — installing all external modules from main HEAD (next channel). Pass --all-stable or --pin to override.',
+      );
+    }
+
     // Get directory from options or prompt
     let confirmedDirectory;
     if (options.directory) {
@@ -331,10 +349,10 @@ class UI {
       selectedModules.unshift('core');
     }
 
-    // Interactive channel gate: "Ready to install (all stable)? [Y/n]" — or
-    // "(all next)" when the installer was launched from a prerelease
-    // (npx bmad-method@next). Only shown for fresh installs with no channel
-    // flags and an external module selected. Non-interactive installs skip this
+    // Interactive channel gate: "Ready to install (all stable)? [Y/n]"
+    // Only shown for fresh installs with no channel flags and an external module
+    // selected. Skipped for prerelease launches because channelOptions.global
+    // was already seeded to 'next' upstream. Non-interactive installs skip this
     // and fall through to the registry default (stable) or whatever flags were
     // supplied.
     await this._interactiveChannelGate({ options, channelOptions, selectedModules });
@@ -1782,17 +1800,16 @@ class UI {
   }
 
   /**
-   * Fast-path channel gate: confirm "all stable" / "all next" or open the
-   * per-module picker. The default channel mirrors the installer's launch tag —
-   * a prerelease bmad-method (npx bmad-method@next) defaults the gate to "all
-   * next"; a stable launch keeps the original "all stable" default.
+   * Fast-path channel gate: confirm "all stable" or open the per-module picker.
    *
    * Skipped when:
    *   - running non-interactively (--yes)
-   *   - the user already passed channel flags (--channel / --pin / --next)
+   *   - the user already passed channel flags (--channel / --pin / --next), OR
+   *     the installer was launched from a prerelease (which seeds
+   *     channelOptions.global = 'next' upstream in promptInstall)
    *   - no externals/community modules are selected
    *
-   * Mutates channelOptions.global / .pins / .nextSet to reflect gate + picker choices.
+   * Mutates channelOptions.pins and channelOptions.nextSet to reflect picker choices.
    */
   async _interactiveChannelGate({ options, channelOptions, selectedModules }) {
     if (options.yes) return;
@@ -1818,24 +1835,11 @@ class UI {
     });
     if (channelSelectable.length === 0) return;
 
-    // When the user launched the installer from a prerelease (npx bmad-method@next),
-    // mirror that intent for external modules: default the gate to "all next" so the
-    // bleeding-edge launch flows end-to-end. Stable launches keep the original
-    // "all stable" default.
-    const launchedFromPrerelease = semver.prerelease(installerPackageJson.version) !== null;
-    const fastPathChannel = launchedFromPrerelease ? 'next' : 'stable';
-
     const fastPath = await prompts.confirm({
-      message: `Ready to install (all ${fastPathChannel})? Pick "n" to customize channels or pin versions.`,
+      message: `Ready to install (all stable)? Pick "n" to customize channels or pin versions.`,
       default: true,
     });
-    if (fastPath) {
-      if (fastPathChannel === 'next') {
-        channelOptions.global = 'next';
-      }
-      // stable: leave channelOptions untouched; registry default applies.
-      return;
-    }
+    if (fastPath) return; // stable for all, registry default applies
 
     // Customize path: per-module picker.
     const { fetchStableTags, parseGitHubRepo } = require('./modules/channel-resolver');
@@ -1865,7 +1869,7 @@ class UI {
           { name: 'next   (main HEAD \u2014 current development)', value: 'next' },
           { name: 'pin    (specific version)', value: 'pin' },
         ],
-        default: fastPathChannel,
+        default: 'stable',
       });
 
       if (choice === 'next') {

--- a/tools/installer/ui.js
+++ b/tools/installer/ui.js
@@ -2,6 +2,7 @@ const path = require('node:path');
 const os = require('node:os');
 const semver = require('semver');
 const fs = require('./fs-native');
+const installerPackageJson = require('../../package.json');
 const { CLIUtils } = require('./cli-utils');
 const { ExternalModuleManager } = require('./modules/external-manager');
 const { resolveModuleVersion } = require('./modules/version-resolver');
@@ -330,10 +331,12 @@ class UI {
       selectedModules.unshift('core');
     }
 
-    // Interactive channel gate: "Ready to install (all stable)? [Y/n]"
-    // Only shown for fresh installs with no channel flags and an external module
-    // selected. Non-interactive installs skip this and fall through to the
-    // registry default (stable) or whatever flags were supplied.
+    // Interactive channel gate: "Ready to install (all stable)? [Y/n]" — or
+    // "(all next)" when the installer was launched from a prerelease
+    // (npx bmad-method@next). Only shown for fresh installs with no channel
+    // flags and an external module selected. Non-interactive installs skip this
+    // and fall through to the registry default (stable) or whatever flags were
+    // supplied.
     await this._interactiveChannelGate({ options, channelOptions, selectedModules });
 
     let toolSelection = await this.promptToolSelection(confirmedDirectory, options);
@@ -1779,14 +1782,17 @@ class UI {
   }
 
   /**
-   * Fast-path channel gate: confirm "all stable" or open the per-module picker.
+   * Fast-path channel gate: confirm "all stable" / "all next" or open the
+   * per-module picker. The default channel mirrors the installer's launch tag —
+   * a prerelease bmad-method (npx bmad-method@next) defaults the gate to "all
+   * next"; a stable launch keeps the original "all stable" default.
    *
    * Skipped when:
    *   - running non-interactively (--yes)
    *   - the user already passed channel flags (--channel / --pin / --next)
    *   - no externals/community modules are selected
    *
-   * Mutates channelOptions.pins and channelOptions.nextSet to reflect picker choices.
+   * Mutates channelOptions.global / .pins / .nextSet to reflect gate + picker choices.
    */
   async _interactiveChannelGate({ options, channelOptions, selectedModules }) {
     if (options.yes) return;
@@ -1812,11 +1818,24 @@ class UI {
     });
     if (channelSelectable.length === 0) return;
 
+    // When the user launched the installer from a prerelease (npx bmad-method@next),
+    // mirror that intent for external modules: default the gate to "all next" so the
+    // bleeding-edge launch flows end-to-end. Stable launches keep the original
+    // "all stable" default.
+    const launchedFromPrerelease = semver.prerelease(installerPackageJson.version) !== null;
+    const fastPathChannel = launchedFromPrerelease ? 'next' : 'stable';
+
     const fastPath = await prompts.confirm({
-      message: `Ready to install (all stable)? Pick "n" to customize channels or pin versions.`,
+      message: `Ready to install (all ${fastPathChannel})? Pick "n" to customize channels or pin versions.`,
       default: true,
     });
-    if (fastPath) return; // stable for all, registry default applies
+    if (fastPath) {
+      if (fastPathChannel === 'next') {
+        channelOptions.global = 'next';
+      }
+      // stable: leave channelOptions untouched; registry default applies.
+      return;
+    }
 
     // Customize path: per-module picker.
     const { fetchStableTags, parseGitHubRepo } = require('./modules/channel-resolver');
@@ -1846,7 +1865,7 @@ class UI {
           { name: 'next   (main HEAD \u2014 current development)', value: 'next' },
           { name: 'pin    (specific version)', value: 'pin' },
         ],
-        default: 'stable',
+        default: fastPathChannel,
       });
 
       if (choice === 'next') {


### PR DESCRIPTION
## Summary

When users run `npx bmad-method@next install`, the bmad-method package itself runs from a prerelease — but the interactive channel gate previously hardcoded "(all stable)", silently defaulting tea/community modules to stable. The bleeding-edge launch did not flow end-to-end.

## Changes

- `tools/installer/ui.js`: detect the installer's own version via `semver.prerelease(installerPackageJson.version)`. If launched from a prerelease, default the gate prompt and per-module picker to `next`. Stable launches keep the original "all stable" default.

## Behavior

| Launch | Gate prompt | Default if user accepts |
|--------|-------------|--------------------------|
| `npx bmad-method install` (stable) | "Ready to install (all stable)?" | stable for all (registry default) |
| `npx bmad-method@next install` | "Ready to install (all next)?" | `channelOptions.global = 'next'` for all |

Users keep full control: hit "n" to customize per-module, or pass explicit `--channel` / `--pin` / `--next` flags to override entirely.

## Test plan
- [ ] Launch with current `@latest` → prompt reads "(all stable)"
- [ ] Launch with current `@next` → prompt reads "(all next)"; accepting installs externals from main HEAD
- [ ] Hit "n" on either → per-module picker default matches the launch channel
- [ ] Pass `--all-stable` while on `@next` → flag wins, gate is skipped