### PR TITLE
refactor(catalog): rename after/before to preceded-by/followed-by

### DIFF
--- a/src/bmm-skills/1-analysis/bmad-prfaq/bmad-manifest.json
+++ b/src/bmm-skills/1-analysis/bmad-prfaq/bmad-manifest.json
@@ -7,8 +7,8 @@
       "description": "Produces battle-tested PRFAQ document and optional LLM distillate for PRD input.",
       "supports-headless": true,
       "phase-name": "1-analysis",
-      "after": ["brainstorming", "perform-research"],
-      "before": ["create-prd"],
+      "preceded-by": ["brainstorming", "perform-research"],
+      "followed-by": ["create-prd"],
       "is-required": false,
       "output-location": "{planning_artifacts}"
     }

--- a/src/bmm-skills/1-analysis/bmad-product-brief/bmad-manifest.json
+++ b/src/bmm-skills/1-analysis/bmad-product-brief/bmad-manifest.json
@@ -8,8 +8,8 @@
       "description": "Produces executive product brief and optional LLM distillate for PRD input.",
       "supports-headless": true,
       "phase-name": "1-analysis",
-      "after": ["brainstorming", "perform-research"],
-      "before": ["create-prd"],
+      "preceded-by": ["brainstorming", "perform-research"],
+      "followed-by": ["create-prd"],
       "is-required": true,
       "output-location": "{planning_artifacts}"
     }

--- a/src/bmm-skills/module-help.csv
+++ b/src/bmm-skills/module-help.csv
@@ -1,4 +1,4 @@
-module,skill,display-name,menu-code,description,action,args,phase,after,before,required,output-location,outputs
+module,skill,display-name,menu-code,description,action,args,phase,preceded-by,followed-by,required,output-location,outputs
 BMad Method,_meta,,,,,,,,,false,https://docs.bmad-method.org/llms.txt,
 BMad Method,bmad-document-project,Document Project,DP,Analyze an existing project to produce useful documentation.,,,anytime,,,false,project-knowledge,*
 BMad Method,bmad-generate-project-context,Generate Project Context,GPC,Scan existing codebase to generate a lean LLM-optimized project-context.md. Essential for brownfield projects.,,,anytime,,,false,output_folder,project context

--- a/src/core-skills/bmad-distillator/resources/distillate-format-reference.md
+++ b/src/core-skills/bmad-distillator/resources/distillate-format-reference.md
@@ -139,7 +139,7 @@ parts: 1
 
 ## Solution Architecture
 - Plugins: skill bundles with Anthropic plugin standard as base format + bmad-manifest.json extending for BMAD-specific metadata (installer options, capabilities, help integration, phase ordering, dependencies)
-- Existing manifest example: `{"module-code":"bmm","replaces-skill":"bmad-create-product-brief","capabilities":[{"name":"create-brief","menu-code":"CB","supports-headless":true,"phase-name":"1-analysis","after":["brainstorming"],"before":["create-prd"],"is-required":true}]}`
+- Existing manifest example: `{"module-code":"bmm","replaces-skill":"bmad-create-product-brief","capabilities":[{"name":"create-brief","menu-code":"CB","supports-headless":true,"phase-name":"1-analysis","preceded-by":["brainstorming"],"followed-by":["create-prd"],"is-required":true}]}`
 - Vercel skills CLI handles platform translation; integration pattern (wrap/fork/call) is PRD decision
 - bmad-setup: global skill scanning installed bmad-manifest.json files, registering capabilities, configuring project settings; always included as base skill in every bundle (solves bootstrapping)
 - bmad-update: plugin update path without full reinstall; technical approach (diff/replace/preserve customizations) is PRD decision

--- a/src/core-skills/bmad-help/SKILL.md
+++ b/src/core-skills/bmad-help/SKILL.md
@@ -33,16 +33,16 @@ When this skill completes, the user should:
 The catalog uses this format:
 
 ```
-module,skill,display-name,menu-code,description,action,args,phase,after,before,required,output-location,outputs
+module,skill,display-name,menu-code,description,action,args,phase,preceded-by,followed-by,required,output-location,outputs
 ```
 
 **Phases** determine the high-level flow:
 - `anytime` — available regardless of workflow state
 - Numbered phases (`1-analysis`, `2-planning`, etc.) flow in order; naming varies by module
 
