### PR TITLE
feat(dev-auto): record final_revision in spec frontmatter at exit

### DIFF
--- a/docs/reference/dev-auto.md
+++ b/docs/reference/dev-auto.md
@@ -89,6 +89,7 @@ On successful completion, the workflow writes or updates the spec with:
   - Verification performed
   - Residual risks
 - `followup_review_recommended` flag. True if LLM decided another review pass seems worthwhile. It's a suggestion, not a must. Simplest way to give it a second review pass is to re-run the skill pointing it at the spec file.
+- `baseline_revision` and `final_revision` — HEAD before implementation and after the final commit. Together they bracket the run's commits: `git log baseline_revision..final_revision` lists exactly what it produced, and equal values mean no commits were made. Both are `NO_VCS` when version control is unavailable.
 
 If version control is available, the workflow commits the change. It does not push.
 
@@ -153,6 +154,7 @@ An orchestrator integrating `bmad-dev-auto` should:
 - Prefer passing a spec path when resuming prior work
 - Monitor the produced spec file or fallback result file for terminal state
 - Read `status`, `blocking condition`, and `followup_review_recommended` rather than inferring success from chat output alone
+- Use `baseline_revision..final_revision` to identify the commits the run produced, rather than inferring them from git state
 - Expect autonomous file changes and possibly a local commit
 - Handle `blocked` as a routing signal, not just a failure signal
 

--- a/src/bmm-skills/4-implementation/bmad-dev-auto/step-04-review.md
+++ b/src/bmm-skills/4-implementation/bmad-dev-auto/step-04-review.md
@@ -85,4 +85,6 @@ Set `{spec_file}` frontmatter `followup_review_recommended` from the judgment ab
 
 If version control is available, commit. Do not push.
 
+Capture `final_revision` (current HEAD after committing, or `NO_VCS` if version control is unavailable) into `{spec_file}` frontmatter.
+
 HALT with status `done`.


### PR DESCRIPTION
## What

At the dev-auto exit step, capture the post-commit HEAD as `final_revision` in the spec frontmatter, alongside the existing `baseline_revision`.

## Why

The implementation-artifacts directory is gitignored, so the spec frontmatter is the only link from the out-of-tree spec to the in-tree commits. The orchestrator that runs immediately after a dev-auto session needs to know what the session produced.

A single endpoint is sufficient — no need to enumerate every commit:
- `baseline_revision..final_revision` is the session's commit range; `git log baseline..final` regenerates the commit list on demand.
- Equal values mean no commits were made.
- One SHA stays O(1) instead of a list that grows with the session (and in the common single-commit case, a list would just duplicate `final_revision`).

Degrades to `NO_VCS` when version control is unavailable, mirroring `baseline_revision`. Written only on the success path (alongside `Status: Done`), so block-presence already serves as the completion marker — no extra status field needed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
