### PR TITLE
docs: retitle autonomous development loop reference

### DIFF
--- a/docs/reference/dev-auto.md
+++ b/docs/reference/dev-auto.md
@@ -1,11 +1,11 @@
 ---
-title: Dev Auto Integration
-description: Orchestrator-facing contract for bmad-dev-auto inputs, outputs, runtime requirements, and terminal states.
+title: Autonomous Development Loops
+description: Reference for running unattended BMad development loops with bmad-dev-auto as the single-iteration worker.
 sidebar:
   order: 7
 ---
 
-`bmad-dev-auto` is like [Quick Dev](../explanation/quick-dev.md), but designed to keep moving without human interaction. You can use it in an interactive session, but its main purpose is to be used in unattended development loops.
+To use BMad in an autonomous development loop, use the `bmad-dev-auto` skill. It is like [Quick Dev](../explanation/quick-dev.md), but designed to keep moving without human interaction. You can use it in an interactive session, but its main purpose is to be used by an orchestrator.
 
 ## What It Does
 

--- a/docs/reference/workflow-map.md
+++ b/docs/reference/workflow-map.md
@@ -95,7 +95,7 @@ Skip phases 1-3 for small, well-understood work.
 | `bmad-quick-dev` | Unified quick flow — clarify intent, plan, implement, review, and present | `spec-*.md` + code |
 | `bmad-dev-auto`  | Runs one unattended development-loop iteration — small intent in, code out | `spec-*.md` + code |
 
-For the orchestrator-facing contract for `bmad-dev-auto`, see [Dev Auto Integration](./dev-auto.md).
+For the reference on unattended development loops with `bmad-dev-auto`, see [Autonomous Development Loops](./dev-auto.md).
 
 ## Context Management
 


### PR DESCRIPTION
## What
Retitles the Dev Auto integration reference to Autonomous Development Loops and updates the workflow map link text.

## Why
The page describes the broader autonomous loop pattern, with `bmad-dev-auto` as the current single-iteration worker.

## How
- Updated the reference page title and description
- Reframed the opening sentence around autonomous development loops
- Updated the workflow map link label

## Testing
Ran `npm ci && npm run quality` successfully.