### PR TITLE
feat: add CodeWhale as supported installer platform

### DIFF
--- a/test/test-installation-components.js
+++ b/test/test-installation-components.js
@@ -447,6 +447,41 @@ async function runTests() {
   // Test 12: Removed — ancestor conflict check no longer applies (no IDE inherits skills from parent dirs)
 
   // ============================================================
+  // Test 12b: CodeWhale Native Skills Install
+  // ============================================================
+  console.log(`${colors.yellow}Test Suite 12b: CodeWhale Native Skills${colors.reset}\n`);
+
+  try {
+    clearCache();
+    const platformCodes12b = await loadPlatformCodes();
+    const codewhaleInstaller = platformCodes12b.platforms.codewhale?.installer;
+
+    assert(codewhaleInstaller?.target_dir === '.codewhale/skills', 'CodeWhale target_dir uses native skills path');
+
+    const tempProjectDir12b = await fs.mkdtemp(path.join(os.tmpdir(), 'bmad-codewhale-test-'));
+    const installedBmadDir12b = await createTestBmadFixture();
+
+    const ideManager12b = new IdeManager();
+    await ideManager12b.ensureInitialized();
+    const result12b = await ideManager12b.setup('codewhale', tempProjectDir12b, installedBmadDir12b, {
+      silent: true,
+      selectedModules: ['bmm'],
+    });
+
+    assert(result12b.success === true, 'CodeWhale setup succeeds against temp project');
+
+    const skillFile12b = path.join(tempProjectDir12b, '.codewhale', 'skills', 'bmad-master', 'SKILL.md');
+    assert(await fs.pathExists(skillFile12b), 'CodeWhale install writes SKILL.md directory output');
+
+    await fs.remove(tempProjectDir12b);
+    await fs.remove(path.dirname(installedBmadDir12b));
+  } catch (error) {
+    assert(false, 'CodeWhale native skills migration test succeeds', error.message);
+  }
+
+  console.log('');
+
+  // ============================================================
   // Test 13: Cursor Native Skills Install
   // ============================================================
   console.log(`${colors.yellow}Test Suite 13: Cursor Native Skills${colors.reset}\n`);

--- a/tools/installer/ide/platform-codes.yaml
+++ b/tools/installer/ide/platform-codes.yaml
@@ -70,6 +70,13 @@ platforms:
       target_dir: .agents/skills
       global_target_dir: ~/.codex/skills
 
+  codewhale:
+    name: "CodeWhale"
+    preferred: false
+    installer:
+      target_dir: .codewhale/skills
+      global_target_dir: ~/.codewhale/skills
+
   codebuddy:
     name: "CodeBuddy"
     preferred: false


### PR DESCRIPTION
CodeWhale uses `.codewhale/skills/` (project) and `~/.codewhale/skills/` (global) for skill directories, matching the existing config-driven installer pattern.

- `platform-codes.yaml`: codewhale entry after codex
- test: Test 12b validates install target and setup

## What
Add CodeWhale as a supported tool option in the BMAD installer, enabling `npx bmad-method install --tools codewhale` and interactive selection.

## Why
CodeWhale users currently have no path to install BMAD skills through the standard installer flow. Since the installer is fully config-driven — every tool is a single entry in `platform-codes.yaml` — adding support is a one-line declaration once the tool's skill directory convention is known.

## How
- Added a `codewhale` platform entry to `tools/installer/ide/platform-codes.yaml` with `target_dir: .codewhale/skills` and `global_target_dir: ~/.codewhale/skills`
- Added Test 12b to `test-installation-components.js` covering platform-code loading, setup success, and `SKILL.md` output verification
- No installer code changes needed — `IdeManager` and `ConfigDrivenIdeSetup` handle all new platforms generically from the YAML

## Testing
- `npm run test:install` passes all suites including the new Test 12b
- `node tools/installer/bmad-cli.js install --list-tools` lists codewhale
- Manual install: `--tools codewhale -y` into a temp directory produces the expected `.codewhale/skills/bmad-master/SKILL.md`