### PR TITLE
fix: adjust nav height for dual announcement banners

### DIFF
--- a/website/src/styles/custom.css
+++ b/website/src/styles/custom.css
@@ -15,7 +15,7 @@
    ============================================ */
 :root {
   --ai-banner-height: 2.75rem;
-  --sl-nav-height: 6.25rem; /* Base nav height (~3.5rem) + banner height (2.75rem) */
+  --sl-nav-height: 9rem; /* Base nav (3.5rem) + two announcement banners (2.75rem each) */
 
   /* Full-width content - override Starlight's default 45rem/67.5rem */
   --sl-content-width: 65rem;


### PR DESCRIPTION
## What

Adjusted the navigation height to account for two top announcement banners displayed on the documentation site.

## Why

The site now displays two announcement banners, but the navigation height was still calculated for a single banner. This caused layout overlap issues on both desktop and mobile views.

## How

* Updated `--sl-nav-height` from `6.25rem` to `9rem`
* Adjusted the height calculation comment to reflect two announcement banners
* Verified the navigation and page content alignment with both banners enabled

## Testing

Tested locally in desktop and mobile responsive views. Confirmed that the header and page content no longer overlap and spacing is rendered correctly.
