### PR TITLE
fix(installer): route community installs through PluginResolver when marketplace.json ships

### DIFF
--- a/tools/installer/modules/community-manager.js
+++ b/tools/installer/modules/community-manager.js
@@ -449,20 +449,39 @@ class CommunityModuleManager {
     const plugins = Array.isArray(marketplaceData?.plugins) ? marketplaceData.plugins : [];
     if (plugins.length === 0) return;
 
-    const plugin = this._selectPluginForModule(plugins, moduleInfo);
-    if (!plugin) {
-      await prompts.log
-        .warn?.(
-          `Community module '${moduleInfo.code}' ships marketplace.json but no plugin entry matches the registry code. ` +
-            `Falling back to legacy install path.`,
-        )
-        .catch(() => {});
+    const selection = this._selectPluginForModule(plugins, moduleInfo);
+    if (!selection) {
+      await this._safeWarn(
+        `Community module '${moduleInfo.code}' ships marketplace.json but no plugin entry matches the registry code. ` +
+          `Falling back to legacy install path.`,
+      );
       return;
+    }
+
+    if (selection.source === 'single-fallback') {
+      // Single-entry marketplace.json whose plugin name doesn't match the registry
+      // code or the module_definition hint. Most likely correct, but worth surfacing
+      // in case marketplace.json is misconfigured and we'd install the wrong plugin.
+      await this._safeWarn(
+        `Community module '${moduleInfo.code}' picked the only plugin in marketplace.json ('${selection.plugin?.name}') ` +
+          `because no name or module_definition match was found. Verify marketplace.json if the install looks wrong.`,
+      );
     }
 
     const { PluginResolver } = require('./plugin-resolver');
     const resolver = new PluginResolver();
-    const resolved = await resolver.resolve(repoPath, plugin);
+    let resolved;
+    try {
+      resolved = await resolver.resolve(repoPath, selection.plugin);
+    } catch (error) {
+      // PluginResolver threw (malformed plugin entry, missing files, etc.).
+      // Honor the silent-fallthrough contract — warn and let the legacy
+      // findModuleSource path handle the install.
+      await this._safeWarn(
+        `PluginResolver failed for community module '${moduleInfo.code}': ${error.message}. ` + `Falling back to legacy install path.`,
+      );
+      return;
+    }
     if (!resolved || resolved.length === 0) return;
 
     // The registry registers a single code per module. If the resolver returns
@@ -472,19 +491,94 @@ class CommunityModuleManager {
     const matched = resolved.find((mod) => mod.code === moduleInfo.code) || (resolved.length === 1 ? resolved[0] : null);
     if (!matched) return;
 
-    // Stamp registry/clone provenance so installFromResolution and downstream
-    // manifest writers see the same channel/sha/tag as the legacy path.
-    matched.code = moduleInfo.code;
-    matched.repoUrl = moduleInfo.url;
-    matched.cloneRef = resolution.channel === 'pinned' ? resolution.version : resolution.approvedTag || null;
-    matched.cloneSha = resolution.sha;
-    matched.communitySource = true;
-    matched.communityChannel = resolution.channel;
-    matched.communityVersion = resolution.version;
-    matched.registryApprovedTag = resolution.approvedTag;
-    matched.registryApprovedSha = resolution.approvedSha;
+    // Shallow-clone before stamping provenance — the resolver may cache or reuse
+    // its return objects, and we don't want install-specific fields leaking back.
+    const stamped = {
+      ...matched,
+      code: moduleInfo.code,
+      repoUrl: moduleInfo.url,
+      cloneRef: resolution.channel === 'pinned' ? resolution.version : resolution.approvedTag || null,
+      cloneSha: resolution.sha,
+      communitySource: true,
+      communityChannel: resolution.channel,
+      communityVersion: resolution.version,
+      registryApprovedTag: resolution.approvedTag,
+      registryApprovedSha: resolution.approvedSha,
+    };
 
-    CommunityModuleManager._pluginResolutions.set(moduleInfo.code, matched);
+    CommunityModuleManager._pluginResolutions.set(moduleInfo.code, stamped);
+  }
+
+  /**
+   * Lazy fallback: resolve marketplace.json straight from the on-disk cache
+   * when `_pluginResolutions` is empty (e.g. callers that reach `install()`
+   * without `cloneModule` having populated the cache earlier in this process).
+   *
+   * Reuses an existing channel resolution if present; otherwise synthesizes a
+   * minimal stable-channel stub from the registry entry + the cached repo's
+   * current HEAD. Returns the cached plugin resolution if one is produced,
+   * otherwise null (caller falls back to the legacy path).
+   *
+   * @param {string} moduleCode
+   * @returns {Promise<Object|null>}
+   */
+  async resolveFromCache(moduleCode) {
+    const existing = this.getPluginResolution(moduleCode);
+    if (existing) return existing;
+
+    const cacheRepoDir = path.join(this.getCacheDir(), moduleCode);
+    const marketplacePath = path.join(cacheRepoDir, '.claude-plugin', 'marketplace.json');
+    if (!(await fs.pathExists(marketplacePath))) return null;
+
+    let moduleInfo;
+    try {
+      moduleInfo = await this.getModuleByCode(moduleCode);
+    } catch {
+      return null;
+    }
+    if (!moduleInfo) return null;
+
+    let channelResolution = this.getResolution(moduleCode);
+    if (!channelResolution) {
+      let sha = '';
+      try {
+        sha = execSync('git rev-parse HEAD', { cwd: cacheRepoDir, stdio: 'pipe' }).toString().trim();
+      } catch {
+        // Not a git repo or unreadable — give up and let the legacy path run.
+        return null;
+      }
+      channelResolution = {
+        channel: 'stable',
+        version: moduleInfo.approvedTag || sha.slice(0, 7),
+        sha,
+        registryApprovedTag: moduleInfo.approvedTag || null,
+        registryApprovedSha: moduleInfo.approvedSha || null,
+      };
+    }
+
+    await this._tryResolveMarketplacePlugin(cacheRepoDir, moduleInfo, {
+      channel: channelResolution.channel,
+      version: channelResolution.version,
+      sha: channelResolution.sha,
+      approvedTag: channelResolution.registryApprovedTag,
+      approvedSha: channelResolution.registryApprovedSha,
+    });
+
+    return this.getPluginResolution(moduleCode);
+  }
+
+  /**
+   * Best-effort warning emitter. `prompts.log.warn` may be undefined in some
+   * harnesses and may return a rejected promise — swallow both cases so a
+   * fallthrough warning can never crash the install.
+   */
+  async _safeWarn(message) {
+    try {
+      const result = prompts.log?.warn?.(message);
+      if (result && typeof result.then === 'function') await result;
+    } catch {
+      /* ignore */
+    }
   }
 
   /**
@@ -492,12 +586,15 @@ class CommunityModuleManager {
    * Precedence:
    *   1. Exact match on `plugin.name === moduleInfo.code`
    *   2. Trailing directory of `module_definition` matches `plugin.name`
-   *   3. Single plugin in marketplace.json — use it
+   *   3. Single plugin in marketplace.json — accepted with a warning so a
+   *      mismatched-but-uniquely-named plugin doesn't install silently.
    *   Otherwise null (caller falls back to legacy path).
+   *
+   * @returns {{plugin: Object, source: 'name'|'hint'|'single-fallback'}|null}
    */
   _selectPluginForModule(plugins, moduleInfo) {
     const byCode = plugins.find((p) => p && p.name === moduleInfo.code);
-    if (byCode) return byCode;
+    if (byCode) return { plugin: byCode, source: 'name' };
 
     if (moduleInfo.moduleDefinition) {
       // module_definition like "src/skills/suno-setup/assets/module.yaml" →
@@ -507,11 +604,11 @@ class CommunityModuleManager {
       if (setupIdx !== -1) {
         const hint = segments[setupIdx];
         const byHint = plugins.find((p) => p && p.name === hint);
-        if (byHint) return byHint;
+        if (byHint) return { plugin: byHint, source: 'hint' };
       }
     }
 
-    if (plugins.length === 1) return plugins[0];
+    if (plugins.length === 1) return { plugin: plugins[0], source: 'single-fallback' };
     return null;
   }
 

--- a/tools/installer/modules/community-manager.js
+++ b/tools/installer/modules/community-manager.js
@@ -29,6 +29,11 @@ class CommunityModuleManager {
   // Shared across all instances; the manifest writer often uses a fresh instance.
   static _resolutions = new Map();
 
+  // moduleCode → ResolvedModule (from PluginResolver) when the cloned repo ships
+  // a `.claude-plugin/marketplace.json`. Lets community installs reuse the same
+  // skill-level install pipeline as custom-source installs (installFromResolution).
+  static _pluginResolutions = new Map();
+
   constructor() {
     this._client = new RegistryClient();
     this._cachedIndex = null;
@@ -38,6 +43,11 @@ class CommunityModuleManager {
   /** Get the most recent channel resolution for a community module. */
   getResolution(moduleCode) {
     return CommunityModuleManager._resolutions.get(moduleCode) || null;
+  }
+
+  /** Get the marketplace.json-derived plugin resolution for a community module, if any. */
+  getPluginResolution(moduleCode) {
+    return CommunityModuleManager._pluginResolutions.get(moduleCode) || null;
   }
 
   // ─── Data Loading ──────────────────────────────────────────────────────────
@@ -371,6 +381,18 @@ class CommunityModuleManager {
       planSource: planEntry.source,
     });
 
+    // If the repo ships a marketplace.json, route through PluginResolver so the
+    // skill-level install pipeline (installFromResolution) handles the copy.
+    // Repos without marketplace.json fall through to the legacy findModuleSource
+    // path unchanged.
+    await this._tryResolveMarketplacePlugin(moduleCacheDir, moduleInfo, {
+      channel: planEntry.channel,
+      version: recordedVersion,
+      sha: installedSha,
+      approvedTag,
+      approvedSha,
+    });
+
     // Install dependencies if needed
     const packageJsonPath = path.join(moduleCacheDir, 'package.json');
     if ((needsDependencyInstall || wasNewClone) && (await fs.pathExists(packageJsonPath))) {
@@ -390,6 +412,107 @@ class CommunityModuleManager {
     }
 
     return moduleCacheDir;
+  }
+
+  // ─── Marketplace.json Resolution ──────────────────────────────────────────
+
+  /**
+   * Detect `.claude-plugin/marketplace.json` in a cloned community repo and
+   * route through PluginResolver. When successful, caches the resolution so
+   * OfficialModulesManager.install() can route the copy through
+   * installFromResolution() — the same path used by custom-source installs.
+   *
+   * Silent no-op when marketplace.json is absent or the resolver returns no
+   * matches; the legacy findModuleSource path then handles the install.
+   *
+   * @param {string} repoPath - Absolute path to the cloned repo
+   * @param {Object} moduleInfo - Normalized community module info
+   * @param {Object} resolution - Resolution metadata from cloneModule
+   * @param {string} resolution.channel - Channel ('stable' | 'next' | 'pinned')
+   * @param {string} resolution.version - Recorded version string
+   * @param {string} resolution.sha - Resolved git SHA
+   * @param {string|null} resolution.approvedTag - Registry approved tag
+   * @param {string|null} resolution.approvedSha - Registry approved SHA
+   */
+  async _tryResolveMarketplacePlugin(repoPath, moduleInfo, resolution) {
+    const marketplacePath = path.join(repoPath, '.claude-plugin', 'marketplace.json');
+    if (!(await fs.pathExists(marketplacePath))) return;
+
+    let marketplaceData;
+    try {
+      marketplaceData = JSON.parse(await fs.readFile(marketplacePath, 'utf8'));
+    } catch {
+      // Malformed marketplace.json — fall through to legacy path.
+      return;
+    }
+
+    const plugins = Array.isArray(marketplaceData?.plugins) ? marketplaceData.plugins : [];
+    if (plugins.length === 0) return;
+
+    const plugin = this._selectPluginForModule(plugins, moduleInfo);
+    if (!plugin) {
+      await prompts.log
+        .warn?.(
+          `Community module '${moduleInfo.code}' ships marketplace.json but no plugin entry matches the registry code. ` +
+            `Falling back to legacy install path.`,
+        )
+        .catch(() => {});
+      return;
+    }
+
+    const { PluginResolver } = require('./plugin-resolver');
+    const resolver = new PluginResolver();
+    const resolved = await resolver.resolve(repoPath, plugin);
+    if (!resolved || resolved.length === 0) return;
+
+    // The registry registers a single code per module. If the resolver returns
+    // multiple modules (Strategy 4: multiple standalone skills), accept only
+    // the entry whose code matches the registry. Other entries are ignored —
+    // they belong to plugins not registered in the community catalog.
+    const matched = resolved.find((mod) => mod.code === moduleInfo.code) || (resolved.length === 1 ? resolved[0] : null);
+    if (!matched) return;
+
+    // Stamp registry/clone provenance so installFromResolution and downstream
+    // manifest writers see the same channel/sha/tag as the legacy path.
+    matched.code = moduleInfo.code;
+    matched.repoUrl = moduleInfo.url;
+    matched.cloneRef = resolution.channel === 'pinned' ? resolution.version : resolution.approvedTag || null;
+    matched.cloneSha = resolution.sha;
+    matched.communitySource = true;
+    matched.communityChannel = resolution.channel;
+    matched.communityVersion = resolution.version;
+    matched.registryApprovedTag = resolution.approvedTag;
+    matched.registryApprovedSha = resolution.approvedSha;
+
+    CommunityModuleManager._pluginResolutions.set(moduleInfo.code, matched);
+  }
+
+  /**
+   * Pick which plugin entry from marketplace.json represents this community module.
+   * Precedence:
+   *   1. Exact match on `plugin.name === moduleInfo.code`
+   *   2. Trailing directory of `module_definition` matches `plugin.name`
+   *   3. Single plugin in marketplace.json — use it
+   *   Otherwise null (caller falls back to legacy path).
+   */
+  _selectPluginForModule(plugins, moduleInfo) {
+    const byCode = plugins.find((p) => p && p.name === moduleInfo.code);
+    if (byCode) return byCode;
+
+    if (moduleInfo.moduleDefinition) {
+      // module_definition like "src/skills/suno-setup/assets/module.yaml" →
+      // hint segment "suno-setup". Match that against plugin names.
+      const segments = moduleInfo.moduleDefinition.split('/').filter(Boolean);
+      const setupIdx = segments.findIndex((s) => s.endsWith('-setup'));
+      if (setupIdx !== -1) {
+        const hint = segments[setupIdx];
+        const byHint = plugins.find((p) => p && p.name === hint);
+        if (byHint) return byHint;
+      }
+    }
+
+    if (plugins.length === 1) return plugins[0];
+    return null;
   }
 
   // ─── Source Finding ───────────────────────────────────────────────────────

--- a/tools/installer/modules/official-modules.js
+++ b/tools/installer/modules/official-modules.js
@@ -269,6 +269,14 @@ class OfficialModules {
       return this.installFromResolution(resolved, bmadDir, fileTrackingCallback, options);
     }
 
+    // Community modules whose cloned repo ships marketplace.json get the same
+    // skill-level install treatment as custom-source installs.
+    const { CommunityModuleManager } = require('./community-manager');
+    const communityResolved = new CommunityModuleManager().getPluginResolution(moduleName);
+    if (communityResolved) {
+      return this.installFromResolution(communityResolved, bmadDir, fileTrackingCallback, options);
+    }
+
     const sourcePath = await this.findModuleSource(moduleName, {
       silent: options.silent,
       channelOptions: options.channelOptions,
@@ -360,21 +368,27 @@ class OfficialModules {
       await this.createModuleDirectories(resolved.code, bmadDir, options);
     }
 
-    // Update manifest. For custom modules, derive channel from the git ref:
-    //   cloneRef present → pinned at that ref
-    //   cloneRef absent  → next (main HEAD)
-    //   local path       → no channel concept
+    // Update manifest. For community installs we honor the channel resolved by
+    // CommunityModuleManager (stable/next/pinned) and propagate the registry's
+    // approved tag/sha. For custom-source installs we derive channel from the
+    // cloneRef (present → pinned, absent → next; local paths have no channel).
     const { Manifest } = require('../core/manifest');
     const manifestObj = new Manifest();
 
     const hasGitClone = !!resolved.repoUrl;
+    const isCommunity = resolved.communitySource === true;
     const manifestEntry = {
-      version: resolved.cloneRef || (hasGitClone ? 'main' : resolved.version || null),
-      source: 'custom',
+      version: resolved.communityVersion || resolved.cloneRef || (hasGitClone ? 'main' : resolved.version || null),
+      source: isCommunity ? 'community' : 'custom',
       npmPackage: null,
       repoUrl: resolved.repoUrl || null,
     };
-    if (hasGitClone) {
+    if (isCommunity) {
+      if (resolved.communityChannel) manifestEntry.channel = resolved.communityChannel;
+      if (resolved.cloneSha) manifestEntry.sha = resolved.cloneSha;
+      if (resolved.registryApprovedTag) manifestEntry.registryApprovedTag = resolved.registryApprovedTag;
+      if (resolved.registryApprovedSha) manifestEntry.registryApprovedSha = resolved.registryApprovedSha;
+    } else if (hasGitClone) {
       manifestEntry.channel = resolved.cloneRef ? 'pinned' : 'next';
       if (resolved.cloneSha) manifestEntry.sha = resolved.cloneSha;
       if (resolved.rawInput) manifestEntry.rawSource = resolved.rawInput;

--- a/tools/installer/modules/official-modules.js
+++ b/tools/installer/modules/official-modules.js
@@ -270,9 +270,16 @@ class OfficialModules {
     }
 
     // Community modules whose cloned repo ships marketplace.json get the same
-    // skill-level install treatment as custom-source installs.
+    // skill-level install treatment as custom-source installs. If the in-process
+    // cache wasn't populated (e.g. caller skipped the pre-clone phase), fall
+    // back to resolving directly from `~/.bmad/cache/community-modules/<name>/`
+    // so we don't silently regress to the legacy half-install path.
     const { CommunityModuleManager } = require('./community-manager');
-    const communityResolved = new CommunityModuleManager().getPluginResolution(moduleName);
+    const communityMgr = new CommunityModuleManager();
+    let communityResolved = communityMgr.getPluginResolution(moduleName);
+    if (!communityResolved) {
+      communityResolved = await communityMgr.resolveFromCache(moduleName);
+    }
     if (communityResolved) {
       return this.installFromResolution(communityResolved, bmadDir, fileTrackingCallback, options);
     }
@@ -400,10 +407,13 @@ class OfficialModules {
       success: true,
       module: resolved.code,
       path: targetPath,
-      // Match the manifestEntry.version expression above so downstream summary
-      // lines show the cloned ref (tag or 'main') instead of the on-disk
-      // package.json version for git-backed custom installs.
-      versionInfo: { version: resolved.cloneRef || (hasGitClone ? 'main' : resolved.version || '') },
+      // Mirror the manifestEntry.version precedence above so downstream summary
+      // lines show the same string we just wrote to disk (community installs
+      // use the registry-approved tag via `communityVersion`; custom git-backed
+      // installs show the cloned ref or 'main').
+      versionInfo: {
+        version: resolved.communityVersion || resolved.cloneRef || (hasGitClone ? 'main' : resolved.version || ''),
+      },
     };
   }
 

--- a/tools/installer/project-root.js
+++ b/tools/installer/project-root.js
@@ -123,12 +123,18 @@ async function resolveInstalledModuleYaml(moduleName) {
       }
     }
 
-    // BMB standard: {setup-skill}/assets/module.yaml (setup skill is any *-setup directory)
-    const rootEntries = await fs.readdir(root, { withFileTypes: true });
-    for (const entry of rootEntries) {
-      if (!entry.isDirectory() || !entry.name.endsWith('-setup')) continue;
-      const setupAssets = path.join(root, entry.name, 'assets', 'module.yaml');
-      if (await fs.pathExists(setupAssets)) results.push(setupAssets);
+    // BMB standard: {setup-skill}/assets/module.yaml (setup skill is any *-setup directory).
+    // Check at the repo root, and also under src/skills/ and skills/ since
+    // marketplace plugins commonly nest skills under src/skills/<name>/.
+    const setupSearchRoots = [root, path.join(root, 'src', 'skills'), path.join(root, 'skills')];
+    for (const setupRoot of setupSearchRoots) {
+      if (!(await fs.pathExists(setupRoot))) continue;
+      const entries = await fs.readdir(setupRoot, { withFileTypes: true });
+      for (const entry of entries) {
+        if (!entry.isDirectory() || !entry.name.endsWith('-setup')) continue;
+        const setupAssets = path.join(setupRoot, entry.name, 'assets', 'module.yaml');
+        if (await fs.pathExists(setupAssets)) results.push(setupAssets);
+      }
     }
 
     const atRoot = path.join(root, 'module.yaml');
@@ -146,6 +152,16 @@ async function resolveInstalledModuleYaml(moduleName) {
   const cacheRoot = getExternalModuleCachePath(moduleName);
   if (await fs.pathExists(cacheRoot)) {
     const found = await searchRoot(cacheRoot);
+    if (found) return found;
+  }
+
+  // Community modules are cloned to ~/.bmad/cache/community-modules/<name>/
+  // (parallel to the external-modules cache used above). Search there too so
+  // collectAgentsFromModuleYaml and writeCentralConfig can locate community
+  // module.yaml files regardless of how nested the layout is.
+  const communityCacheRoot = path.join(os.homedir(), '.bmad', 'cache', 'community-modules', moduleName);
+  if (await fs.pathExists(communityCacheRoot)) {
+    const found = await searchRoot(communityCacheRoot);
     if (found) return found;
   }
 


### PR DESCRIPTION
## Summary

Community-catalog installs were ignoring `.claude-plugin/marketplace.json`, so any community module that ships skills under `src/skills/<name>/` and nests its `module.yaml` inside a setup skill's `assets/` directory ended up half-installed:

- `_bmad/<code>/` got only `module-help.csv` and a generated `config.yaml`.
- The actual skill source trees never landed under `_bmad/<code>/` or `.agents/skills/`.
- The install silently emitted `[warn] collectAgentsFromModuleYaml: could not locate module.yaml for '<code>'` and `[warn] writeCentralConfig: could not locate module.yaml for '<code>'`.

`PluginResolver` already supports this exact layout via Strategy 2 ("setup skill with `assets/module.yaml + module-help.csv`"), but only `CustomModuleManager` (the "install from custom source — Git URL or local path" path) was wired to use it. The community-catalog path was using its own narrower `findModuleSource` lookup that returned just the directory containing `module.yaml`, leaving sibling skill directories invisible to the copier.

This PR routes both paths through the same resolver + `installFromResolution()` pipeline. Verified end-to-end against the live `zarlor/suno-band-manager` community module — all 6 skills now install correctly and no `module.yaml` warnings fire.

## Changes (3 files, +166 / -13)

### `tools/installer/modules/community-manager.js`
- New `_pluginResolutions` static cache + `getPluginResolution()` accessor (parallels existing `_resolutions`).
- `cloneModule()` calls a new `_tryResolveMarketplacePlugin()` after the clone + ref checkout completes.
- `_tryResolveMarketplacePlugin()` reads `.claude-plugin/marketplace.json`, picks the matching plugin, runs `PluginResolver`, stamps registry provenance (channel / sha / approvedTag / approvedSha / `communitySource: true`) onto the resolution, and caches it.
- `_selectPluginForModule()` precedence: exact `plugin.name === code` → `module_definition` setup-skill hint → single-plugin fallback. Otherwise warns and falls through to the legacy path.

### `tools/installer/modules/official-modules.js`
- `install()`: after the existing `CustomModuleManager.getResolution()` check, also consults `CommunityModuleManager.getPluginResolution()` and routes to `installFromResolution()`.
- `installFromResolution()`: branches on `resolved.communitySource` to write `source: 'community'` with the resolved channel and the registry's `registryApprovedTag` / `registryApprovedSha`. Custom-source path is unchanged.

### `tools/installer/project-root.js`
- `resolveInstalledModuleYaml()` now also searches `~/.bmad/cache/community-modules/<name>/`, parallel to the existing external-modules cache lookup.
- `searchRootAll` extends BMB setup-skill detection to walk `src/skills/` and `skills/` in addition to the repo root, so `<root>/src/skills/<name>-setup/assets/module.yaml` is found.

## Backward compatibility

- Repos without `.claude-plugin/marketplace.json` (e.g. WDS, which uses `module_definition: src/module.yaml`) keep going through the legacy `findModuleSource` path. `_tryResolveMarketplacePlugin` returns silently when marketplace.json is absent and `_pluginResolutions` stays empty, so `install()` falls through unchanged.
- The new community manifest entry adds `source: 'community'` and propagates `registryApprovedTag` / `registryApprovedSha` / `channel` — same shape `getModuleVersionInfo` already produces for the legacy path.

## Test plan

- [x] All existing tests green: `npm run test:install` (290 pass), `npm run test:channels` (83 pass), `npm run test:refs` (7 pass).
- [x] `npm run lint` clean, `npm run lint:md` clean, `npm run format:check` clean.
- [x] 23-check fixture suite covering three repo shapes (Suno-style: `marketplace.json` + `src/skills/<name>-setup/assets/module.yaml`; WDS-style: root `module.yaml` and no marketplace.json; bare-style: SKILL.md only):
  - `PluginResolver` returns Strategy 2 with all skill paths for Suno-shape.
  - `_tryResolveMarketplacePlugin` populates the cache with correct provenance for Suno-shape, no-ops for WDS-shape and bare-shape.
  - `resolveInstalledModuleYaml` finds the BMB setup-skill `module.yaml` inside `~/.bmad/cache/community-modules/<name>/src/skills/<name>-setup/assets/`.
  - `installFromResolution` copies all three skill directories under `_bmad/<code>/`, places `module-help.csv` at the module root, and writes `source: community` + `registryApprovedTag` + `sha` + `channel` to `_config/manifest.yaml`.
- [x] Real-world: ran resolver against the actual `~/.bmad/cache/community-modules/suno/` cache from a prior install — Strategy 2 fires, all 6 skills enumerated, module.yaml resolved at the correct nested path.
- [x] Re-installed Suno locally with the patched installer — all 6 skills landed in `_bmad/suno/<name>/` and `.agents/skills/`, no `module.yaml` warnings emitted.