### PR TITLE
feat(dev-auto): route done spec to a follow-up review pass

### DIFF
--- a/src/bmm-skills/4-implementation/bmad-dev-auto/step-01-clarify-and-route.md
+++ b/src/bmm-skills/4-implementation/bmad-dev-auto/step-01-clarify-and-route.md
@@ -20,7 +20,7 @@ If the invocation prompt explicitly points to an existing spec file with recogni
 - `ready-for-dev` or `in-progress` → `./step-03-implement.md`
 - `in-review` → `./step-04-review.md`
 - `blocked` → HALT with status `blocked` and blocking condition `blocked spec supplied`.
-- `done` → ingest as context and proceed to INSTRUCTIONS — do not resume.
+- `done` → set `review_loop_iteration` to `0` in the frontmatter, then **EARLY EXIT** to `./step-04-review.md` for a fresh review pass. (A `done` spec is a completed run, so this starts a follow-up review, not a resumption.)
 
 Otherwise, treat the invocation prompt as starting intent. This may be a story ID, ticket ID, file path, short description, or longer free-form intent. Do not infer workflow state from non-spec files.
 If the invocation prompt does not contain enough intent to identify what to implement, HALT with status `blocked` and blocking condition `unclear intent`.


### PR DESCRIPTION
## What

Re-invoking `bmad-dev-auto` on a spec with `status: done` now starts a fresh review pass instead of ingesting the spec as context.

In step-01's status router, the `done` route changes from "ingest as context and proceed to INSTRUCTIONS — do not resume" to: reset `review_loop_iteration` to `0`, then route directly to step-04 (review).

## Why

After a successful run the spec ends at `status: done` — the one terminal state with no path back into review. step-04 is already built for repeated, independent passes (review subagents get no prior context, the diff is reconstructed from `baseline_revision`, the triage log is keyed per pass, and Finalize already emits `followup_review_recommended`). This change opens the only missing door, so an orchestrator can layer follow-up reviews on a completed spec — gated on `followup_review_recommended` — without invoking another skill.

The previous `done`-as-context behavior was redundant: step-01's **Previous story continuity** step already pulls prior same-epic `done` specs into planning automatically.

## Note on the counter reset

The reset lives in the `done` route only. The `in-review` route is a *resumption* of an interrupted pass and keeps its counter, preserving the non-convergence guard (HALT after 5 bad_spec loopbacks). A `done` re-invocation is a new pass, so it starts the clock fresh.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
