### PR TITLE
fix(skills): pass diff output inline to the blind-hunter reviewer

### DIFF
--- a/src/bmm-skills/4-implementation/bmad-code-review/steps/step-02-review.md
+++ b/src/bmm-skills/4-implementation/bmad-code-review/steps/step-02-review.md
@@ -18,7 +18,7 @@ failed_layers: '' # set at runtime: comma-separated list of layers that failed o
 
 2. Launch parallel subagents without conversation context. If subagents are not available, generate prompt files in `{implementation_artifacts}` — one per reviewer role below — and HALT. Ask the user to run each in a separate session (ideally a different LLM) and paste back the findings. When findings are pasted, resume from this point and proceed to step 3.
 
-   - **Blind Hunter** — receives `{diff_output}` only. No spec, no context docs, no project access. Invoke via the `bmad-review-adversarial-general` skill.
+   - **Blind Hunter** — receives inline `{diff_output}` only. No spec, no context docs, no project access. Invoke via the `bmad-review-adversarial-general` skill.
 
    - **Edge Case Hunter** — receives `{diff_output}` and read access to the project. Invoke via the `bmad-review-edge-case-hunter` skill.
 

--- a/src/bmm-skills/4-implementation/bmad-quick-dev/step-04-review.md
+++ b/src/bmm-skills/4-implementation/bmad-quick-dev/step-04-review.md
@@ -25,7 +25,7 @@ Do NOT `git add` anything — this is read-only inspection.
 
 Launch three subagents without conversation context. If no sub-agents are available, generate three review prompt files in `{implementation_artifacts}` — one per reviewer role below — and HALT. Ask the human to run each in a separate session (ideally a different LLM) and paste back the findings.
 
-- **Blind hunter** — receives `{diff_output}` only. No spec, no context docs, no project access. Invoke via the `bmad-review-adversarial-general` skill.
+- **Blind hunter** — receives inline `{diff_output}` only. No spec, no context docs, no project access. Invoke via the `bmad-review-adversarial-general` skill.
 - **Edge case hunter** — receives `{diff_output}` and read access to the project. Invoke via the `bmad-review-edge-case-hunter` skill.
 - **Acceptance auditor** — receives `{diff_output}`, `{spec_file}`, and read access to the project. Must also read the docs listed in `{spec_file}` frontmatter `context`. Checks for violations of acceptance criteria, rules, and principles from the spec and context docs.
 


### PR DESCRIPTION
## Problem

The **Blind Hunter** adversarial reviewer (used in both `bmad-code-review` step 2 and `bmad-quick-dev` step 4) intentionally runs with **no tool access** — it is supposed to judge the diff blind, with no spec, context docs, or project access.

However, the review steps never specified *how* `{diff_output}` should be delivered to the subagent. With newer LLMs, orchestrators commonly write the diff to a temp file and instruct the agent to read it. Since the agent has no tools, that read silently fails — the run ends with 0 tool calls, which looks normal for this agent, so nothing flags it.

Worse, the review's aggressive ~10-finding requirement then pressures the agent to fabricate findings (and even code snippets) for a diff it never saw. This usually only gets caught when the hallucinations are extreme enough that the orchestrator notices the review makes no sense.

## Fix

Explicitly state in both skill steps that `{diff_output}` is passed **inline** in the subagent prompt:

- `src/bmm-skills/4-implementation/bmad-code-review/steps/step-02-review.md`
- `src/bmm-skills/4-implementation/bmad-quick-dev/step-04-review.md`

## Testing

- Full pre-commit suite passed: `test:refs`, `test:install`, `test:urls`, `test:channels`, eslint, markdownlint, prettier.

🤖 Generated with [Claude Code](https://claude.com/claude-code)