### PR TITLE
fix(installer): descriptive error when module definition missing after clone

### DIFF
--- a/tools/installer/modules/external-manager.js
+++ b/tools/installer/modules/external-manager.js
@@ -532,13 +532,11 @@ class ExternalModuleManager {
     const resolution = ExternalModuleManager._resolutions.get(moduleCode);
     const versionHint = resolution?.version ? `version ${resolution.version}` : 'the cloned version';
     const channelHint =
-      resolution?.channel === 'stable'
-        ? ` Try reinstalling with \`--next=${moduleCode}\` to use the latest main branch instead.`
-        : '';
+      resolution?.channel === 'stable' ? ` Try reinstalling with \`--next=${moduleCode}\` to use the latest main branch instead.` : '';
     throw new Error(
       `Module '${moduleCode}' was downloaded but its module definition was not found. ` +
-      `Expected '${moduleDefinitionPath}' to exist in ${versionHint}, but it is missing. ` +
-      `The repository may have been restructured after this release was tagged.${channelHint}`,
+        `Expected '${moduleDefinitionPath}' to exist in ${versionHint}, but it is missing. ` +
+        `The repository may have been restructured after this release was tagged.${channelHint}`,
     );
   }
   cachedModules = null;

--- a/tools/installer/modules/external-manager.js
+++ b/tools/installer/modules/external-manager.js
@@ -524,8 +524,22 @@ class ExternalModuleManager {
       return path.dirname(rootCandidate);
     }
 
-    // Nothing found: return configured path (preserves old behavior for error messaging)
-    return path.dirname(configuredPath);
+    // Nothing found: the cloned ref does not contain a recognizable module structure.
+    // This happens when a stable tag predates a module restructure (e.g. the repo
+    // moved files from payload/ to skills/ after the tag was cut). Returning a
+    // non-existent path silently causes a confusing ENOENT deep inside copyModuleWithFiltering;
+    // throw a descriptive error here instead so the user knows what happened and how to recover.
+    const resolution = ExternalModuleManager._resolutions.get(moduleCode);
+    const versionHint = resolution?.version ? `version ${resolution.version}` : 'the cloned version';
+    const channelHint =
+      resolution?.channel === 'stable'
+        ? ` Try reinstalling with \`--next=${moduleCode}\` to use the latest main branch instead.`
+        : '';
+    throw new Error(
+      `Module '${moduleCode}' was downloaded but its module definition was not found. ` +
+        `Expected '${moduleDefinitionPath}' to exist in ${versionHint}, but it is missing. ` +
+        `The repository may have been restructured after this release was tagged.${channelHint}`,
+    );
   }
   cachedModules = null;
 }

--- a/tools/installer/modules/external-manager.js
+++ b/tools/installer/modules/external-manager.js
@@ -537,8 +537,8 @@ class ExternalModuleManager {
         : '';
     throw new Error(
       `Module '${moduleCode}' was downloaded but its module definition was not found. ` +
-        `Expected '${moduleDefinitionPath}' to exist in ${versionHint}, but it is missing. ` +
-        `The repository may have been restructured after this release was tagged.${channelHint}`,
+      `Expected '${moduleDefinitionPath}' to exist in ${versionHint}, but it is missing. ` +
+      `The repository may have been restructured after this release was tagged.${channelHint}`,
     );
   }
   cachedModules = null;


### PR DESCRIPTION
## What

`findExternalModuleSource` now throws a clear, actionable error when a cloned module's repo doesn't contain the expected module definition path, instead of silently returning that non-existent path.

## Why

When a stable tag predates a module restructure, the installer cloned the tagged version, couldn't find `module_definition` (e.g. `skills/module.yaml`) anywhere in the repo, then silently returned the configured (but non-existent) path as `sourcePath`. This caused a confusing ENOENT buried inside `getFileList`/`copyModuleWithFiltering`:

```
ENOENT: no such file or directory, scandir '~/.bmad/cache/external-modules/baut/skills'
    at async OfficialModules.getFileList (official-modules.js:785:21)
    at async OfficialModules.copyModuleWithFiltering (official-modules.js:519:25)
    at async OfficialModules.install (official-modules.js:303:5)
```

Users had no idea which module failed or why. Reported in #2372.

## How

Replaced the silent `return path.dirname(configuredPath)` fallback with a thrown error that:
- Names the module code and missing definition path
- Includes the version/tag that was cloned
- When the channel was `stable`, appends a `--next=<code>` hint so the user can recover immediately

## Example new error

```
Error: Module 'baut' was downloaded but its module definition was not found.
Expected 'skills/module.yaml' to exist in version v1.14.0, but it is missing.
The repository may have been restructured after this release was tagged.
Try reinstalling with `--next=baut` to use the latest main branch instead.
```

## Related

- Closes #2372
- Root cause fix: created `v1.14.2` git tag on `bmad-code-org/bmad-automator`
- Registry fix: `bmad-code-org/bmad-plugins-marketplace` PR setting `default_channel: next` for `baut`