### PR TITLE
fix(installer): accept windows custom module paths

### DIFF
--- a/test/test-parse-source-urls.js
+++ b/test/test-parse-source-urls.js
@@ -212,6 +212,28 @@ console.log(`\n${colors.cyan}Simple owner/repo URLs (regression check)${colors.r
   assert(result.cloneUrl === 'git@github.com:owner/repo.git', 'SSH cloneUrl unchanged', `Got: ${result.cloneUrl}`);
 }
 
+// ─── Windows local paths ────────────────────────────────────────────────────
+
+console.log(`\n${colors.cyan}Windows local paths${colors.reset}\n`);
+
+{
+  const result = manager.parseSource(String.raw`C:\__bmad_missing_module__\source`);
+  assert(result.type === 'local', 'Windows drive path is treated as local');
+  assert(result.error && result.error.startsWith('Path does not exist:'), 'missing Windows drive path gets path-specific error');
+}
+
+{
+  const result = manager.parseSource('C:/__bmad_missing_module__/source');
+  assert(result.type === 'local', 'Windows forward-slash drive path is treated as local');
+  assert(result.error && result.error.startsWith('Path does not exist:'), 'missing Windows forward-slash path gets path-specific error');
+}
+
+{
+  const result = manager.parseSource(String.raw`.\__bmad_missing_module__\source`);
+  assert(result.type === 'local', 'Windows relative path is treated as local');
+  assert(result.error && result.error.startsWith('Path does not exist:'), 'missing Windows relative path gets path-specific error');
+}
+
 // ─── Generic URL handling (any host, any path depth) ────────────────────────
 
 console.log(`\n${colors.cyan}Generic URL handling${colors.reset}\n`);

--- a/test/test-parse-source-urls.js
+++ b/test/test-parse-source-urls.js
@@ -234,6 +234,18 @@ console.log(`\n${colors.cyan}Windows local paths${colors.reset}\n`);
   assert(result.error && result.error.startsWith('Path does not exist:'), 'missing Windows relative path gets path-specific error');
 }
 
+{
+  const result = manager.parseSource(String.raw`C:\__bmad_missing_module__\source@main`);
+  assert(result.type === 'local', 'Windows drive path with @version is treated as local');
+  assert(result.error === 'Local paths do not support @version suffixes', 'Windows drive path rejects @version suffix');
+}
+
+{
+  const result = manager.parseSource(String.raw`.\__bmad_missing_module__\source@main`);
+  assert(result.type === 'local', 'Windows relative path with @version is treated as local');
+  assert(result.error === 'Local paths do not support @version suffixes', 'Windows relative path rejects @version suffix');
+}
+
 // ─── Generic URL handling (any host, any path depth) ────────────────────────
 
 console.log(`\n${colors.cyan}Generic URL handling${colors.reset}\n`);

--- a/tools/installer/modules/custom-module-manager.js
+++ b/tools/installer/modules/custom-module-manager.js
@@ -11,6 +11,18 @@ function quoteCustomRef(ref) {
   return `"${ref}"`;
 }
 
+function isLocalSourcePath(input) {
+  return (
+    input.startsWith('/') ||
+    input.startsWith('./') ||
+    input.startsWith('../') ||
+    input.startsWith('.\\') ||
+    input.startsWith('..\\') ||
+    input.startsWith('~') ||
+    path.win32.isAbsolute(input)
+  );
+}
+
 /**
  * Manages custom modules installed from user-provided sources.
  * Supports any Git host (GitHub, GitLab, Bitbucket, self-hosted) and local file paths.
@@ -97,8 +109,8 @@ class CustomModuleManager {
       }
     }
 
-    // Local path detection: starts with /, ./, ../, or ~
-    if (trimmed.startsWith('/') || trimmed.startsWith('./') || trimmed.startsWith('../') || trimmed.startsWith('~')) {
+    // Local path detection: POSIX, Windows, relative, or home-relative.
+    if (isLocalSourcePath(trimmed)) {
       if (versionSuffix) {
         return {
           type: 'local',

--- a/tools/installer/modules/custom-module-manager.js
+++ b/tools/installer/modules/custom-module-manager.js
@@ -95,8 +95,7 @@ class CustomModuleManager {
         // Avoid consuming the @ in `git@host:owner/repo` — `before` wouldn't end with a path separator
         // in that case. Require that the @ comes after the host/path, not inside the auth segment.
         // Rule: the @ is a version suffix only if `before` looks like a complete URL or local path.
-        const beforeLooksLikeRepo =
-          isLocalSourcePath(before) || /^https?:\/\//i.test(before) || /^git@[^:]+:.+/.test(before);
+        const beforeLooksLikeRepo = isLocalSourcePath(before) || /^https?:\/\//i.test(before) || /^git@[^:]+:.+/.test(before);
         if (beforeLooksLikeRepo) {
           versionSuffix = candidate;
           trimmed = before;

--- a/tools/installer/modules/custom-module-manager.js
+++ b/tools/installer/modules/custom-module-manager.js
@@ -96,12 +96,7 @@ class CustomModuleManager {
         // in that case. Require that the @ comes after the host/path, not inside the auth segment.
         // Rule: the @ is a version suffix only if `before` looks like a complete URL or local path.
         const beforeLooksLikeRepo =
-          before.startsWith('/') ||
-          before.startsWith('./') ||
-          before.startsWith('../') ||
-          before.startsWith('~') ||
-          /^https?:\/\//i.test(before) ||
-          /^git@[^:]+:.+/.test(before);
+          isLocalSourcePath(before) || /^https?:\/\//i.test(before) || /^git@[^:]+:.+/.test(before);
         if (beforeLooksLikeRepo) {
           versionSuffix = candidate;
           trimmed = before;


### PR DESCRIPTION
## What
Custom module source parsing now accepts Windows local paths such as `C:\modules\foo`, `C:/modules/foo`, and `.\foo`.

## Why
Windows-style local paths such as `C:\projects\ai\BMAD-METHOD` fell through to the Git URL parser and were rejected as invalid, even though slash-style paths like `/projects/ai/BMAD-METHOD` already worked.

## How
- Added shared local-source detection for POSIX, Windows absolute, Windows relative, and home-relative paths.
- Routed the existing custom source parser through that detector before URL handling.
- Added parser regression coverage for Windows-shaped local paths.

## Testing
Ran `npm run lint`, `npm run test:urls`, and `node test/test-installation-components.js`; all passed.