### PR TITLE
[codex] Fix brainstorming collaborative idea flow

### DIFF
--- a/src/core-skills/bmad-brainstorming/steps/step-03-technique-execution.md
+++ b/src/core-skills/bmad-brainstorming/steps/step-03-technique-execution.md
@@ -7,7 +7,7 @@
 ## MANDATORY EXECUTION RULES (READ FIRST):
 
 - ✅ YOU ARE A CREATIVE FACILITATOR, engaging in genuine back-and-forth coaching
-- 🎯 AIM FOR 100+ IDEAS before suggesting organization - quantity unlocks quality (quality must grow as we progress)
+- 🎯 AIM FOR 100+ COLLABORATIVE IDEAS before suggesting organization - quantity unlocks quality, but do not batch-generate ideas to satisfy the count
 - 🔄 DEFAULT IS TO KEEP EXPLORING - only move to organization when user explicitly requests it
 - 🧠 **THOUGHT BEFORE INK (CoT):** Before generating each idea, you must internally reason: "What domain haven't we explored yet? What would make this idea surprising or 'uncomfortable' for the user?"
 - 🛡️ **ANTI-BIAS DOMAIN PIVOT:** Every 10 ideas, review existing themes and consciously pivot to an orthogonal domain (e.g., UX -> Business -> Physics -> Social Impact).
@@ -29,6 +29,7 @@ _Novelty_: [What makes this different from obvious solutions]
 ## EXECUTION PROTOCOLS:
 
 - 🎯 Present one technique element at a time for deep exploration
+- 🛑 Present at most one new idea, provocation, or angle before asking for user input
 - ⚠️ Ask "Continue with current technique?" before moving to next technique
 - 💾 Document insights and ideas using the **IDEA FORMAT TEMPLATE**
 - 📖 Follow user's creative energy and interests within technique structure
@@ -171,7 +172,7 @@ Before moving to next technique element:
 - **Switch techniques** for a fresh perspective?
 - Or are you feeling like we've **thoroughly explored** this space?
 
-Remember: The goal is quantity first - we can organize later. What feels right?"
+Remember: The goal is quantity through collaboration, not a generated list. What feels right?"
 
 **IMPORTANT:** Default to continuing exploration. Only suggest organization if:
 
@@ -292,7 +293,7 @@ After final technique element:
 
 **HALT — wait for user selection before proceeding.**
 
-**Default recommendation:** Unless you feel we've generated at least 100+ ideas, I suggest we keep exploring! The best insights often come after the obvious ideas are exhausted.
+**Default recommendation:** Unless you feel we've developed enough ideas together, I suggest we keep exploring. The best insights often come after the obvious ideas are exhausted.
 
 ### 8. Handle Menu Selection
 
@@ -362,7 +363,7 @@ When user selects 'C', append the content directly to `{brainstorming_session_ou
 
 ## SUCCESS METRICS:
 
-✅ Minimum 100 ideas generated before organization is offered
+✅ Substantial collaborative idea volume before organization is offered
 ✅ User explicitly confirms readiness to conclude (not AI-initiated)
 ✅ Multiple technique exploration encouraged over single-technique completion
 ✅ True back-and-forth facilitation rather than question-answer format
@@ -376,6 +377,7 @@ When user selects 'C', append the content directly to `{brainstorming_session_ou
 ## FAILURE MODES:
 
 ❌ Offering organization after only one technique or <20 ideas
+❌ Batch-generating idea lists instead of facilitating dialogue
 ❌ AI initiating conclusion without user explicitly requesting it
 ❌ Treating technique completion as session completion signal
 ❌ Rushing to document rather than staying in generative mode

--- a/src/core-skills/bmad-brainstorming/workflow.md
+++ b/src/core-skills/bmad-brainstorming/workflow.md
@@ -12,7 +12,7 @@ context_file: '' # Optional context file path for project-specific guidance
 
 **Anti-Bias Protocol:** LLMs naturally drift toward semantic clustering (sequential bias). To combat this, you MUST consciously shift your creative domain every 10 ideas. If you've been focusing on technical aspects, pivot to user experience, then to business viability, then to edge cases or "black swan" events. Force yourself into orthogonal categories to maintain true divergence.
 
-**Quantity Goal:** Aim for 100+ ideas before any organization. The first 20 ideas are usually obvious - the magic happens in ideas 50-100.
+**Quantity Goal:** Aim for 100+ collaboratively developed ideas before any organization. This is a session goal, not a request to generate a large list. Ideas count only when they emerge through dialogue with the user or are accepted and developed by the user.
 
 ---
 


### PR DESCRIPTION
## Summary

Clarifies the brainstorming workflow's quantity target so `100+ ideas` is treated as a long-running collaborative session goal, not permission for the model to batch-generate a large idea list.

## Why

The brainstorming skill already frames the agent as a facilitator, but the old quantity language could be interpreted as “generate 100 ideas yourself.” That undercuts the intended back-and-forth coaching mode.

## Changes

- Defines the quantity target as `100+ collaboratively developed ideas`.
- Counts only ideas that emerge through dialogue or are accepted and developed by the user.
- Adds an execution rule to present at most one new idea, provocation, or angle before asking for user input.
- Marks batch-generated idea lists as a failure mode.

## Validation

- `npm run validate:skills`
- `npx markdownlint-cli2 src/core-skills/bmad-brainstorming/workflow.md src/core-skills/bmad-brainstorming/steps/step-03-technique-execution.md`
- Full pre-commit `npm test` suite ran successfully during commit.
