### PR TITLE
feat(dev-auto): commit completed work at end of successful run

### DIFF
--- a/src/bmm-skills/4-implementation/bmad-dev-auto/step-04-review.md
+++ b/src/bmm-skills/4-implementation/bmad-dev-auto/step-04-review.md
@@ -83,4 +83,6 @@ Prepare `Auto Run Result` details:
 
 Before HALT with status `done`, set `{spec_file}` frontmatter `followup_review_recommended` from the final-pass judgment above. Do not set or recommend follow-up review on blocked exits, including review-loop non-convergence.
 
+If version control is available, commit. Do not push.
+
 HALT with status `done`.

--- a/src/bmm-skills/4-implementation/bmad-dev-auto/step-04-review.md
+++ b/src/bmm-skills/4-implementation/bmad-dev-auto/step-04-review.md
@@ -81,7 +81,7 @@ Prepare `Auto Run Result` details:
 - Verification performed, including command outcomes or manual inspection notes
 - Any residual risks
 
-Before HALT with status `done`, set `{spec_file}` frontmatter `followup_review_recommended` from the final-pass judgment above. Do not set or recommend follow-up review on blocked exits, including review-loop non-convergence.
+Set `{spec_file}` frontmatter `followup_review_recommended` from the judgment above.
 
 If version control is available, commit. Do not push.
 


### PR DESCRIPTION
## What

Adds the missing end-of-run **commit** to the `bmad-dev-auto` workflow, and trims some over-prompting in step-04's Finalize while there.

`step-04-review.md` Finalize now ends with:

> Set `{spec_file}` frontmatter `followup_review_recommended` from the judgment above.
>
> If version control is available, commit. Do not push.
>
> HALT with status `done`.

## Why

dev-auto's start-of-run check (`step-01` instruction #3) already HALTs `blocked` if the worktree is dirty — but nothing committed the work at the end, so an unattended loop's next iteration would trip that check on the previous iteration's own output. Committing on the successful `done` path completes the VCS bookend and makes each iteration atomic: it ends clean, so the next one starts clean.

## Commits

- `feat`: add the commit line to Finalize (commit on `done`, no push, gated on version control).
- `chore`: trim over-prompting in Finalize — drop the redundant "Before HALT with status done" ordering and the "do not set follow-up on blocked exits" caveat (blocked exits never reach that line).

## Notes

- The "verify worktree is clean at the start" half already existed (`step-01` #3); no change needed there.
- `SKILL.md`'s shared HALT is intentionally untouched, so `blocked` exits never commit.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
