### PR TITLE
fix(installer): resolve url-source custom modules from custom-modules cache

### DIFF
--- a/tools/installer/project-root.js
+++ b/tools/installer/project-root.js
@@ -1,5 +1,6 @@
 const path = require('node:path');
 const os = require('node:os');
+const yaml = require('yaml');
 const fs = require('./fs-native');
 
 /**
@@ -86,8 +87,11 @@ function getExternalModuleCachePath(moduleName, ...segments) {
  * Built-in modules (core, bmm) live under <src>. External official modules are
  * cloned into ~/.bmad/cache/external-modules/<name>/ with varying internal
  * layouts (some at src/module.yaml, some at skills/module.yaml, some nested).
- * Local custom-source modules are not cached; their path is read from the
- * CustomModuleManager resolution cache set during the same install run.
+ * Url-source custom modules are cloned into ~/.bmad/cache/custom-modules/<host>/<owner>/<repo>/
+ * and are resolved by walking the cache and matching `code` or `name` from the
+ * discovered module.yaml. Local custom-source modules are not cached; their
+ * path is read from the CustomModuleManager resolution cache set during the
+ * same install run.
  * This mirrors the candidate-path search in
  * ExternalModuleManager.findExternalModuleSource but performs no git/network
  * work, which keeps it safe to call during manifest writing.
@@ -148,6 +152,35 @@ async function resolveInstalledModuleYaml(moduleName) {
     }
   } catch {
     // Resolution cache unavailable — continue
+  }
+
+  // Fallback: url-source custom modules cloned to ~/.bmad/cache/custom-modules/.
+  // Walk every cached repo, locate its module.yaml via searchRoot, and match by
+  // the yaml's `code` or `name` field. This works on re-install runs where
+  // _resolutionCache is empty and covers both discovery-mode (with marketplace.json)
+  // and direct-mode modules, since we identify repo roots by .bmad-source.json
+  // (written by cloneRepo) or .claude-plugin/ rather than by marketplace.json.
+  try {
+    const customCacheDir = path.join(os.homedir(), '.bmad', 'cache', 'custom-modules');
+    if (await fs.pathExists(customCacheDir)) {
+      const { CustomModuleManager } = require('./modules/custom-module-manager');
+      const customMgr = new CustomModuleManager();
+      const repoRoots = await customMgr._findCacheRepoRoots(customCacheDir);
+      for (const { repoPath } of repoRoots) {
+        const candidate = await searchRoot(repoPath);
+        if (!candidate) continue;
+        try {
+          const parsed = yaml.parse(await fs.readFile(candidate, 'utf8'));
+          if (parsed && (parsed.code === moduleName || parsed.name === moduleName)) {
+            return candidate;
+          }
+        } catch {
+          // Malformed yaml — skip
+        }
+      }
+    }
+  } catch {
+    // Custom-modules cache walk failed — continue
   }
 
   return null;

--- a/tools/installer/project-root.js
+++ b/tools/installer/project-root.js
@@ -103,11 +103,14 @@ async function resolveInstalledModuleYaml(moduleName) {
   const builtIn = path.join(getModulePath(moduleName), 'module.yaml');
   if (await fs.pathExists(builtIn)) return builtIn;
 
-  // Search a resolved root directory using the same candidate-path pattern.
-  async function searchRoot(root) {
+  // Collect every module.yaml under a root using the standard candidate paths.
+  // Url-source repos can host multiple plugins (discovery mode), so we need all
+  // matches, not just the first. Returned in priority order.
+  async function searchRootAll(root) {
+    const results = [];
     for (const dir of ['skills', 'src']) {
       const direct = path.join(root, dir, 'module.yaml');
-      if (await fs.pathExists(direct)) return direct;
+      if (await fs.pathExists(direct)) results.push(direct);
 
       const dirPath = path.join(root, dir);
       if (await fs.pathExists(dirPath)) {
@@ -115,7 +118,7 @@ async function resolveInstalledModuleYaml(moduleName) {
         for (const entry of entries) {
           if (!entry.isDirectory()) continue;
           const nested = path.join(dirPath, entry.name, 'module.yaml');
-          if (await fs.pathExists(nested)) return nested;
+          if (await fs.pathExists(nested)) results.push(nested);
         }
       }
     }
@@ -125,12 +128,19 @@ async function resolveInstalledModuleYaml(moduleName) {
     for (const entry of rootEntries) {
       if (!entry.isDirectory() || !entry.name.endsWith('-setup')) continue;
       const setupAssets = path.join(root, entry.name, 'assets', 'module.yaml');
-      if (await fs.pathExists(setupAssets)) return setupAssets;
+      if (await fs.pathExists(setupAssets)) results.push(setupAssets);
     }
 
     const atRoot = path.join(root, 'module.yaml');
-    if (await fs.pathExists(atRoot)) return atRoot;
-    return null;
+    if (await fs.pathExists(atRoot)) results.push(atRoot);
+    return results;
+  }
+
+  // Backwards-compatible single-result variant for the existing external-cache
+  // and resolution-cache fallbacks (one module per root by construction).
+  async function searchRoot(root) {
+    const all = await searchRootAll(root);
+    return all.length > 0 ? all[0] : null;
   }
 
   const cacheRoot = getExternalModuleCachePath(moduleName);
@@ -155,7 +165,8 @@ async function resolveInstalledModuleYaml(moduleName) {
   }
 
   // Fallback: url-source custom modules cloned to ~/.bmad/cache/custom-modules/.
-  // Walk every cached repo, locate its module.yaml via searchRoot, and match by
+  // Walk every cached repo, enumerate ALL module.yaml files via searchRootAll
+  // (a single repo can host multiple plugins in discovery mode), and match by
   // the yaml's `code` or `name` field. This works on re-install runs where
   // _resolutionCache is empty and covers both discovery-mode (with marketplace.json)
   // and direct-mode modules, since we identify repo roots by .bmad-source.json
@@ -167,15 +178,16 @@ async function resolveInstalledModuleYaml(moduleName) {
       const customMgr = new CustomModuleManager();
       const repoRoots = await customMgr._findCacheRepoRoots(customCacheDir);
       for (const { repoPath } of repoRoots) {
-        const candidate = await searchRoot(repoPath);
-        if (!candidate) continue;
-        try {
-          const parsed = yaml.parse(await fs.readFile(candidate, 'utf8'));
-          if (parsed && (parsed.code === moduleName || parsed.name === moduleName)) {
-            return candidate;
+        const candidates = await searchRootAll(repoPath);
+        for (const candidate of candidates) {
+          try {
+            const parsed = yaml.parse(await fs.readFile(candidate, 'utf8'));
+            if (parsed && (parsed.code === moduleName || parsed.name === moduleName)) {
+              return candidate;
+            }
+          } catch {
+            // Malformed yaml — skip
           }
-        } catch {
-          // Malformed yaml — skip
         }
       }
     }


### PR DESCRIPTION
## Summary
- Closes #2312
- `resolveInstalledModuleYaml` only searched `~/.bmad/cache/external-modules/`, so modules installed via `--custom-source <git-url>` (cached at `~/.bmad/cache/custom-modules/<host>/<owner>/<repo>/`) couldn't be located on re-install runs.
- Adds a fallback that walks the custom-modules cache via `_findCacheRepoRoots`, reuses the existing `searchRoot` candidate-path logic, and matches by the discovered yaml's `code` or `name` field.

## Why
Reproducing #2312:
1. `npx bmad-method install --custom-source https://github.com/<owner>/<repo>`
2. `npx bmad-method install` (re-run, no flag)
3. Warnings:
   ```
   [warn] collectAgentsFromModuleYaml: could not locate module.yaml for '<name>'
   [warn] writeCentralConfig: could not locate module.yaml for '<name>'
   ```
The follow-up to #2316. That PR added a `_resolutionCache.localPath` fallback for local custom-source modules, but the in-memory cache is empty on re-install runs and only stores `localPath` for local sources, so url-source modules cached on disk still slipped through.

## How
- Identifies repo roots by `.bmad-source.json` (written by `cloneRepo`) or `.claude-plugin/`, **not** by `marketplace.json`. This means **both** discovery-mode and direct-mode (no marketplace.json) modules are covered.
- Reuses `searchRoot` from #2316 so all candidate layouts (`skills/`, `src/`, nested, BMB `*-setup/assets/`) are covered identically to the external-cache path.
- Wraps every disk/parse step in try/catch — any failure falls through to `return null` rather than crashing manifest writing.
- No network, no git work — safe to call during manifest writing.

## Test plan
- [x] `pnpm test` — 373 tests pass (290 install + 83 channel)
- [x] `pnpm lint` + `prettier --check` — clean
- [x] Smoke test: built-in modules (`core`, `bmm`) still resolve, missing modules return null cleanly, fallback no-ops without crashing when `~/.bmad/cache/custom-modules/` doesn't exist
- [ ] Manual repro of #2312 in a clean environment with a real `--custom-source <git-url>` install + re-install