### PR TITLE
fix(bmad-investigate): keep method-internal vocabulary out of user-facing output

### DIFF
--- a/src/bmm-skills/4-implementation/bmad-investigate/SKILL.md
+++ b/src/bmm-skills/4-implementation/bmad-investigate/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: bmad-investigate
-description: Forensic case investigation with evidence-graded findings, calibrated to the input. Use when the user asks to investigate a bug, trace what caused an incident, walk through unfamiliar code, or build a mental model of a code area before working on it.
+description: 'Forensic case investigation with evidence-graded findings, producing a structured case file an engineer can pick up cold. Use when the user says "bmad investigate" or "open an investigation".'
 ---
 
 # Investigate
@@ -46,7 +46,9 @@ After every outcome, present what was learned and pause for the user before cont
 - **Issue independent operations in parallel** (multi-grep, multi-read, parallel inventories) — one message, multiple
   tool calls.
 - **Communication.** Evidence-first language ("the evidence shows", "unconfirmed, requires X to verify"). No hedging,
-  no narrative.
+  no narrative. User-facing messages use plain English. Terms from this skill — "stronghold", "Outcome 1",
+  "Hypothesis #1" — belong in the case file and your reasoning, not in chat. In chat, say what was found and what
+  happens next.
 
 ## On Activation
 
@@ -121,7 +123,7 @@ and collision rules in Overview). Create the file from `{workflow.case_file_temp
 Brief; populate the Investigation Backlog with prioritized data-collection items; record "to make progress, I need one
 of: …"; pause for the user to provide evidence or authorize Outcome 2 to scan more broadly.
 
-Otherwise present scope, stronghold, file path, proposed approach. Pause for user with the recap above; wait for direction.
+Otherwise present scope, the confirmed starting evidence, file path, proposed approach. Pause for user with the recap above; wait for direction.
 
 ### Outcome 2: Evidence perimeter is mapped
 


### PR DESCRIPTION
## What

Two related fixes in `bmad-investigate`, both addressing #2452:

1. **Stop method-internal vocabulary from leaking into user-facing output** — the Outcome 1 recap instruction told the agent to "present scope, stronghold, file path" verbatim, which in real sessions produced lines like "let me anchor the stronghold in code".
2. **Tighten the trigger description** so the skill only fires on explicit invocation, per the maintainer's note in the issue thread that "skills like this … should really be not auto firing unless very explicitly called. feel free to change it or improve it in any way."

## How

Three edits to `src/bmm-skills/4-implementation/bmad-investigate/SKILL.md`:

- **Frontmatter `description`** rewritten to match the house style used by `bmad-code-review`, `bmad-create-story`, etc. — quoted explicit invocation phrases (`"bmad investigate"`, `"open an investigation"`). Drops broad-paraphrase triggers like `"walk through unfamiliar code"` / `"build a mental model"`.
- **Communication principle** extended with a guardrail: user-facing chat uses plain English; skill-internal terms ("stronghold", "Outcome 1", "Hypothesis #3") stay in the case file and the agent's reasoning, not in chat.
- **Outcome 1 recap instruction** changed from `present scope, stronghold, file path` to `present scope, the confirmed starting evidence, file path` — the exact phrasing the issue author suggested.

## Notes

- **Internal vocabulary is intentionally preserved.** The `Stronghold first.` principle (line 32), the Outcome 1 heading, and the "find the stronghold" instructions in Outcome 1's body are unchanged. Per the issue author's preference, this PR fixes the chat-output leak via guardrail rather than renaming the method's internal language. Whether to rename `Stronghold first.` itself is a separate question, fit for a follow-up PR if you want it.
- **Trigger tightening is beyond the issue body's Suggested fix** — included here in direct response to the maintainer comment quoted above. Happy to split it into a follow-up PR if preferred.

## Verification

- `node tools/validate-skills.js --json src/bmm-skills/4-implementation/bmad-investigate` → `[]`
- `npm ci && npm run quality` → `Errors: 0` (23 unrelated `vi-vn`/`zh-cn` sidebar-order warnings)

Opening as draft to get a quick direction-check on the new trigger phrasing before polish.