### PR TITLE
fix(create-architecture): unprime step-07 validation checklist (#2292)

### DIFF
--- a/src/bmm-skills/3-solutioning/bmad-create-architecture/steps/step-07-validation.md
+++ b/src/bmm-skills/3-solutioning/bmad-create-architecture/steps/step-07-validation.md
@@ -227,37 +227,39 @@ Prepare the content to append to the document:
 
 ### Architecture Completeness Checklist
 
-**✅ Requirements Analysis**
+Mark each item `[x]` only if validation confirms it; leave `[ ]` if it is missing, partial, or unverified. Any unchecked item must be reflected in the Gap Analysis above and in the Overall Status below.
 
-- [x] Project context thoroughly analyzed
-- [x] Scale and complexity assessed
-- [x] Technical constraints identified
-- [x] Cross-cutting concerns mapped
+**Requirements Analysis**
 
-**✅ Architectural Decisions**
+- [ ] Project context thoroughly analyzed
+- [ ] Scale and complexity assessed
+- [ ] Technical constraints identified
+- [ ] Cross-cutting concerns mapped
 
-- [x] Critical decisions documented with versions
-- [x] Technology stack fully specified
-- [x] Integration patterns defined
-- [x] Performance considerations addressed
+**Architectural Decisions**
 
-**✅ Implementation Patterns**
+- [ ] Critical decisions documented with versions
+- [ ] Technology stack fully specified
+- [ ] Integration patterns defined
+- [ ] Performance considerations addressed
 
-- [x] Naming conventions established
-- [x] Structure patterns defined
-- [x] Communication patterns specified
-- [x] Process patterns documented
+**Implementation Patterns**
 
-**✅ Project Structure**
+- [ ] Naming conventions established
+- [ ] Structure patterns defined
+- [ ] Communication patterns specified
+- [ ] Process patterns documented
 
-- [x] Complete directory structure defined
-- [x] Component boundaries established
-- [x] Integration points mapped
-- [x] Requirements to structure mapping complete
+**Project Structure**
+
+- [ ] Complete directory structure defined
+- [ ] Component boundaries established
+- [ ] Integration points mapped
+- [ ] Requirements to structure mapping complete
 
 ### Architecture Readiness Assessment
 
-**Overall Status:** READY FOR IMPLEMENTATION
+**Overall Status:** {{READY FOR IMPLEMENTATION | READY WITH MINOR GAPS | NOT READY}} (choose READY FOR IMPLEMENTATION only when all 16 checklist items are `[x]` and no Critical Gaps remain; choose NOT READY when any Critical Gap is open or any Requirements Analysis or Architectural Decisions item is unchecked; otherwise READY WITH MINOR GAPS)
 
 **Confidence Level:** {{high/medium/low}} based on validation results
 


### PR DESCRIPTION
## Summary

- Closes #2292.
- `bmad-create-architecture` step-07-validation template shipped with all 16 Architecture Completeness Checklist items pre-checked (`[x]`) and **Overall Status** hard-coded to `READY FOR IMPLEMENTATION`. The validation gate signaled pass before any validation actually ran.
- Reset all 16 checkboxes to `[ ]`, removed the ✅ pre-assertions on the section headers, and replaced the hard-coded status with a templated choice (`READY FOR IMPLEMENTATION | READY WITH MINOR GAPS | NOT READY`) tied to checklist completion and the Gap Analysis above it.
- Added a one-line instruction telling the agent to mark `[x]` only when validation confirms the item, and to reflect any unchecked item in the Gap Analysis and Overall Status.

Single-file change to `src/bmm-skills/3-solutioning/bmad-create-architecture/steps/step-07-validation.md`.

## Test plan

- [x] `npm test` passes locally (refs, install, channels, lint, lint:md, format:check)
- [ ] Run `bmad-create-architecture` end-to-end on a sample project; confirm step-07 emits an unchecked checklist and the agent fills items based on actual validation rather than asserting pass by default
- [ ] Confirm Overall Status is selected from the templated choice (not the hard-coded string) in the saved `architecture.md`