### PR TITLE
docs: route all web-bundles install traffic to bmadcode.com/web-bundles

### DIFF
--- a/README.md
+++ b/README.md
@@ -79,11 +79,13 @@ BMad Method extends with official modules for specialized domains. Available dur
 
 ## Web Bundles
 
-V4 shipped web bundles. V6 brings them back, new and improved. Find them in [`web-bundles/`](./web-bundles/).
+V4 shipped web bundles. V6 brings them back, new and improved.
 
-Web bundles package selected BMad skills for installation as **Google Gemini Gems** and **ChatGPT Custom GPTs**. Use them to do the upfront planning work (brainstorming, product briefs, PRDs, PRFAQs, UX specs, market and industry research) in your web LLM subscription, then bring the polished artifacts into your IDE for implementation. Planning runs on a flat-rate subscription instead of metered IDE tokens, which is a meaningful cost saver on longer engagements. Ensure that when using you choose the best model available to you in Gemini or ChatGPT.
+Web bundles package selected BMad skills for installation as **Google Gemini Gems** and **ChatGPT Custom GPTs**. Use them to do the upfront planning work (brainstorming, product briefs, PRDs, PRFAQs, UX specs, market and industry research) in your web LLM subscription, then bring the polished artifacts into your IDE for implementation. Planning runs on a flat-rate subscription instead of metered IDE tokens, which is a meaningful cost saver on longer engagements. Choose the best model available to you in Gemini or ChatGPT.
 
