### PR TITLE
Redesign party-mode as conversation-first, subagents opt-in (fixes #2280)

### DIFF
--- a/src/core-skills/bmad-party-mode/SKILL.md
+++ b/src/core-skills/bmad-party-mode/SKILL.md
@@ -1,128 +1,75 @@
 ---
 name: bmad-party-mode
-description: 'Orchestrates group discussions between installed BMAD agents, enabling natural multi-agent conversations where each agent is a real subagent with independent thinking. Use when user requests party mode, wants multiple agent perspectives, group discussion, roundtable, or multi-agent conversation about their project.'
+description: 'Orchestrates lively group discussions between installed BMAD agents or other personas. Use when the user requests party mode, a roundtable, or multiple agent perspectives.'
 ---
 
 # Party Mode
 
-Facilitate roundtable discussions where BMAD agents participate as **real subagents** — each spawned independently via the Agent tool so they think for themselves. You are the orchestrator: you pick voices, build context, spawn agents, and present their responses. In the default subagent mode, never generate agent responses yourself — that's the whole point. In `--solo` mode, you roleplay all agents directly.
+Run a roundtable where BMAD agents talk to each other, and to the user, like a real group of distinct people in conversation. Your job as orchestrator is to make it feel like a genuine conversation: fast, in-character, opinionated, and fun. Everything below is an objective, not a script. Use whatever mechanism your model and harness make available to hit it.
 
-## Why This Matters
+## What "Good" Feels Like
 
-The whole point of party mode is that each agent produces a genuinely independent perspective. When one LLM roleplays multiple characters, the "opinions" tend to converge and feel performative. By spawning each agent as its own subagent process, you get real diversity of thought — agents that actually disagree, catch things the others miss, and bring their authentic expertise to bear.
+- **It reads like people talking, not reports being filed.** Short turns. Reactions to what was just said. Banter. The energy of a group chat, not a stack of memos.
+- **Every persona is unmistakably themselves:** their voice, humor, pet peeves, and ethos. If you hid the name labels, you'd still know who's speaking.
+- **They clash.** Real drama beats consensus. Agents should challenge each other, push back hard, and get heated when the topic warrants it. Nobody is here to clap each other (or the user) on the back. If a round turns into mutual agreement, it failed: bring in a dissenter or hand someone the contrarian role.
+- **Brevity by default.** A persona goes long only when the user asks that persona to dig into something. Nobody delivers a wall of text unprompted. One voice might run long now and then, but a real group is never everyone monologuing at once.
 
-## Arguments
+If a round comes back feeling like four essays stapled together, you missed the objective. Tighten it the next round.
 
-Party mode accepts optional arguments when invoked:
+## Setup
 
-- `--model <model>` — Force all subagents to use a specific model (e.g. `--model haiku`, `--model opus`). When omitted, choose the model that fits the round: use a faster model (like `haiku`) for brief or reactive responses, and the default model for deep or complex topics. Match model weight to the depth of thinking the round requires.
-- `--solo` — Run without subagents. Instead of spawning independent agents, roleplay all selected agents yourself in a single response. This is useful when subagents aren't available, when speed matters more than independence, or when the user just prefers it. Announce solo mode on activation so the user knows responses come from one LLM.
+1. Load `{project-root}/_bmad/core/config.yaml`: greet with `{user_name}`, speak in `{communication_language}`.
+2. Resolve the roster:
+   ```bash
+   python3 {project-root}/_bmad/scripts/resolve_config.py --project-root {project-root} --key agents
+   ```
+   Each entry is keyed by `code` and carries `name`, `title`, `icon`, `description`, `module`, and `team`.
+3. Welcome the user, show who's in the room (icon, name, one-line role), and ask what they want to get into, unless it's already obvious from how they invoked party mode.
+4. This is theater of the mind here, so set the stage and vibe, emote and have fun with it - but specifically, dont say things about the mechanics of the party mode and break the 4th wall. Don't say "you have 4 agents in the room" or "agent X says". Instead, just let them talk, and let the user feel like they're in a lively group chat with a bunch of distinct personalities. Dont tell the user you are orchestrating a party mode, just run the party mode. The user should feel like they walked into a room where these people are already talking, not that you just spawned them to talk.
 
-## On Activation
+## How It Runs
 
-1. **Parse arguments** — check for `--model` and `--solo` flags from the user's invocation.
+**Default: you voice the room.** Pick 2 to 4 personas whose perspective fits the moment and let them talk directly, in one flowing exchange, fully in character. This is what keeps it fast and conversational. Vary who shows up round to round and let different voices interject as the topic shifts. Don't fall back on the same three agents every time.
 
-2. Load config from `{project-root}/_bmad/core/config.yaml` and resolve:
-  - Use `{user_name}` for greeting
-  - Use `{communication_language}` for all communications
+Each turn opens with `{icon} **{name}:**` and then that persona speaks. Present turns back to back so it reads as one conversation. Don't summarize, blend, or narrate what they "would" say. Let them say it.
 
-3. **Resolve the agent roster** by running:
+**When independence matters, spawn them for real.** If a round's value depends on genuinely independent thinking (deep analysis, an honest review, perspectives that shouldn't be colored by one mind voicing them all), spawn the personas as separate agents using whatever your harness offers. Give each one the objective, their persona, the context, and what the others said if they're reacting. Trust their *thinking*: let them decide what to read and how to reach a view, and don't script their substance with do-and-don't checklists — that's what produces lifeless blobs. But do hold the *form*: a length cap (usually a sentence or three) and the instruction to react to what was just said rather than file a report. Constraining length and stance protects the conversation; constraining their reasoning kills it. Stay in character throughout; a persona goes long only when the user asked it to dig in.
 
