### PR TITLE
fix: remove explicit host memory loading from implementation skills

### DIFF
--- a/src/bmm-skills/4-implementation/bmad-code-review/SKILL.md
+++ b/src/bmm-skills/4-implementation/bmad-code-review/SKILL.md
@@ -50,7 +50,6 @@ Load config from `{project-root}/_bmad/bmm/config.yaml` and resolve:
 - `date` as system-generated current datetime
 - `sprint_status` = `{implementation_artifacts}/sprint-status.yaml`
 - `project_context` = `**/project-context.md` (load if exists)
-- CLAUDE.md / memory files (load if exist)
 - YOU MUST ALWAYS SPEAK OUTPUT in your Agent communication style with the config `{communication_language}`
 
 ### Step 5: Greet the User

--- a/src/bmm-skills/4-implementation/bmad-dev-auto/SKILL.md
+++ b/src/bmm-skills/4-implementation/bmad-dev-auto/SKILL.md
@@ -81,7 +81,6 @@ Load config from `{project-root}/_bmad/bmm/config.yaml` and resolve:
 - `communication_language`, `document_output_language`, `user_skill_level`
 - `date` as system-generated current datetime
 - `project_context` = `**/project-context.md` (load if exists)
-- CLAUDE.md / memory files (load if exist)
 - YOU MUST ALWAYS SPEAK OUTPUT in your Agent communication style with the config `{communication_language}`
 - Language MUST be tailored to `{user_skill_level}`
 - Generate all documents in `{document_output_language}`

--- a/src/bmm-skills/4-implementation/bmad-quick-dev/SKILL.md
+++ b/src/bmm-skills/4-implementation/bmad-quick-dev/SKILL.md
@@ -71,7 +71,6 @@ Load config from `{project-root}/_bmad/bmm/config.yaml` and resolve:
 - `date` as system-generated current datetime
 - `sprint_status` = `{implementation_artifacts}/sprint-status.yaml`
 - `project_context` = `**/project-context.md` (load if exists)
-- CLAUDE.md / memory files (load if exist)
 - YOU MUST ALWAYS SPEAK OUTPUT in your Agent communication style with the config `{communication_language}`
 - Language MUST be tailored to `{user_skill_level}`
 - Generate all documents in `{document_output_language}`


### PR DESCRIPTION
## What
Removes the explicit `CLAUDE.md / memory files` loading instruction from the three implementation skills called out in #2518.

## Why
Those host/session instruction files should be provided by the platform, not loaded explicitly by the skills themselves.

## How
- delete the explicit host-memory loading line from `bmad-code-review`
- delete the explicit host-memory loading line from `bmad-dev-auto`
- delete the explicit host-memory loading line from `bmad-quick-dev`

## Testing
- `npm ci && npm run quality`
- commit hooks re-ran the repo test suite on amend

Closes #2518