-Current shelf: brainstorming, product brief, PRFAQ, PRD, UX, market & industry research. Each bundle has its own `INSTRUCTIONS.md` to follow; the setup pattern is the same across the shelf (create a Gem or GPT, attach knowledge file(s) (bundle customized SKILL.md and additional content), paste the instructions block, save). See [the web bundles guide](https://docs.bmad-method.org/explanation/web-bundles/) for the concept and [the how-to](https://docs.bmad-method.org/how-to/use-web-bundles/) for setup details.
+Current shelf: brainstorming, product brief, PRFAQ, PRD, UX, market & industry research.
+
+**Browse and install at [bmadcode.com/web-bundles](https://bmadcode.com/web-bundles/)**. One card per bundle, inline install steps for Gemini and ChatGPT, one-click ZIP download. See [the web bundles guide](https://docs.bmad-method.org/explanation/web-bundles/) for the concept.
 
 ## Documentation
 

--- a/docs/explanation/web-bundles.md
+++ b/docs/explanation/web-bundles.md
@@ -9,7 +9,7 @@ Run the planning side of BMad in your web LLM subscription, then bring the artif
 
 A web bundle is a BMad skill repackaged for installation as a **Google Gemini Gem** or **ChatGPT Custom GPT**. Each bundle includes a `SKILL.md` protocol you upload as a knowledge file, an `INSTRUCTIONS.md` block you paste into the Gem or GPT instructions, and any data files the skill needs (CSVs, templates, validation checklists, additionally progressively disclosed content). The persona lives in the pasted instructions; the protocol lives in the knowledge file. Swap personas without touching the protocol.
 
-Setup is not one-click; you create the Gem or GPT, upload the knowledge files, paste the instructions, and save. The pattern is the same across the shelf, so once you've installed one bundle the next one is mechanical. Follow each bundle's `INSTRUCTIONS.md` for the platform-specific details.
+Setup is not one-click, but the steps are guided. **Install from [bmadcode.com/web-bundles](https://bmadcode.com/web-bundles/)**. The site lists every bundle in a card grid, shows you the Gemini and ChatGPT install steps inline, and hands you the ZIP download. That is the supported install path; the pattern is the same across the shelf, so once you've installed one the next one is mechanical.
 
 V4 of BMad shipped web bundles. V6 brings them back, rewritten for the current Gem and Custom GPT platforms with Canvas, Deep Research, and image generation in mind.
 
@@ -79,4 +79,4 @@ Persona swaps, default user name, team-specific guardrails, preferred phrasing: 
 
 Web bundles are generated from BMad skills using the `bmad-os-skill-to-bundle` utility skill. Point it at any BMad skill folder and it produces the bundle files with persona inheritance from the owning agent.
 
-See the [how-to guide](../how-to/use-web-bundles.md) for installation steps.
+Install any bundle from [bmadcode.com/web-bundles](https://bmadcode.com/web-bundles/).

--- a/docs/how-to/use-web-bundles.md
+++ b/docs/how-to/use-web-bundles.md
@@ -3,64 +3,30 @@ title: 'Use Web Bundles'
 description: Install a BMad web bundle as a Google Gemini Gem or ChatGPT Custom GPT
 ---
 
-Use a **web bundle** to run BMad planning work in your Gemini or ChatGPT subscription instead of your IDE.
+Web bundles install from **[bmadcode.com/web-bundles](https://bmadcode.com/web-bundles/)**.
 
-## When to Use This
+## Why a single front door
 
-- You want to run brainstorming, product brief, PRFAQ, PRD, UX, or market research in a web LLM.
-- You want to save IDE tokens by keeping the planning conversation on a flat-rate subscription.
-- You want to share a planning artifact with collaborators who don't have your IDE setup.
+The site is the only supported install path for the shelf. It keeps the steps current as Gemini and ChatGPT evolve, always points at the newest tagged release, and lets one signup put you on the list for new bundles as they ship.
 
-## When to Skip This
+## What you'll do on the site
 
-- The work needs to read or modify code in your repo. Stay in the IDE.
-- You don't have a Gemini Advanced or ChatGPT Plus subscription.
+1. Pick a bundle from the card grid.
+2. Open the install modal. Switch between the **Gemini Gem** and **ChatGPT GPT** tabs for the platform-specific steps.
+3. Download the bundle ZIP (one click; one-time free signup for email-only members).
+4. Follow the inline steps: create the Gem or Custom GPT, upload the knowledge files, paste the instructions block, save.
 
-:::note[Prerequisites]
+## Prerequisites
 
 - **For Gemini Gems**: Gemini Advanced subscription.
-- **For ChatGPT Custom GPTs**: Plus, Pro, Business, or Enterprise plan. Some bundles use Deep Research, which has its own plan availability.
-- A bundle from [`web-bundles/`](https://github.com/bmad-code-org/BMAD-METHOD/tree/main/web-bundles).
-:::
+- **For ChatGPT Custom GPTs**: Plus, Pro, Business, or Enterprise plan.
+- For bundles that use **Deep Research** (currently Market & Industry Research), enable it from the prompt bar (Tools → Deep Research). Deep Research has its own plan limits.
 
-## Steps
+## Customize the persona
 
-### 1. Pick a Bundle
+Each bundle's `INSTRUCTIONS.md` (inside the ZIP) includes a **Persona Swap Example** above the paste boundary. Replace the `[persona]` block in your installed instructions with the swap example to change voice without changing the protocol. You can also write your own persona from scratch; the protocol stays the same.
 
-Browse [`web-bundles/`](https://github.com/bmad-code-org/BMAD-METHOD/tree/main/web-bundles) and pick the one for the work you're doing. Open the bundle folder; you'll see `SKILL.md`, `INSTRUCTIONS.md`, and any data files (CSVs, templates, validation checklists).
-
-### 2. Install in Google Gemini
-
-1. Go to [gemini.google.com](https://gemini.google.com) and create a new Gem.
-2. Name the Gem after the bundle (for example, **Market & Industry Research**).
-3. Upload the bundle's `SKILL.md` and any data files (`.csv`, `.md` templates, validation files) as knowledge files.
-4. Open the bundle's `INSTRUCTIONS.md`, scroll to the **PASTE BOUNDARY** line, and paste everything below it into the Gem's instructions box.
-5. Save.
-
-Some bundles call for Deep Research. If yours does, enable it from the Gemini prompt bar (Tools → Deep Research) before starting each session.
-
-### 3. Install in ChatGPT
-
-1. Go to [chatgpt.com](https://chatgpt.com) and create a new Custom GPT under **Explore GPTs → Create**.
-2. Name the GPT after the bundle.
-3. Under **Configure → Knowledge**, upload the bundle's `SKILL.md` and any data files.
-4. Open the bundle's `INSTRUCTIONS.md`, scroll to the **PASTE BOUNDARY** line, and paste everything below it into **Instructions**.
-5. Under **Capabilities**, turn on **Web Browsing** if the bundle's install steps call for it.
-6. Save.
-
-If the bundle integrates Deep Research, enable it before each session via the composer "+" menu or **Tools → Run deep research**.
-
-### 4. Customize the Persona (Optional)
-
-Each bundle's `INSTRUCTIONS.md` includes a **Persona Swap Example** above the paste boundary. Replace the `[persona]` block in your installed instructions with the swap example to change voice without changing the protocol. You can also write your own persona from scratch; the protocol stays the same.
-
-### 5. Run a Session
-
-Open the Gem or Custom GPT and send your first message. The persona greets you in character and starts the discovery conversation defined in `SKILL.md`. Canvas opens automatically when relevant.
-
-When you're done, export or copy the Canvas document into your repo or hand it off to the next BMad skill in your IDE.
-
-## What You Get
+## What you get
 
 - A reusable Gem or Custom GPT scoped to one BMad planning capability.
 - Polished artifacts (briefs, PRDs, research reports, UX specs) ready to drop into your IDE for implementation.
@@ -70,6 +36,6 @@ When you're done, export or copy the Canvas document into your repo or hand it o
 Web LLMs occasionally drop persona partway through long sessions. If the model starts speaking out of character, remind it of its persona or start a fresh session.
 :::
 
-## Building Your Own
+## Building your own
 
-To turn an existing BMad skill into a web bundle, use the `bmad-os-skill-to-bundle` utility skill from [bmad-utility-skills](https://github.com/bmad-code-org/bmad-utility-skills). It produces the bundle files with persona inheritance from the owning agent and a swap-example contrast voice.
+To turn an existing BMad skill into a web bundle, use the `bmad-os-skill-to-bundle` utility skill from [bmad-utility-skills](https://github.com/bmad-code-org/bmad-utility-skills). It produces the bundle files with persona inheritance from the owning agent and a swap-example contrast voice. Submit your bundle to the shelf by opening a PR on [BMAD-METHOD](https://github.com/bmad-code-org/BMAD-METHOD) that adds the bundle directory and an entry in `web-bundles/bundles.json`.

--- a/web-bundles/README.md
+++ b/web-bundles/README.md
@@ -2,39 +2,45 @@
 
 V4 shipped web bundles. V6 brings them back, new and improved. Each bundle packages a BMad skill as a self-contained install for **Google Gemini Gems** and **ChatGPT Custom GPTs**, so you can run the planning work in your web LLM subscription before opening your IDE.
 
-## Why use these
+## Install
+
+**Go to [bmadcode.com/web-bundles](https://bmadcode.com/web-bundles/).**
+
+The site lists every bundle in a card grid, walks you through the Gemini and ChatGPT setup inline, and hands you the ZIP download in one click. That is the only supported install path.
+
+Why a single front door:
+
+- One place to keep install steps current as Gemini and ChatGPT evolve.
+- Versioned releases. Every shelf update ships as a tagged GitHub Release; the site always points at the newest tag.
+- One signup gets you on the list for new bundles as they ship.
+
+## Why use them
 
 - **Cost.** Web LLM subscriptions are flat-rate. Run brainstorming, briefs, PRDs, and research there instead of burning IDE tokens.
 - **Right tool for the job.** Planning conversations want Canvas, image generation, and Deep Research. Implementation wants the codebase and a terminal. Use each where it's strongest.
-- **Persona swapping.** Every bundle's `INSTRUCTIONS.md` carries a default persona and a contrasting swap example. Change voices without touching the protocol.
+- **Persona swapping.** Every bundle ships a default persona and a contrasting swap example. Change voices without touching the protocol.
 
 ## The shelf
 
 | Bundle | Purpose |
 | --- | --- |
-| [`brainstorming-coach/`](./brainstorming-coach/) | Facilitated ideation across 60 techniques. Defaults to **Carson** (Osborn lineage); swap to **Mary** for analyst rigor. |
-| [`product-brief-coach/`](./product-brief-coach/) | Build a one-page product brief through guided discovery. |
-| [`prfaq-coach/`](./prfaq-coach/) | Working Backwards PRFAQ challenge (Bezos lineage) to forge and stress-test product concepts. |
-| [`prd-coach/`](./prd-coach/) | Product Requirements Document with built-in validation (Cagan lineage). |
-| [`ux-coach/`](./ux-coach/) | UX patterns, flows, and design specifications. |
-| [`market-and-industry-research/`](./market-and-industry-research/) | Market research, customer JTBD, competitive landscape, regulatory and technical lenses. Deep Research mode integrated. |
+| Brainstorming Coach | Facilitated ideation across 60 techniques. Defaults to **Carson** (Osborn lineage); swap to **Mary** for analyst rigor. |
+| Product Brief Coach | Build a product brief through guided discovery. Create, Update, or Validate modes. |
+| PRFAQ Coach | Working Backwards PRFAQ challenge (Bezos lineage) to forge and stress-test product concepts. |
+| PRD Coach | Product Requirements Document with built-in validation (Cagan lineage). |
+| UX Coach | UX patterns, flows, and design specifications. Pairs with Google Stitch. |
+| Market & Industry Research | Market research, customer JTBD, competitive landscape, regulatory and technical lenses. Deep Research mode integrated. |
 
-## Install
-
-Each bundle has its own `INSTRUCTIONS.md` with platform-specific setup steps. Pattern is the same:
-
-1. Create a Gem (Gemini) or Custom GPT (ChatGPT).
-2. Upload the bundle's `SKILL.md` (and any data files) as knowledge.
-3. Paste the block below the **PASTE BOUNDARY** into the instructions box.
-4. Enable Web Browsing / Deep Research if the bundle's install steps call for it.
-
-Gemini Gems require Gemini Advanced. ChatGPT Custom GPTs require Plus, Pro, Business, or Enterprise; Deep Research has its own plan limits.
+Requires Gemini Advanced (for Gems) or ChatGPT Plus / Pro / Business / Enterprise (for Custom GPTs). Deep Research has its own plan limits.
 
 ## Build your own
 
 Web bundles are generated from BMad skills using the [`bmad-os-skill-to-bundle`](https://github.com/bmad-code-org/bmad-utility-skills) utility skill. Point it at any BMad skill folder and it produces a `SKILL.md`, an `INSTRUCTIONS.md`, and any required data files, with persona inheritance from the owning agent.
 
-## Docs
+## What's in this folder
 
-- [What web bundles are and when to use them](https://docs.bmad-method.org/explanation/web-bundles/)
-- [How to install a web bundle](https://docs.bmad-method.org/how-to/use-web-bundles/)
+This folder is the **source** for the shelf, packaged into ZIPs and attached to GitHub Releases. End users do not install from here. If you are a contributor working on a bundle, the bundle directories and `bundles.json` are the files you edit; the [release packager](../tools/bundle-web-bundles.js) zips them and updates the release.
+
+## Concept docs
+
+[What web bundles are and when to use them](https://docs.bmad-method.org/explanation/web-bundles/).


### PR DESCRIPTION
## Summary

Make [bmadcode.com/web-bundles](https://bmadcode.com/web-bundles/) the single supported install path for the web bundles shelf. Today, install instructions are duplicated across the README, the web-bundles README, an explanation doc, and a how-to. With the storefront live (shipped in #2424), maintaining four parallel install paths invites drift the moment Gemini or ChatGPT changes a setting.

Centralizing has a second benefit: every install drives a signup, which becomes the notification channel for the next bundle drop.

## What changes

| File | Change |
| --- | --- |
| `README.md` | Drop the direct-folder install reference; point to the site. |
| `web-bundles/README.md` | Lead with **Install** (site). Reframe the folder as the **source** for the shelf (what contributors edit and the packager zips), not the install target. Keep shelf table, "Build your own", and concept-doc pointer. |
| `docs/explanation/web-bundles.md` | Replace the per-bundle `INSTRUCTIONS.md` steer with the site link. Replace the dead how-to link. |
| `docs/how-to/use-web-bundles.md` | Rewrite as a short pointer to the site (kept the file so existing inbound links resolve). Retain prerequisites, persona customization, and build-your-own sections. |

The per-bundle `INSTRUCTIONS.md` files inside each bundle directory are left intact — they're the install content the site references and ship inside the ZIPs.

## Test plan

- [ ] Render README on github.com and confirm the Web Bundles section points to bmadcode.com
- [ ] Render web-bundles/README.md and confirm Install section is first and points to the site
- [ ] Build the Astro docs site and confirm /explanation/web-bundles/ and /how-to/use-web-bundles/ still resolve
- [ ] Click through bmadcode.com/web-bundles/ from each updated doc link