### PR TITLE
feat(web-bundles): release packager + manifest for bmadcode.com/web-bundles/

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -81,3 +81,6 @@ _bmad/custom/*.user.toml
 website/.astro/
 website/dist/
 build/
+
+# Web bundle release artifacts
+dist/web-bundles/

--- a/tools/bundle-web-bundles.js
+++ b/tools/bundle-web-bundles.js
@@ -7,10 +7,8 @@
  * Usage:
  *   node tools/bundle-web-bundles.js
  *
- * Then upload the resulting zips to a GitHub Release:
- *   gh release create web-bundles-v1 dist/web-bundles/*.zip \
- *     --title "Web Bundles v1" \
- *     --notes "BMad web bundles for Gemini Gems and ChatGPT Custom GPTs"
+ * After running, the script prints the exact `gh release create` command
+ * (with the correct tag from bundles.json) for you to copy.
  */
 
 const fs = require('node:fs');
@@ -22,14 +20,42 @@ const BUNDLES_DIR = path.join(REPO_ROOT, 'web-bundles');
 const DIST_DIR = path.join(REPO_ROOT, 'dist', 'web-bundles');
 const MANIFEST = path.join(BUNDLES_DIR, 'bundles.json');
 
-function main() {
-  if (!fs.existsSync(MANIFEST)) {
-    console.error(`Error: bundles.json not found at ${MANIFEST}`);
-    process.exit(1);
-  }
+function fail(msg) {
+  console.error(`[ERROR] ${msg}`);
+  process.exit(1);
+}
 
-  const manifest = JSON.parse(fs.readFileSync(MANIFEST, 'utf-8'));
-  const releaseTag = manifest.releaseTag || 'web-bundles-v1';
+function requireZipCli() {
+  try {
+    execSync('zip -v', { stdio: 'ignore' });
+  } catch {
+    fail("'zip' CLI not found on PATH. Install zip (macOS: preinstalled; Debian/Ubuntu: apt install zip; Alpine: apk add zip) and re-run.");
+  }
+}
+
+function loadManifest() {
+  if (!fs.existsSync(MANIFEST)) {
+    fail(`bundles.json not found at ${MANIFEST}`);
+  }
+  let manifest;
+  try {
+    manifest = JSON.parse(fs.readFileSync(MANIFEST, 'utf-8'));
+  } catch (error) {
+    fail(`bundles.json is not valid JSON: ${error.message}`);
+  }
+  if (!Array.isArray(manifest.bundles) || manifest.bundles.length === 0) {
+    fail('bundles.json is missing a non-empty "bundles" array.');
+  }
+  if (typeof manifest.releaseTag !== 'string' || !manifest.releaseTag) {
+    fail('bundles.json is missing "releaseTag".');
+  }
+  return manifest;
+}
+
+function main() {
+  requireZipCli();
+  const manifest = loadManifest();
+  const releaseTag = manifest.releaseTag;
 
   fs.mkdirSync(DIST_DIR, { recursive: true });
 
@@ -37,6 +63,10 @@ function main() {
 
   const zipped = [];
   for (const bundle of manifest.bundles) {
+    if (!bundle.slug) {
+      console.warn(`  [SKIP] bundle entry missing slug — ${JSON.stringify(bundle).slice(0, 80)}`);
+      continue;
+    }
     const src = path.join(BUNDLES_DIR, bundle.slug);
     if (!fs.existsSync(src)) {
       console.warn(`  [SKIP] ${bundle.slug} — directory not found`);
@@ -46,20 +76,28 @@ function main() {
     const out = path.join(DIST_DIR, `${bundle.slug}.zip`);
     if (fs.existsSync(out)) fs.unlinkSync(out);
 
-    execSync(`zip -r -X -q "${out}" "${bundle.slug}" -x "*.DS_Store"`, {
-      cwd: BUNDLES_DIR,
-      stdio: 'inherit',
-    });
+    try {
+      execSync(`zip -r -X -q "${out}" "${bundle.slug}" -x "*.DS_Store"`, {
+        cwd: BUNDLES_DIR,
+        stdio: 'inherit',
+      });
+    } catch (error) {
+      fail(`zip failed for ${bundle.slug}: ${error.message}`);
+    }
 
     const size = (fs.statSync(out).size / 1024).toFixed(1);
     console.log(`  [OK] ${bundle.slug}.zip (${size} KB)`);
     zipped.push(bundle.slug);
   }
 
+  if (zipped.length === 0) {
+    fail('No bundles were packaged. Check bundles.json slugs against web-bundles/ subdirectories.');
+  }
+
   console.log(`\nWrote ${zipped.length} bundles to ${path.relative(REPO_ROOT, DIST_DIR)}/`);
   console.log('\nNext step — create or update the GitHub Release:\n');
   console.log(`  gh release create ${releaseTag} dist/web-bundles/*.zip \\`);
-  console.log(`    --title "Web Bundles v1" \\`);
+  console.log(`    --title "${releaseTag}" \\`);
   console.log(`    --notes "BMad web bundles for Gemini Gems and ChatGPT Custom GPTs. See https://bmadcode.com/web-bundles/"\n`);
   console.log('Or, to refresh an existing release:\n');
   console.log(`  gh release upload ${releaseTag} dist/web-bundles/*.zip --clobber\n`);

--- a/tools/bundle-web-bundles.js
+++ b/tools/bundle-web-bundles.js
@@ -13,12 +13,13 @@
 
 const fs = require('node:fs');
 const path = require('node:path');
-const { execSync } = require('node:child_process');
+const { execSync, execFileSync } = require('node:child_process');
 
 const REPO_ROOT = path.resolve(__dirname, '..');
 const BUNDLES_DIR = path.join(REPO_ROOT, 'web-bundles');
 const DIST_DIR = path.join(REPO_ROOT, 'dist', 'web-bundles');
 const MANIFEST = path.join(BUNDLES_DIR, 'bundles.json');
+const SLUG_RE = /^[a-z0-9][a-z0-9-]*$/;
 
 function fail(msg) {
   console.error(`[ERROR] ${msg}`);
@@ -62,14 +63,18 @@ function main() {
   console.log(`Packaging ${manifest.bundles.length} bundles for release ${releaseTag}\n`);
 
   const zipped = [];
+  const missing = [];
+  const invalid = [];
   for (const bundle of manifest.bundles) {
-    if (!bundle.slug) {
-      console.warn(`  [SKIP] bundle entry missing slug — ${JSON.stringify(bundle).slice(0, 80)}`);
+    if (!bundle.slug || !SLUG_RE.test(bundle.slug)) {
+      invalid.push(bundle.slug || '(no slug)');
+      console.error(`  [INVALID] slug must match ${SLUG_RE} — got: ${bundle.slug}`);
       continue;
     }
     const src = path.join(BUNDLES_DIR, bundle.slug);
     if (!fs.existsSync(src)) {
-      console.warn(`  [SKIP] ${bundle.slug} — directory not found`);
+      missing.push(bundle.slug);
+      console.error(`  [MISSING] ${bundle.slug} — directory not found`);
       continue;
     }
 
@@ -77,7 +82,7 @@ function main() {
     if (fs.existsSync(out)) fs.unlinkSync(out);
 
     try {
-      execSync(`zip -r -X -q "${out}" "${bundle.slug}" -x "*.DS_Store"`, {
+      execFileSync('zip', ['-r', '-X', '-q', out, bundle.slug, '-x', '*.DS_Store'], {
         cwd: BUNDLES_DIR,
         stdio: 'inherit',
       });
@@ -90,8 +95,14 @@ function main() {
     zipped.push(bundle.slug);
   }
 
+  if (invalid.length > 0) {
+    fail(`Refusing to publish: ${invalid.length} bundle(s) have invalid slugs: ${invalid.join(', ')}`);
+  }
+  if (missing.length > 0) {
+    fail(`Refusing to publish an incomplete release: missing directories for ${missing.join(', ')}`);
+  }
   if (zipped.length === 0) {
-    fail('No bundles were packaged. Check bundles.json slugs against web-bundles/ subdirectories.');
+    fail('No bundles were packaged. Check bundles.json against web-bundles/ subdirectories.');
   }
 
   console.log(`\nWrote ${zipped.length} bundles to ${path.relative(REPO_ROOT, DIST_DIR)}/`);

--- a/tools/bundle-web-bundles.js
+++ b/tools/bundle-web-bundles.js
@@ -1,0 +1,68 @@
+/**
+ * Web Bundle Release Packager
+ *
+ * Zips each bundle under web-bundles/ into dist/web-bundles/{slug}.zip
+ * for attachment to a GitHub Release.
+ *
+ * Usage:
+ *   node tools/bundle-web-bundles.js
+ *
+ * Then upload the resulting zips to a GitHub Release:
+ *   gh release create web-bundles-v1 dist/web-bundles/*.zip \
+ *     --title "Web Bundles v1" \
+ *     --notes "BMad web bundles for Gemini Gems and ChatGPT Custom GPTs"
+ */
+
+const fs = require('node:fs');
+const path = require('node:path');
+const { execSync } = require('node:child_process');
+
+const REPO_ROOT = path.resolve(__dirname, '..');
+const BUNDLES_DIR = path.join(REPO_ROOT, 'web-bundles');
+const DIST_DIR = path.join(REPO_ROOT, 'dist', 'web-bundles');
+const MANIFEST = path.join(BUNDLES_DIR, 'bundles.json');
+
+function main() {
+  if (!fs.existsSync(MANIFEST)) {
+    console.error(`Error: bundles.json not found at ${MANIFEST}`);
+    process.exit(1);
+  }
+
+  const manifest = JSON.parse(fs.readFileSync(MANIFEST, 'utf-8'));
+  const releaseTag = manifest.releaseTag || 'web-bundles-v1';
+
+  fs.mkdirSync(DIST_DIR, { recursive: true });
+
+  console.log(`Packaging ${manifest.bundles.length} bundles for release ${releaseTag}\n`);
+
+  const zipped = [];
+  for (const bundle of manifest.bundles) {
+    const src = path.join(BUNDLES_DIR, bundle.slug);
+    if (!fs.existsSync(src)) {
+      console.warn(`  [SKIP] ${bundle.slug} — directory not found`);
+      continue;
+    }
+
+    const out = path.join(DIST_DIR, `${bundle.slug}.zip`);
+    if (fs.existsSync(out)) fs.unlinkSync(out);
+
+    execSync(`zip -r -X -q "${out}" "${bundle.slug}" -x "*.DS_Store"`, {
+      cwd: BUNDLES_DIR,
+      stdio: 'inherit',
+    });
+
+    const size = (fs.statSync(out).size / 1024).toFixed(1);
+    console.log(`  [OK] ${bundle.slug}.zip (${size} KB)`);
+    zipped.push(bundle.slug);
+  }
+
+  console.log(`\nWrote ${zipped.length} bundles to ${path.relative(REPO_ROOT, DIST_DIR)}/`);
+  console.log('\nNext step — create or update the GitHub Release:\n');
+  console.log(`  gh release create ${releaseTag} dist/web-bundles/*.zip \\`);
+  console.log(`    --title "Web Bundles v1" \\`);
+  console.log(`    --notes "BMad web bundles for Gemini Gems and ChatGPT Custom GPTs. See https://bmadcode.com/web-bundles/"\n`);
+  console.log('Or, to refresh an existing release:\n');
+  console.log(`  gh release upload ${releaseTag} dist/web-bundles/*.zip --clobber\n`);
+}
+
+main();

--- a/web-bundles/bundles.json
+++ b/web-bundles/bundles.json
@@ -2,13 +2,12 @@
   "schemaVersion": "1.0",
   "releaseTag": "web-bundles-v1.0.0",
   "releasedAt": "2026-05-25",
-  "downloadUrlPattern": "https://github.com/bmad-code-org/BMAD-METHOD/releases/download/web-bundles-v1.0.0/{slug}.zip",
   "bundles": [
     {
       "slug": "brainstorming-coach",
       "name": "Brainstorming Coach",
-      "tagline": "Facilitated ideation across 60+ techniques",
-      "description": "Unlock creativity through guided exploration. The coach walks you through proven brainstorming methods — divergent, convergent, lateral — and helps you converge to a decision worth acting on.",
+      "tagline": "60 ideation techniques across 10 categories — structured, wild, biomimetic, theatrical, and more",
+      "description": "Sixty proven brainstorming techniques spanning structured frameworks (SCAMPER, Five Whys, First Principles), wild plays (Drunk History Retelling, Zombie Apocalypse Planning), biomimetic prompts (Nature's Solutions), theatrical methods (Six Thinking Hats, Role Playing), introspective work (Shadow Work Mining, Values Archaeology), and quantum-flavored framings (Superposition Collapse, Observer Effect). The coach picks the right one for your problem and walks you through it.",
       "defaultPersona": {
         "name": "Carson",
         "title": "Elite Brainstorming Specialist",
@@ -29,8 +28,8 @@
     {
       "slug": "product-brief-coach",
       "name": "Product Brief Coach",
-      "tagline": "Build a one-page product brief through guided discovery",
-      "description": "Shape a raw idea, evolve an existing brief, or pressure-test a draft before it goes downstream. The coach mirrors before pushing, names the assumption hiding under your confident sentence, and refuses to write the brief for you.",
+      "tagline": "Shape, evolve, or pressure-test a product brief through guided discovery",
+      "description": "Shape a raw idea, evolve an existing brief, or pressure-test a draft before it goes downstream. Brief length is whatever the product earns — focused for early-stage, longer for complex products. The coach mirrors before pushing, names the assumption hiding under your confident sentence, and refuses to write the brief for you.",
       "defaultPersona": {
         "name": "Mary",
         "title": "Strategic Business Analyst",

--- a/web-bundles/bundles.json
+++ b/web-bundles/bundles.json
@@ -6,8 +6,8 @@
     {
       "slug": "brainstorming-coach",
       "name": "Brainstorming Coach",
-      "tagline": "60 ideation techniques across 10 categories — structured, wild, biomimetic, theatrical, and more",
-      "description": "Sixty proven brainstorming techniques spanning structured frameworks (SCAMPER, Five Whys, First Principles), wild plays (Drunk History Retelling, Zombie Apocalypse Planning), biomimetic prompts (Nature's Solutions), theatrical methods (Six Thinking Hats, Role Playing), introspective work (Shadow Work Mining, Values Archaeology), and quantum-flavored framings (Superposition Collapse, Observer Effect). The coach picks the right one for your problem and walks you through it.",
+      "tagline": "60 ideation techniques across 10 categories — from SCAMPER to Zombie Apocalypse Planning",
+      "description": "Sixty proven brainstorming techniques spanning structured frameworks (SCAMPER, Five Whys, First Principles), wild plays (Drunk History Retelling, Zombie Apocalypse Planning), biomimetic prompts (Nature's Solutions), introspective work (Shadow Work Mining, Values Archaeology), and quantum-flavored framings (Superposition Collapse). Pick a route — browse the library, get a recommendation, take a random surprise, or run a progressive divergence-to-action flow. The coach asks; you generate every idea. Targets ~100 ideas before organizing (the breakthroughs live past idea 20), then promotes the session into themes, a 2×2 prioritization, and a breakthrough collage in Canvas.",
       "defaultPersona": {
         "name": "Carson",
         "title": "Elite Brainstorming Specialist",
@@ -28,8 +28,8 @@
     {
       "slug": "product-brief-coach",
       "name": "Product Brief Coach",
-      "tagline": "Shape, evolve, or pressure-test a product brief through guided discovery",
-      "description": "Shape a raw idea, evolve an existing brief, or pressure-test a draft before it goes downstream. Brief length is whatever the product earns — focused for early-stage, longer for complex products. The coach mirrors before pushing, names the assumption hiding under your confident sentence, and refuses to write the brief for you.",
+      "tagline": "Three modes (Create / Update / Validate), two paths (Fast / Coaching), one brief you're proud of",
+      "description": "Create a brief drawn out through real conversation. Update an existing brief against a change signal. Or Validate — honest critique against the brief's own purpose. Two working modes: Fast path batches the gaps into one or two consolidated questions and tags assumptions for you to fix in review (best for pitching tomorrow); Coaching path walks section by section, mirrors before pushing, names the assumption hiding under your confident sentence (best for the brief you want to be proud of). The coach refuses to invent moats, traction, or differentiation you didn't give it. Depth that doesn't fit the brief lands in an Addendum so nothing valuable gets lost. Length is whatever the product earns.",
       "defaultPersona": {
         "name": "Mary",
         "title": "Strategic Business Analyst",
@@ -50,8 +50,8 @@
     {
       "slug": "prfaq-coach",
       "name": "PRFAQ Coach",
-      "tagline": "Working Backwards challenge to forge product concepts",
-      "description": "Write the press release first. Stress-test a product concept against the customer who will actually buy it, before any building begins. Customer-first by force of method.",
+      "tagline": "Amazon's Working Backwards as a forcing function — write the press release before you build",
+      "description": "Four stages of customer-first pressure: Ignition (specific customer, concrete problem, real stakes), Press Release (9 sections, each forcing a different clarity — headline, problem paragraph, solution paragraph, leader quote, customer quote, getting started), Customer FAQ (validate the value proposition from outside in), and Internal FAQ + Verdict (feasibility, trade-offs, what survived). Hardcore mode: weasel words like 'best-in-class', 'seamless', and 'revolutionary' get challenged on sight; if you lead with technology, the coach redirects to the customer's actual problem. Generates a hero image for the press release. Works for commercial products, internal tools, open source, and community initiatives — the structure stays, the language adapts.",
       "defaultPersona": {
         "name": "Mary",
         "title": "Strategic Business Analyst",
@@ -72,8 +72,8 @@
     {
       "slug": "prd-coach",
       "name": "PRD Coach",
-      "tagline": "Product Requirements with built-in validation",
-      "description": "Coach a PRD that engineering can actually build from. Capabilities go in the PRD, mechanism in the Addendum. Validation pass surfaces the gap between what you said and what you meant.",
+      "tagline": "PRD coaching with built-in validation — capabilities in the PRD, mechanism in the Addendum",
+      "description": "Three modes (Create / Update / Validate), two entry points (Vision + Features for enterprise and dev products, Journey-led for consumer and UX-heavy products). Captures named-protagonist user journeys ('Mary, mom of three, kids finally asleep') instead of abstract personas. Enforces glossary discipline: every domain noun defined once, used verbatim across FRs, UJs, and SMs. Maintains stable IDs (FR-1..N globally, success metrics paired with counter-metrics SM-C1..N). The 7-dimension validation rubric grades decision-readiness, substance over theater, strategic coherence, done-ness clarity, scope honesty, downstream usability, and shape fit, with each finding cited to a specific PRD location. Length scales with stakes — hobby PRDs hit two pages; launch PRDs run as long as the FRs require.",
       "defaultPersona": {
         "name": "John",
         "title": "Product Manager",
@@ -94,8 +94,8 @@
     {
       "slug": "ux-coach",
       "name": "UX Coach",
-      "tagline": "UX patterns, flows, and design specifications",
-      "description": "Build spines engineering can take and ship. Pressure-test hierarchy, behavior, and visual logic. Hand-off-ready specs with optional Stitch integration for editable mockups.",
+      "tagline": "Two spines engineering can build from — DESIGN.md + EXPERIENCE.md as the contract",
+      "description": "Don Norman's human-centered design as the operating method. The coach elicits your vision and never imposes its own — no colors, fonts, or layouts you didn't put on the table. Captures named-protagonist journeys ('Mary on her couch after the kids are asleep') as the unit of design thinking. Produces two spines: DESIGN.md for visual identity (tokens in YAML frontmatter), EXPERIENCE.md for information architecture, behavior, states, and accessibility. Spines win on conflict with any mock, wireframe, or Stitch output. Surface closure is the test: every stated need has a surface, every surface has a journey. Pairs with Google Stitch — the handoff produces a Stitch prompt you copy straight from Canvas to generate editable mockups.",
       "defaultPersona": {
         "name": "Sally",
         "title": "UX Designer",
@@ -116,8 +116,8 @@
     {
       "slug": "market-and-industry-research",
       "name": "Market & Industry Research",
-      "tagline": "Competitive landscape, JTBD, segments — Deep Research integrated",
-      "description": "Market research that drives a positioning decision, not a deliverable. Segments, competitive alternatives, regulatory and technical lenses. Uses Deep Research for the heavy lift.",
+      "tagline": "Deep Research wrapped in a sharp brief — research as input to a decision, not a deliverable",
+      "description": "Built around platform Deep Research mode. The coach handles the conversation: scopes what you actually need, drafts a sharp Deep Research brief you copy directly into Gemini or ChatGPT, then ingests the report and shapes the deliverable around your decision or learning goal. Methodology anchors when they help: Michael Porter for competitive structure, Clayton Christensen for Jobs-to-be-Done. Six sections to mix and match — market dynamics, customer insights, competitive landscape, regulatory & compliance, technical & technology trends, strategic synthesis. Validates every numeric, regulatory, or competitive claim against a source and a date. Generic findings ('the market is growing') get pushed back to specifics ('which segment, what rate, citing whom'). The deliverable is the synthesis against your decision, not the research dump.",
       "defaultPersona": {
         "name": "Mary",
         "title": "Strategic Business Analyst",

--- a/web-bundles/bundles.json
+++ b/web-bundles/bundles.json
@@ -1,0 +1,140 @@
+{
+  "schemaVersion": "1.0",
+  "releaseTag": "web-bundles-v1.0.0",
+  "releasedAt": "2026-05-25",
+  "downloadUrlPattern": "https://github.com/bmad-code-org/BMAD-METHOD/releases/download/web-bundles-v1.0.0/{slug}.zip",
+  "bundles": [
+    {
+      "slug": "brainstorming-coach",
+      "name": "Brainstorming Coach",
+      "tagline": "Facilitated ideation across 60+ techniques",
+      "description": "Unlock creativity through guided exploration. The coach walks you through proven brainstorming methods — divergent, convergent, lateral — and helps you converge to a decision worth acting on.",
+      "defaultPersona": {
+        "name": "Carson",
+        "title": "Elite Brainstorming Specialist",
+        "lineage": "Osborn lineage"
+      },
+      "swapPersona": {
+        "name": "Mary",
+        "title": "Strategic Business Analyst",
+        "lineage": "BMad analyst — research-first rigor"
+      },
+      "accentColor": "#3b82f6",
+      "motif": "constellation",
+      "knowledgeFiles": ["SKILL.md", "brain-methods.csv"],
+      "needsWebBrowsing": true,
+      "needsDeepResearch": false,
+      "stitchIntegration": false
+    },
+    {
+      "slug": "product-brief-coach",
+      "name": "Product Brief Coach",
+      "tagline": "Build a one-page product brief through guided discovery",
+      "description": "Shape a raw idea, evolve an existing brief, or pressure-test a draft before it goes downstream. The coach mirrors before pushing, names the assumption hiding under your confident sentence, and refuses to write the brief for you.",
+      "defaultPersona": {
+        "name": "Mary",
+        "title": "Strategic Business Analyst",
+        "lineage": "BMad analyst"
+      },
+      "swapPersona": {
+        "name": "Iris",
+        "title": "Senior Product Strategist",
+        "lineage": "Mirror-then-push, unhurried thinking-partner voice"
+      },
+      "accentColor": "#d4a853",
+      "motif": "single-page",
+      "knowledgeFiles": ["SKILL.md"],
+      "needsWebBrowsing": true,
+      "needsDeepResearch": false,
+      "stitchIntegration": false
+    },
+    {
+      "slug": "prfaq-coach",
+      "name": "PRFAQ Coach",
+      "tagline": "Working Backwards challenge to forge product concepts",
+      "description": "Write the press release first. Stress-test a product concept against the customer who will actually buy it, before any building begins. Customer-first by force of method.",
+      "defaultPersona": {
+        "name": "Mary",
+        "title": "Strategic Business Analyst",
+        "lineage": "BMad analyst"
+      },
+      "swapPersona": {
+        "name": "Bezos",
+        "title": "Working Backwards Coach",
+        "lineage": "Amazon discipline — direct, dry, customer-first"
+      },
+      "accentColor": "#dc2626",
+      "motif": "document-ribbon",
+      "knowledgeFiles": ["SKILL.md"],
+      "needsWebBrowsing": true,
+      "needsDeepResearch": false,
+      "stitchIntegration": false
+    },
+    {
+      "slug": "prd-coach",
+      "name": "PRD Coach",
+      "tagline": "Product Requirements with built-in validation",
+      "description": "Coach a PRD that engineering can actually build from. Capabilities go in the PRD, mechanism in the Addendum. Validation pass surfaces the gap between what you said and what you meant.",
+      "defaultPersona": {
+        "name": "John",
+        "title": "Product Manager",
+        "lineage": "BMad PM — Cagan lineage"
+      },
+      "swapPersona": {
+        "name": "Ezra",
+        "title": "Principal Product Manager",
+        "lineage": "Calmer, slower-tempo coaching"
+      },
+      "accentColor": "#6366f1",
+      "motif": "section-stack",
+      "knowledgeFiles": ["SKILL.md", "prd-template.md", "prd-validation-checklist.md"],
+      "needsWebBrowsing": true,
+      "needsDeepResearch": false,
+      "stitchIntegration": false
+    },
+    {
+      "slug": "ux-coach",
+      "name": "UX Coach",
+      "tagline": "UX patterns, flows, and design specifications",
+      "description": "Build spines engineering can take and ship. Pressure-test hierarchy, behavior, and visual logic. Hand-off-ready specs with optional Stitch integration for editable mockups.",
+      "defaultPersona": {
+        "name": "Sally",
+        "title": "UX Designer",
+        "lineage": "BMad UX designer"
+      },
+      "swapPersona": {
+        "name": "Kenji",
+        "title": "Principal Product Designer",
+        "lineage": "Rams restraint + Zhuo systems discipline"
+      },
+      "accentColor": "#10b981",
+      "motif": "nested-layers",
+      "knowledgeFiles": ["SKILL.md", "ux-validation.md"],
+      "needsWebBrowsing": true,
+      "needsDeepResearch": false,
+      "stitchIntegration": true
+    },
+    {
+      "slug": "market-and-industry-research",
+      "name": "Market & Industry Research",
+      "tagline": "Competitive landscape, JTBD, segments — Deep Research integrated",
+      "description": "Market research that drives a positioning decision, not a deliverable. Segments, competitive alternatives, regulatory and technical lenses. Uses Deep Research for the heavy lift.",
+      "defaultPersona": {
+        "name": "Mary",
+        "title": "Strategic Business Analyst",
+        "lineage": "BMad analyst"
+      },
+      "swapPersona": {
+        "name": "Geoff",
+        "title": "Market Strategist",
+        "lineage": "Geoffrey Moore + April Dunford lineage"
+      },
+      "accentColor": "#f59e0b",
+      "motif": "positioning-rings",
+      "knowledgeFiles": ["SKILL.md"],
+      "needsWebBrowsing": true,
+      "needsDeepResearch": true,
+      "stitchIntegration": false
+    }
+  ]
+}


### PR DESCRIPTION
## Summary

Adds the release infrastructure for the upcoming `bmadcode.com/web-bundles/` page — a single-click install storefront for the six BMad web bundles (Gemini Gems + ChatGPT Custom GPTs).

The page itself lives in the ghost-site repo and will land in a separate PR after this merges (since it reads `bundles.json` from this repo's `main` branch via raw.githubusercontent.com).

## What's in this PR

- **`web-bundles/bundles.json`** — single manifest with everything the Ghost page needs to render cards + modals:
  - Per-bundle: slug, name, tagline, description, default + swap persona, accent color, motif key, knowledge files list, feature flags (web-browsing / deep-research / Stitch).
  - Top-level: `releaseTag` and `downloadUrlPattern` so the consuming page constructs download URLs without hardcoding release tags.
- **`tools/bundle-web-bundles.js`** — zero-dependency packager. Reads `bundles.json`, zips each `web-bundles/{slug}/` into `dist/web-bundles/{slug}.zip`, prints the `gh release create` command at the end.
- **`.gitignore`** — exclude `dist/web-bundles/` build artifacts.

## Release status

The `web-bundles-v1.0.0` GitHub Release exists as a **draft** with all 6 zips attached (~55 KB total). It'll be published in coordination with the Ghost site page going live — not as part of this PR.

## Test plan

- [ ] Pull branch, run `node tools/bundle-web-bundles.js` — should produce 6 zips in `dist/web-bundles/` and print the release command.
- [ ] Verify `bundles.json` parses (Ghost page consumes it via fetch).
- [ ] Confirm `.gitignore` excludes `dist/web-bundles/` so build artifacts don't accidentally land in commits.