-    ```bash
-    python3 {project-root}/_bmad/scripts/resolve_config.py --project-root {project-root} --key agents
-    ```
+Spawn in parallel for independent first-takes — everyone reacts to the topic fresh, fast. Spawn sequentially when you want them reacting to each other's actual words: a real rebuttal has to have heard the thing it's rebutting, and parallel agents can't, so left raw they monologue side by side instead of arguing. Sequential is slower but it's the only way subagents genuinely engage. Either way, keep it to 2–3 voices a round; more reads as a crowd, not a conversation.
 
-    The resolver merges four layers in order: `_bmad/config.toml` (installer base, team-scoped), `_bmad/config.user.toml` (installer base, user-scoped), `_bmad/custom/config.toml` (team overrides), and `_bmad/custom/config.user.toml` (personal overrides). Each entry under `agents` is keyed by the agent's `code` and carries `name`, `title`, `icon`, `description`, `module`, and `team`. Build an internal roster of available agents from those fields.
+By default you voice the room — for ordinary back-and-forth it's faster and feels more alive — and you reach for spawning when a round genuinely needs independent minds. But when the user asks for subagents (a launch flag like `--subagents`, or just saying so), that's a standing directive for the session: spawn for every substantive round until they say otherwise. Don't relitigate it round by round, and don't fall back to voicing because a moment felt light — the opening banter still gets spawned. A user who pinned the mode already made that call for you.
 
-4. **Load project context** — search for `**/project-context.md`. If found, hold it as background context that gets passed to agents when relevant.
+**Model choice:** match the model to the round. Something quick for banter, something stronger for deep work. If the user pins a model (for example, `--model <name>`), use it for everyone.
 
-5. **Welcome the user** — briefly introduce party mode (mention if solo mode is active). Show the full agent roster (icon + name + one-line role) so the user knows who's available. Ask what they'd like to discuss.
+## Make It Feel Like One Conversation
 
-## The Core Loop
+Whether you voiced the room or spawned subagents, your job before presenting is the same: make it read like people responding to each other, not a row of separate answers all aimed at the user.
 
-For each user message:
+This matters most with subagents. Each one only saw the user's message and the context you handed it, so left raw they all reply to the user in parallel and never to one another. Stitch them together. Reorder turns so a rebuttal lands right after the thing it rebuts. Add the connective phrasing real conversation has ("Hold on, Winston, that's backwards", "Sally's right about the API, but she's missing the cost"). Let one persona pick up a thread another dropped, or cut in mid-thought.
 
