### PR TITLE
fix: clarify quick dev subagent use

### DIFF
--- a/src/bmm-skills/4-implementation/bmad-code-review/SKILL.md
+++ b/src/bmm-skills/4-implementation/bmad-code-review/SKILL.md
@@ -9,6 +9,9 @@ description: 'Review code changes adversarially using parallel review layers (Bl
 
 **Your Role:** You are an elite code reviewer. You gather context, launch parallel adversarial reviews, triage findings with precision, and present actionable results. No noise, no filler.
 
+Subagents, when the capability is available, are an important part of this workflow. Use them as directed by the workflow steps.
+If you need an explicit user instruction to run them, ask once now for the whole workflow run.
+
 ## Conventions
 
 - Bare paths (e.g. `checklist.md`) resolve from the skill root.

--- a/src/bmm-skills/4-implementation/bmad-create-story/SKILL.md
+++ b/src/bmm-skills/4-implementation/bmad-create-story/SKILL.md
@@ -16,6 +16,9 @@ description: 'Creates a dedicated story file with all the context the agent will
 - SAVE QUESTIONS: If you think of questions or clarifications during analysis, save them for the end after the complete story is written
 - ZERO USER INTERVENTION: Process should be fully automated except for initial epic/story selection or missing documents
 
+Subagents, when the capability is available, are an important part of this workflow. Use them as directed by the workflow steps.
+If you need an explicit user instruction to run them, ask once now for the whole workflow run.
+
 ## Conventions
 
 - Bare paths (e.g. `discover-inputs.md`) resolve from the skill root.

--- a/src/bmm-skills/4-implementation/bmad-quick-dev/SKILL.md
+++ b/src/bmm-skills/4-implementation/bmad-quick-dev/SKILL.md
@@ -9,6 +9,9 @@ description: 'Implements any user intent, requirement, story, bug fix or change 
 
 **CRITICAL:** If a step says "read fully and follow step-XX", you read and follow step-XX. No exceptions.
 
+Subagents, when the capability is available, are an important part of this workflow. Use them as directed by the workflow steps.
+If you need an explicit user instruction to run them, ask once now for the whole workflow run.
+
 ## READY FOR DEVELOPMENT STANDARD
 
 A specification is "Ready for Development" when:


### PR DESCRIPTION
## What
Adds a compact guardrail to subagent-dependent BMAD workflows explaining that subagents are part of the workflow when the runtime supports them.

## Why
This is a targeted workaround for a Codex ambiguity tracked in openai/codex#23496: Codex may treat skill-required subagent use as conflicting with the `spawn_agent` tool rule that requires explicit user authorization.

Without the guardrail, Codex can resolve that conflict inconsistently: it may spawn anyway, ask for permission, or incorrectly treat missing authorization as if subagents were unavailable and silently degrade to a fallback.

## How
- Adds a short subagent-use note near the top of `bmad-quick-dev/SKILL.md`
- Adds the same note to `bmad-code-review/SKILL.md` and `bmad-create-story/SKILL.md`
- Nudges runtimes that require explicit authorization to ask once for the full workflow run
- Leaves existing step-specific subagent requirements and fallbacks unchanged

## Testing
Ran targeted skill validation for the modified skills and the full push gate: `npm ci && npm run quality`.

Also installed the modified skill into `/tmp/bmad-quick-dev-subagent-test` for Codex/Claude smoke testing against a pre-change quick-dev copy.
