### PR TITLE
chore(code-review): harden triage severity calibration

### DIFF
--- a/src/bmm-skills/4-implementation/bmad-code-review/steps/step-03-triage.md
+++ b/src/bmm-skills/4-implementation/bmad-code-review/steps/step-03-triage.md
@@ -6,7 +6,6 @@
 ## RULES
 
 - YOU MUST ALWAYS SPEAK OUTPUT in your Agent communication style with the config `{communication_language}`
-- Be precise. When uncertain between categories, prefer the more conservative classification.
 
 ## INSTRUCTIONS
 
@@ -29,13 +28,15 @@
    - Append any unique detail, reasoning, or location references from the other finding(s) into the surviving `detail` field.
    - Set `source` to the merged sources (e.g., `blind+edge`).
 
-3. **Assign severity** to each finding by consequence for the artifact's main consumer (software user, document reader, etc).
+3. **Read the code before rating.** Before assigning severity, open the source at each finding's location and read enough surrounding code to judge reachability -- call sites, guards, and validation that live outside the diff hunk. Do not rate from the diff hunk alone. Severity reflects the real consequence at a real call site, not the worst theoretical reading.
+
+4. **Assign severity** to each finding by consequence for the artifact's main consumer (software user, document reader, etc).
    Disregard any severity assigned by a reviewing subagent. Review subagents operate under by-design information asymmetry and do not have enough context to set final severity for this workflow.
    - `low` -- none or cosmetic
    - `medium` -- tolerable
    - `high` -- intolerable
 
-4. **Route** each finding into exactly one triage bucket:
+5. **Route** each finding into exactly one triage bucket:
    - **decision_needed** -- There is an ambiguous choice that requires human input. The code cannot be correctly patched without knowing the user's intent. Only possible if `{review_mode}` = `"full"`.
    - **patch** -- Code issue that is fixable without human input. The correct fix is unambiguous.
    - **defer** -- Pre-existing issue not caused by the current change. Real but not actionable now.
@@ -43,11 +44,11 @@
 
    If `{review_mode}` = `"no-spec"` and a finding would otherwise be `decision_needed`, reclassify it as `patch` (if the fix is unambiguous) or `defer` (if not).
 
-5. **Drop** all `dismiss` findings. Record the dismiss count for the summary.
+6. **Drop** all `dismiss` findings. Record the dismiss count for the summary.
 
-6. If `{failed_layers}` is non-empty, report which layers failed before announcing results. If zero findings remain after dropping dismissed AND `{failed_layers}` is non-empty, warn the user that the review may be incomplete rather than announcing a clean review.
+7. If `{failed_layers}` is non-empty, report which layers failed before announcing results. If zero findings remain after dropping dismissed AND `{failed_layers}` is non-empty, warn the user that the review may be incomplete rather than announcing a clean review.
 
-7. If zero findings remain after triage (all rejected or none raised): state "✅ Clean review — all layers passed." (Step 3 already warned if any review layers failed via `{failed_layers}`.)
+8. If zero findings remain after triage (all rejected or none raised): state "✅ Clean review — all layers passed." (Step 3 already warned if any review layers failed via `{failed_layers}`.)
 
 
 ## NEXT


### PR DESCRIPTION
## What

Hardens severity calibration in `bmad-code-review` step 3 (triage), where severity is now assigned.

In the standalone code-review skill the triage adjudicator sees only the diff plus the subagents' text — not the surrounding source. So it judges reachability blind to call sites and guards outside the hunk, and over-rates (e.g. `run_ui_2026-06-22` F7).

## Changes (single file: `steps/step-03-triage.md`)

- **Read the code before rating.** New step inserted between dedup and severity: open the source at each finding's location and read enough surrounding code (call sites, guards, validation outside the diff hunk) to judge reachability. Don't rate from the hunk alone — severity reflects real consequence at a real call site, not the worst theoretical reading.
- **Drop the conservative tie-breaker.** Removed "When uncertain between categories, prefer the more conservative classification." On a genuine toss-up the model is forced to pick; we don't bias the direction (which was inflating severity).
- **Remove the now-vacuous "Be precise." rule.** The steps already mandate one severity and exactly one bucket per finding.

Routing buckets and the severity-ownership wording (assign by consumer consequence; disregard subagent severity) are unchanged.

🤖 Generated with [Claude Code](https://claude.com/claude-code)