### PR TITLE
docs: update planning workflow diagram

### DIFF
--- a/website/public/workflow-map-diagram.html
+++ b/website/public/workflow-map-diagram.html
@@ -202,19 +202,19 @@
                         <span class="workflow-name">prd</span>
                     </div>
                     <div class="workflow-meta">
-                        <div class="agent"><div class="agent-icon john">J</div><span class="agent-name">Any</span></div>
+                        <div class="agent"><div class="agent-icon john">J</div><span class="agent-name">John</span></div>
                         <span class="output">prd.md →</span>
                     </div>
                 </div>
                 <div class="decision">Has UI?</div>
                 <div class="workflow">
                     <div class="workflow-header">
-                        <span class="workflow-name">create-ux-design</span>
+                        <span class="workflow-name">ux</span>
                         <span class="badge iffy">if yes</span>
                     </div>
                     <div class="workflow-meta">
                         <div class="agent"><div class="agent-icon sally">S</div><span class="agent-name">Sally</span></div>
-                        <span class="output">ux-spec.md →</span>
+                        <span class="output">DESIGN.md + EXPERIENCE.md →</span>
                     </div>
                 </div>
             </div>


### PR DESCRIPTION
## What
Updated the Planning section of `workflow-map-diagram.html` so it matches the current BMad Method planning workflow labels.

## Why
The diagram had outdated Planning details: PRD was shown as owned by `Any`, and UX still used the old `create-ux-design` workflow and `ux-spec.md` output. Fixes #2443

## How
- Changed the PRD agent label from `Any` to `John`.
- Renamed the UX workflow label from `create-ux-design` to `ux`.
- Updated the UX output label from `ux-spec.md` to `DESIGN.md + EXPERIENCE.md`.

## Testing
Ran `npm ci` successfully. Ran `npm run quality`, which failed at existing repo-wide Prettier formatting warnings unrelated to this HTML-only change.