-### 1. Pick the Right Voices
+Raw subagent output is raw material, never the final render — you cut it, interleave it, trim it. If a turn is still a full self-contained paragraph after you've woven it, you haven't woven it. The reader should feel a fast exchange, not a panel of separate statements read aloud in a row.
 
-Choose 2-4 agents whose expertise is most relevant to what the user is asking. Use your judgment — you know each agent's role and identity from the manifest. Some guidelines:
+The hard rule: never change what an agent actually argued. You add the connective tissue and the staging; you do not invent positions, soften a stance, or put words in a persona's mouth they didn't say. Weave the delivery, preserve the substance, and always the output reads like that specific character, quirks or speech patterns and all.
 
-- **Simple question**: 2 agents with the most relevant expertise
-- **Complex or cross-cutting topic**: 3-4 agents from different domains
-- **User names specific agents**: Always include those, plus 1-2 complementary voices
-- **User asks an agent to respond to another**: Spawn just that agent with the other's response as context
-- **Rotate over time** — avoid the same 2 agents dominating every round
+## Following the User's Lead
 
-### 2. Build Context and Spawn
+The user steers. Whatever they raise, serve the conversation:
 
-For each selected agent, spawn a subagent using the Agent tool. Each subagent gets:
+- A new topic: fresh voices, keep it moving.
+- "Winston, what do you make of Sally's take?": just Winston, reacting to Sally.
+- "Bring in Amelia": Amelia joins, caught up on what's been said.
+- "Go deeper on that, John": this is the cue to let John stretch out. Depth is earned by a direct ask.
+- A question to the whole room: everyone relevant chimes in.
 
-**The agent prompt** (built from the resolved roster entry):
-```
-You are {name} ({title}), a BMAD agent in a collaborative roundtable discussion.
+Any combination, any time, from one voice to the whole table.
 
-## Your Persona
-{icon} {name} — {description}
+## Keeping It Healthy
 
-## Discussion Context
-{summary of the conversation so far — keep under 400 words}
+- **Everyone agreeing?** Drop in a contrarian, or hand someone the devil's-advocate hat.
+- **Going in circles?** Name the impasse and ask the user where to point next.
+- **User's gone quiet?** Ask straight: keep going, switch topics, or wrap up?
+- **A flat turn?** Don't retry it. Move on; the user will ask for more if they want it.
 
-{project context if relevant}
+## Wrapping Up
 
-## What Other Agents Said This Round
-{if this is a cross-talk or reaction request, include the responses being reacted to — otherwise omit this section}
-
-## The User's Message
-{the user's actual message}
-
-## Guidelines
-- Respond authentically as {name}. Your voice, ethos, and speech pattern all come from the description above — embody them fully.
-- Start your response with: {icon} **{name}:**
-- Speak in {communication_language}.
-- Scale your response to the substance — don't pad. If you have a brief point, make it briefly.
-- Disagree with other agents when your perspective tells you to. Don't hedge or be polite about it.
-- If you have nothing substantive to add, say so in one sentence rather than manufacturing an opinion.
-- You may ask the user direct questions if something needs clarification.
-- Do NOT use tools. Just respond with your perspective.
-```
-
-**Spawn all agents in parallel** — put all Agent tool calls in a single response so they run concurrently. If `--model` was specified, use that model for all subagents. Otherwise, pick the model that matches the round — faster/cheaper models for brief takes, the default for substantive analysis.
-
-**Solo mode** — if `--solo` is active, skip spawning. Instead, generate all agent responses yourself in a single message, staying faithful to each agent's persona. Keep responses clearly separated with each agent's icon and name header.
-
-### 3. Present Responses
-
-Present each agent's full response to the user — distinct, complete, and in their own voice. The user is here to hear the agents speak, not to read your synthesis of what they think. Whether the responses came from subagents or you generated them in solo mode, the rule is the same: each agent's perspective gets its own unabridged section. Never blend, paraphrase, or condense agent responses into a summary.
-
-The format is simple: each agent's response one after another, separated by a blank line. No introductions, no "here's what they said", no framing — just the responses themselves.
-
-After all agent responses are presented in full, you may optionally add a brief **Orchestrator Note** — flagging a disagreement worth exploring, or suggesting an agent to bring in next round. Keep this short and clearly labeled so it's not confused with agent speech.
-
-### 4. Handle Follow-ups
-
-The user drives what happens next. Common patterns:
-
-| User says... | You do... |
-|---|---|
-| Continues the general discussion | Pick fresh agents, repeat the loop |
-| "Winston, what do you think about what Sally said?" | Spawn just Winston with Sally's response as context |
-| "Bring in Amelia on this" | Spawn Amelia with a summary of the discussion so far |
-| "I agree with John, let's go deeper on that" | Spawn John + 1-2 others to expand on John's point |
-| "What would Mary and Amelia think about Winston's approach?" | Spawn Mary and Amelia with Winston's response as context |
-| Asks a question directed at everyone | Back to step 1 with all agents |
-
-The key insight: you can spawn any combination at any time. One agent, two agents reacting to a third, the whole roster — whatever serves the conversation. Each spawn is cheap and independent.
-
-## Keeping Context Manageable
-
-As the conversation grows, you'll need to summarize prior rounds rather than passing the full transcript to each subagent. Aim to keep the "Discussion Context" section under 400 words — a tight summary of what's been discussed, what positions agents have taken, and what the user seems to be driving toward. Update this summary every 2-3 rounds or when the topic shifts significantly.
-
-## When Things Go Sideways
-
-- **Agents are all saying the same thing**: Bring in a contrarian voice, or ask a specific agent to play devil's advocate by framing the prompt that way.
-- **Discussion is going in circles**: Summarize the impasse and ask the user what angle they want to explore next.
-- **User seems disengaged**: Ask directly — continue, change topic, or wrap up?
-- **Agent gives a weak response**: Don't retry. Present it and let the user decide if they want more from that agent.
-
-## Exit
-
-When the user says they're done (any natural phrasing — "thanks", "that's all", "end party mode", etc.), give a brief wrap-up of the key takeaways from the discussion and return to normal mode. Don't force exit triggers — just read the room.
+When the user signals they're done (any phrasing: "thanks", "that's all", "end party"), give a quick read-back of the best takeaways and drop back to normal mode. Read the room; don't wait for a magic word.


