### PR TITLE
feat(elicitation): halt with clear error on missing/malformed registry

### DIFF
--- a/src/core-skills/bmad-advanced-elicitation/SKILL.md
+++ b/src/core-skills/bmad-advanced-elicitation/SKILL.md
@@ -35,7 +35,11 @@ When invoked from another prompt or process:
 
 ### Step 1: Method Registry Loading
 
-**Action:** Load `./methods.csv` for elicitation methods. If party-mode may participate, resolve the agent roster via:
+**Action:** Load `./methods.csv` for elicitation methods.
+
+**HALT — registry guard:** If `./methods.csv` cannot be read, is empty, is missing the header `num,category,method_name,description,output_pattern`, or contains no method rows, STOP immediately and report to the user: "Advanced Elicitation cannot run — the method registry `methods.csv` is missing or malformed." Do NOT invent methods or proceed from memory.
+
+If party-mode may participate, resolve the agent roster via:
 
 ```bash
 python3 {project-root}/_bmad/scripts/resolve_config.py --project-root {project-root} --key agents


### PR DESCRIPTION
## What

Add a registry load guard to `bmad-advanced-elicitation` Step 1: HALT with a clear error if `methods.csv` is missing, empty, or malformed.

## Why

Step 1 loaded `methods.csv` with no failure path, so a missing/corrupted registry made the agent silently invent methods from memory. This fails fast with an explicit message instead.
Fixes #2516

## How

- Insert a natural-language HALT after the load step: unreadable / empty / wrong header / no rows → stop and report.
- Forbid inventing methods or proceeding from memory.
- Natural-language only; no code, no new control surface.

## Testing

- `npm run validate:refs`, `npm run validate:skills`, and `markdownlint` on the file: no new findings vs `main` (verified by diffing counts with/without the change).
- Confirmed the guard text matches the actual CSV header.