### PR TITLE
fix: remove empty skill-group dirs left in _bmad after install

### DIFF
--- a/test/test-installation-components.js
+++ b/test/test-installation-components.js
@@ -3278,8 +3278,9 @@ async function runTests() {
   // ============================================================
   console.log(`${colors.yellow}Test Suite 45: cleanup prunes empty skill-group dirs${colors.reset}\n`);
 
+  let root45;
   try {
-    const root45 = await fs.mkdtemp(path.join(os.tmpdir(), 'bmad-cleanup-test-'));
+    root45 = await fs.mkdtemp(path.join(os.tmpdir(), 'bmad-cleanup-test-'));
     const bmadDir45 = path.join(root45, '_bmad');
     await fs.ensureDir(path.join(bmadDir45, '_config'));
 
@@ -3307,12 +3308,12 @@ async function runTests() {
     assert(!(await fs.pathExists(path.join(bmadDir45, 'bmm', '1-analysis', 'research'))), 'empty nested skill-group dir is pruned');
     assert(await fs.pathExists(path.join(bmadDir45, 'bmm', 'config.yaml')), 'module-level files are preserved');
     assert(await fs.pathExists(bmadDir45), 'bmad root is never removed');
-
-    await fs.remove(root45);
   } catch (error) {
     console.log(`${colors.red}Test Suite 45 setup failed: ${error.message}${colors.reset}`);
     console.log(error.stack);
     failed++;
+  } finally {
+    if (root45) await fs.remove(root45).catch(() => {});
   }
 
   console.log('');

--- a/test/test-installation-components.js
+++ b/test/test-installation-components.js
@@ -3274,6 +3274,50 @@ async function runTests() {
   console.log('');
 
   // ============================================================
+  // Test Suite 45: _cleanupSkillDirs prunes empty parent dirs (#empty-bmm-folders)
+  // ============================================================
+  console.log(`${colors.yellow}Test Suite 45: cleanup prunes empty skill-group dirs${colors.reset}\n`);
+
+  try {
+    const root45 = await fs.mkdtemp(path.join(os.tmpdir(), 'bmad-cleanup-test-'));
+    const bmadDir45 = path.join(root45, '_bmad');
+    await fs.ensureDir(path.join(bmadDir45, '_config'));
+
+    // Two skills nested under the same grouping dir (1-analysis), plus a
+    // module-level file that must survive the cleanup.
+    await fs.writeFile(
+      path.join(bmadDir45, '_config', 'skill-manifest.csv'),
+      [
+        'canonicalId,name,description,module,path',
+        '"bmad-agent-analyst","bmad-agent-analyst","fixture","bmm","_bmad/bmm/1-analysis/bmad-agent-analyst/SKILL.md"',
+        '"bmad-research","bmad-research","fixture","bmm","_bmad/bmm/1-analysis/research/bmad-research/SKILL.md"',
+        '',
+      ].join('\n'),
+    );
+    await fs.ensureDir(path.join(bmadDir45, 'bmm', '1-analysis', 'bmad-agent-analyst'));
+    await fs.writeFile(path.join(bmadDir45, 'bmm', '1-analysis', 'bmad-agent-analyst', 'SKILL.md'), 'x');
+    await fs.ensureDir(path.join(bmadDir45, 'bmm', '1-analysis', 'research', 'bmad-research'));
+    await fs.writeFile(path.join(bmadDir45, 'bmm', '1-analysis', 'research', 'bmad-research', 'SKILL.md'), 'x');
+    await fs.writeFile(path.join(bmadDir45, 'bmm', 'config.yaml'), 'module: bmm\n');
+
+    const installer45 = new Installer();
+    await installer45._cleanupSkillDirs(bmadDir45);
+
+    assert(!(await fs.pathExists(path.join(bmadDir45, 'bmm', '1-analysis'))), 'empty skill-group dir is pruned after cleanup');
+    assert(!(await fs.pathExists(path.join(bmadDir45, 'bmm', '1-analysis', 'research'))), 'empty nested skill-group dir is pruned');
+    assert(await fs.pathExists(path.join(bmadDir45, 'bmm', 'config.yaml')), 'module-level files are preserved');
+    assert(await fs.pathExists(bmadDir45), 'bmad root is never removed');
+
+    await fs.remove(root45);
+  } catch (error) {
+    console.log(`${colors.red}Test Suite 45 setup failed: ${error.message}${colors.reset}`);
+    console.log(error.stack);
+    failed++;
+  }
+
+  console.log('');
+
+  // ============================================================
   // Summary
   // ============================================================
   console.log(`${colors.cyan}========================================`);

--- a/tools/installer/core/installer.js
+++ b/tools/installer/core/installer.js
@@ -426,17 +426,24 @@ class Installer {
 
   /**
    * Remove now-empty parent directories left behind after skill dir cleanup.
-   * Walks up from dir, stopping at (and never removing) bmadDir.
+   * Walks up from dir, stopping at (and never removing) bmadDir. Best-effort:
+   * a directory that vanishes or fills in mid-walk just ends the walk.
    * @param {string} dir - Directory to start walking up from
    * @param {string} bmadDir - BMAD installation directory (boundary)
    */
   async _removeEmptyParents(dir, bmadDir) {
     let current = dir;
-    while (current.startsWith(bmadDir) && current !== bmadDir) {
-      if (!(await fs.pathExists(current))) break;
-      const entries = await fs.readdir(current);
-      if (entries.length > 0) break;
-      await fs.rmdir(current);
+    while (true) {
+      // Path-boundary check (not a string prefix, so siblings like _bmad2 don't match).
+      const rel = path.relative(bmadDir, current);
+      if (rel === '' || rel.startsWith('..') || path.isAbsolute(rel)) break;
+      try {
+        const entries = await fs.readdir(current);
+        if (entries.length > 0) break;
+        await fs.rmdir(current);
+      } catch {
+        break;
+      }
       current = path.dirname(current);
     }
   }

--- a/tools/installer/core/installer.js
+++ b/tools/installer/core/installer.js
@@ -419,7 +419,25 @@ class Installer {
       const sourceDir = path.dirname(path.join(bmadDir, relativePath));
       if (await fs.pathExists(sourceDir)) {
         await fs.remove(sourceDir);
+        await this._removeEmptyParents(path.dirname(sourceDir), bmadDir);
       }
+    }
+  }
+
+  /**
+   * Remove now-empty parent directories left behind after skill dir cleanup.
+   * Walks up from dir, stopping at (and never removing) bmadDir.
+   * @param {string} dir - Directory to start walking up from
+   * @param {string} bmadDir - BMAD installation directory (boundary)
+   */
+  async _removeEmptyParents(dir, bmadDir) {
+    let current = dir;
+    while (current.startsWith(bmadDir) && current !== bmadDir) {
+      if (!(await fs.pathExists(current))) break;
+      const entries = await fs.readdir(current);
+      if (entries.length > 0) break;
+      await fs.rmdir(current);
+      current = path.dirname(current);
     }
   }
 


### PR DESCRIPTION
## Problem

After installing, empty grouping folders are left behind under `_bmad/<module>` — e.g. `_bmad/bmm/1-analysis`, `2-plan-workflows`, `3-solutioning`, `4-implementation`. These aren't output/artifact dirs and aren't meant to stick around; they're just leftovers from the install.

## Cause

`_cleanupSkillDirs` (`tools/installer/core/installer.js`) removes each skill's own directory after skills are copied to the IDE target, but it only deletes the skill dir itself — not the grouping folder above it. Once every skill under a group is removed, the empty group folder remains.

## Fix

After removing a skill dir, walk up and drop any parent directories that are now empty, stopping at (and never removing) the bmad root. Module-level files like `config.yaml` and `_config/` keep their parents alive, so only genuinely-empty grouping dirs get pruned.

## Tests

Appended a suite to `test/test-installation-components.js` covering:
- empty skill-group dir is pruned
- empty nested group dir (e.g. `1-analysis/research`) is pruned
- module-level files are preserved
- the bmad root is never removed

Full suite passes.