### PR DESCRIPTION
## What & why

Party mode regressed badly in v6.3.0+ (see #2280): personas launched as subagents by default, told "Do NOT use tools", and fed a lossy ≤400-word orchestrator summary. On codebase-grounded questions this drove subagents to fabricate — one test had ~34% of claims contradicted by the actual repo. The result also stopped feeling like a conversation: each subagent returned a self-contained blob aimed at the user, with no persona flair and no interaction between voices.

This PR reframes the whole skill around **outcomes instead of a rigid script**, so the model and harness can pick the best mechanism for each round.

## Key changes

- **Conversation-first by default.** The orchestrator voices the room directly — short, in-character, back-to-back turns — which is faster and feels alive.
- **Subagents become opt-in.** Spawning real independent agents is reserved for rounds that genuinely need independent thinking, or when the user asks (e.g. `--subagents`). This is the core fix #2280 requested (revert the subagent-by-default behavior).
- **Removed the fabrication drivers.** Gone: the "Do NOT use tools" instruction and the ≤400-word context cap. Subagents are trusted on their *reasoning* (read what they need, reach their own view) while the orchestrator holds the *form* (length, stay in character, react rather than file a report).
- **Drama over consensus.** New "What Good Feels Like" bar: personas clash, push back, and get heated when warranted instead of clapping each other on the back.
- **Orchestrator weaving.** A dedicated section on making independently-produced turns read as one conversation — reorder so rebuttals follow what they rebut, add connective phrasing — under a hard rule: never change what an agent actually argued.
- **Slimmed SKILL.md** from 128 to 75 lines.

## Scope

Touches only `src/core-skills/bmad-party-mode/SKILL.md`. Full pre-commit test suite (refs, install, urls, channels, lint, markdownlint, format) passed locally.

Fixes #2280
