### PR TITLE
fix(review): give Blind Hunter project access; verbatim skill prompts

### DIFF
--- a/src/bmm-skills/4-implementation/bmad-code-review/steps/step-02-review.md
+++ b/src/bmm-skills/4-implementation/bmad-code-review/steps/step-02-review.md
@@ -18,9 +18,9 @@ failed_layers: '' # set at runtime: comma-separated list of layers that failed o
 
 2. Launch parallel subagents without conversation context. If subagents are not available, generate prompt files in `{implementation_artifacts}` — one per reviewer role below — and HALT. Ask the user to run each in a separate session (ideally a different LLM) and paste back the findings. When findings are pasted, resume from this point and proceed to step 3.
 
-   - **Blind Hunter** — receives inline `{diff_output}` only. No spec, no context docs, no project access. Invoke via the `bmad-review-adversarial-general` skill.
+   - **Blind Hunter** — prompt: "Use the `bmad-review-adversarial-general` skill on `{diff_output}`."
 
-   - **Edge Case Hunter** — receives `{diff_output}` and read access to the project. Invoke via the `bmad-review-edge-case-hunter` skill.
+   - **Edge Case Hunter** — prompt: "Use the `bmad-review-edge-case-hunter` skill on `{diff_output}`."
 
    - **Acceptance Auditor** (only if `{review_mode}` = `"full"`) — receives `{diff_output}`, the content of the file at `{spec_file}`, and any loaded context docs. Its prompt:
      > You are an Acceptance Auditor. Review this diff against the spec and context docs. Check for: violations of acceptance criteria, deviations from spec intent, missing implementation of specified behavior, contradictions between spec constraints and actual code. Output findings as a Markdown list. Each finding: one-line title, which AC/constraint it violates, and evidence from the diff.

--- a/src/bmm-skills/4-implementation/bmad-dev-auto/step-04-review.md
+++ b/src/bmm-skills/4-implementation/bmad-dev-auto/step-04-review.md
@@ -25,8 +25,8 @@ Do NOT `git add` anything — this is read-only inspection.
 
 Launch two subagents without prior session context.
 
-- **Blind hunter** — receives inline `{diff_output}` only. No spec, no context docs, no project access. Invoke via the `bmad-review-adversarial-general` skill.
-- **Edge case hunter** — receives `{diff_output}` and read access to the project. Invoke via the `bmad-review-edge-case-hunter` skill.
+- **Blind hunter** — prompt: "Use the `bmad-review-adversarial-general` skill on `{diff_output}`."
+- **Edge case hunter** — prompt: "Use the `bmad-review-edge-case-hunter` skill on `{diff_output}`."
 
 ### Classify
 

--- a/src/bmm-skills/4-implementation/bmad-quick-dev/step-04-review.md
+++ b/src/bmm-skills/4-implementation/bmad-quick-dev/step-04-review.md
@@ -24,8 +24,8 @@ Do NOT `git add` anything — this is read-only inspection.
 
 Launch two subagents without conversation context. If no subagents are available, generate two review prompt files in `{implementation_artifacts}` — one per reviewer role below — and HALT. Ask the human to run each in a separate session (ideally a different LLM) and paste back the findings.
 
-- **Blind hunter** — receives inline `{diff_output}` only. No spec, no context docs, no project access. Invoke via the `bmad-review-adversarial-general` skill.
-- **Edge case hunter** — receives `{diff_output}` and read access to the project. Invoke via the `bmad-review-edge-case-hunter` skill.
+- **Blind hunter** — prompt: "Use the `bmad-review-adversarial-general` skill on `{diff_output}`."
+- **Edge case hunter** — prompt: "Use the `bmad-review-edge-case-hunter` skill on `{diff_output}`."
 
 ### Classify
 


### PR DESCRIPTION
## What

Fixes the **Blind Hunter** review subagent across `bmad-dev-auto`, `bmad-quick-dev`, and `bmad-code-review`, and makes the review-skill invocation explicit.

## Why — the bug

All three skills described the Blind Hunter as receiving the diff with **"no project access."** That's wrong. "Blind" means blind to *intent* — no spec, no context docs, so it can't anchor on why the change was made — **not** blind to the codebase. Denying it project access crippled it: it could only see the diff, never the surrounding code that determines whether the change is actually correct.

## The change

Replace the prose reviewer descriptions with bare, verbatim prompts:

```
- **Blind hunter** — prompt: "Use the `bmad-review-adversarial-general` skill on `{diff_output}`."
- **Edge case hunter** — prompt: "Use the `bmad-review-edge-case-hunter` skill on `{diff_output}`."
```

- Subagents already have project read access by default, so nothing needs to grant it — and the prompt carries only the diff, so the intent-blindness is preserved by construction (no need to *state* "no spec/context").
- The verbatim "Use the `…` skill" prompt also replaces the vague "invoke via the skill" phrasing that previously left room to *emulate* the review instead of actually invoking the skill.
- `bmad-code-review`'s Acceptance Auditor is unchanged — it's the spec-aware reviewer by design.

## Scope

Three one-line-per-reviewer edits; `npm run quality` passes. Separate from #2506 (dev-auto commit-at-end); the two PRs touch `dev-auto/step-04-review.md` in different hunks.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