-**Dependencies** determine ordering within and across phases:
-- `after` — skills that should ideally complete before this one
-- `before` — skills that should run after this one
+**Sequencing** determines recommended ordering within and across phases (these are soft suggestions, not hard gates — see `required` for gating):
+- `preceded-by` — skills that should ideally complete before this one
+- `followed-by` — skills that should ideally run after this one
 - Format: `skill-name` for single-action skills, `skill-name:action` for multi-action skills
 
 **Required gates**:

--- a/src/core-skills/module-help.csv
+++ b/src/core-skills/module-help.csv
@@ -1,4 +1,4 @@
-module,skill,display-name,menu-code,description,action,args,phase,after,before,required,output-location,outputs
+module,skill,display-name,menu-code,description,action,args,phase,preceded-by,followed-by,required,output-location,outputs
 Core,_meta,,,,,,,,,false,https://docs.bmad-method.org/llms.txt,
 Core,bmad-brainstorming,Brainstorming,BSP,Use early in ideation or when stuck generating ideas.,,,anytime,,,false,{output_folder}/brainstorming,brainstorming session
 Core,bmad-party-mode,Party Mode,PM,Orchestrate multi-agent discussions when you need multiple perspectives or want agents to collaborate.,,,anytime,,,false,,

--- a/tools/installer/core/installer.js
+++ b/tools/installer/core/installer.js
@@ -942,7 +942,8 @@ class Installer {
    */
   async mergeModuleHelpCatalogs(bmadDir, _agentEntries = []) {
     const allRows = [];
-    const headerRow = 'module,skill,display-name,menu-code,description,action,args,phase,preceded-by,followed-by,required,output-location,outputs';
+    const headerRow =
+      'module,skill,display-name,menu-code,description,action,args,phase,preceded-by,followed-by,required,output-location,outputs';
     const COLUMN_COUNT = 13;
     const PHASE_INDEX = 7;
 

--- a/tools/installer/core/installer.js
+++ b/tools/installer/core/installer.js
@@ -942,7 +942,7 @@ class Installer {
    */
   async mergeModuleHelpCatalogs(bmadDir, _agentEntries = []) {
     const allRows = [];
-    const headerRow = 'module,skill,display-name,menu-code,description,action,args,phase,after,before,required,output-location,outputs';
+    const headerRow = 'module,skill,display-name,menu-code,description,action,args,phase,preceded-by,followed-by,required,output-location,outputs';
     const COLUMN_COUNT = 13;
     const PHASE_INDEX = 7;
 

--- a/tools/installer/core/installer.js
+++ b/tools/installer/core/installer.js
@@ -12,6 +12,7 @@ const { BMAD_FOLDER_NAME } = require('../ide/shared/path-utils');
 const { InstallPaths } = require('./install-paths');
 const { ExternalModuleManager } = require('../modules/external-manager');
 const { resolveModuleVersion } = require('../modules/version-resolver');
+const { MODULE_HELP_CSV_HEADER } = require('../modules/module-help-schema');
 
 const { ExistingInstall } = require('./existing-install');
 const { warnPreNativeSkillsLegacy } = require('./legacy-warnings');
@@ -942,8 +943,7 @@ class Installer {
    */
   async mergeModuleHelpCatalogs(bmadDir, _agentEntries = []) {
     const allRows = [];
-    const headerRow =
-      'module,skill,display-name,menu-code,description,action,args,phase,preceded-by,followed-by,required,output-location,outputs';
+    const headerRow = MODULE_HELP_CSV_HEADER;
     const COLUMN_COUNT = 13;
     const PHASE_INDEX = 7;
 
@@ -976,9 +976,19 @@ class Installer {
           const content = await fs.readFile(helpFilePath, 'utf8');
           const lines = content.split('\n').filter((line) => line.trim() && !line.startsWith('#'));
 
+          let headerWarned = false;
           for (const line of lines) {
-            // Skip header row
+            // Header row: warn on drift from canonical schema, then skip.
+            // Data rows are loaded positionally regardless, so the warning
+            // is advisory — the maintainer should rename their columns.
             if (line.startsWith('module,')) {
+              if (!headerWarned && line.trim() !== headerRow) {
+                await prompts.log.warn(
+                  `  ${moduleName}/module-help.csv header does not match canonical schema. ` +
+                    `Expected: ${headerRow} | Found: ${line.trim()} | Data loaded positionally.`,
+                );
+                headerWarned = true;
+              }
               continue;
             }
 

--- a/tools/installer/modules/module-help-schema.js
+++ b/tools/installer/modules/module-help-schema.js
@@ -1,0 +1,13 @@
+/**
+ * Canonical schema for per-module `module-help.csv` files.
+ *
+ * Both the merger (`Installer.mergeModuleHelpCatalogs`) and the synthesizer
+ * (`PluginResolver._buildSynthesizedHelpCsv`) emit this exact header. The
+ * merger compares each per-module file's header against this string and
+ * warns on drift, so any rename here must be matched in external module
+ * authors' CSVs (or accepted as a positional fall-through with a warning).
+ */
+const MODULE_HELP_CSV_HEADER =
+  'module,skill,display-name,menu-code,description,action,args,phase,preceded-by,followed-by,required,output-location,outputs';
+
+module.exports = { MODULE_HELP_CSV_HEADER };

--- a/tools/installer/modules/plugin-resolver.js
+++ b/tools/installer/modules/plugin-resolver.js
@@ -338,7 +338,7 @@ class PluginResolver {
    * @returns {string} CSV content
    */
   _buildSynthesizedHelpCsv(moduleName, skillInfos) {
-    const header = 'module,skill,display-name,menu-code,description,action,args,phase,after,before,required,output-location,outputs';
+    const header = 'module,skill,display-name,menu-code,description,action,args,phase,preceded-by,followed-by,required,output-location,outputs';
     const rows = [header];
 
     for (const info of skillInfos) {

--- a/tools/installer/modules/plugin-resolver.js
+++ b/tools/installer/modules/plugin-resolver.js
@@ -1,6 +1,7 @@
 const fs = require('../fs-native');
 const path = require('node:path');
 const yaml = require('yaml');
+const { MODULE_HELP_CSV_HEADER } = require('./module-help-schema');
 
 /**
  * Resolves how to install a plugin from marketplace.json by analyzing
@@ -338,9 +339,7 @@ class PluginResolver {
    * @returns {string} CSV content
    */
   _buildSynthesizedHelpCsv(moduleName, skillInfos) {
-    const header =
-      'module,skill,display-name,menu-code,description,action,args,phase,preceded-by,followed-by,required,output-location,outputs';
-    const rows = [header];
+    const rows = [MODULE_HELP_CSV_HEADER];
 
     for (const info of skillInfos) {
       const displayName = this._formatDisplayName(info.name || info.dirName);

--- a/tools/installer/modules/plugin-resolver.js
+++ b/tools/installer/modules/plugin-resolver.js
@@ -338,7 +338,8 @@ class PluginResolver {
    * @returns {string} CSV content
    */
   _buildSynthesizedHelpCsv(moduleName, skillInfos) {
-    const header = 'module,skill,display-name,menu-code,description,action,args,phase,preceded-by,followed-by,required,output-location,outputs';
+    const header =
+      'module,skill,display-name,menu-code,description,action,args,phase,preceded-by,followed-by,required,output-location,outputs';
     const rows = [header];
 
     for (const info of skillInfos) {


### PR DESCRIPTION
## Summary

- Renames the `after` and `before` columns in `module-help.csv` (and matching JSON manifest keys) to `preceded-by` and `followed-by` so the dependency direction is unambiguous.
- The bare prepositions had no subject anchor — "X has Y in its `after` column" reads plausibly as either "Y comes after X" or "X comes after Y", and an LLM consumer recently flipped the direction because of it. Passive-voice participles ("X is preceded by Y") force a single reading.
- The separate `required` column continues to carry hard-gate semantics; the renamed columns remain pure soft-sequencing hints, as already documented in `bmad-help`.

Files touched:
- `src/bmm-skills/module-help.csv`, `src/core-skills/module-help.csv` — header rename
- `src/core-skills/bmad-help/SKILL.md` — schema doc + descriptions
- `tools/installer/core/installer.js`, `tools/installer/modules/plugin-resolver.js` — header strings used to synthesize `bmad-help.csv`
- `src/bmm-skills/1-analysis/bmad-product-brief/bmad-manifest.json`, `src/bmm-skills/1-analysis/bmad-prfaq/bmad-manifest.json` — JSON keys
- `src/core-skills/bmad-distillator/resources/distillate-format-reference.md` — manifest example in prose

## Test plan

- [x] `npm ci && npm run quality` passes locally (format, lint, docs:build, tests, validate:refs, validate:skills — only 2 pre-existing LOW skill findings unrelated to this change)
- [ ] Reviewer: install BMAD into a fresh directory and confirm the synthesized `_bmad/_config/bmad-help.csv` carries the new column names
- [ ] Reviewer: invoke `bmad-help` and confirm dependency-aware recommendations still surface in the right order

🤖 Generated with [Claude Code](https://claude.com/claude-code)
