### PR TITLE
refactor(quick-dev): fold deletion audit into edge case hunter

### DIFF
--- a/docs/reference/core-tools.md
+++ b/docs/reference/core-tools.md
@@ -222,6 +222,8 @@ Spec Law enforces eight rules: capabilities carry both intent and success; inten
 
 **Output:** JSON array of findings, each with `location`, `trigger_condition`, `guard_snippet`, and `potential_consequence`
 
+**Deletion check (secondary):** When the diff removes meaningful code, the hunter also flags deletions that drop behavior or contracts without replacement, tagged `kind: deletion` in the same array.
+
 :::note[Complementary Reviews]
 Run both `bmad-review-adversarial-general` and `bmad-review-edge-case-hunter` together for orthogonal coverage. The adversarial review catches quality and completeness issues; the edge case hunter catches unhandled paths.
 :::

--- a/src/core-skills/bmad-review-edge-case-hunter/SKILL.md
+++ b/src/core-skills/bmad-review-edge-case-hunter/SKILL.md
@@ -9,6 +9,7 @@ description: 'Walk every branching path and boundary condition in content, repor
 When a diff is provided, scan only the diff hunks and list boundaries that are directly reachable from the changed lines and lack an explicit guard in the diff.
 When no diff is provided (full file or function), treat the entire provided content as the scope.
 Ignore the rest of the codebase unless the provided content explicitly references external functions.
+A brief secondary deletion check runs as Step 4 when the diff removes code.
 
 **Inputs:**
 - **content** — Content to review: diff, full file, or function
@@ -42,14 +43,18 @@ Ignore the rest of the codebase unless the provided content explicitly reference
 - Revisit every edge class from Step 2 — e.g., missing else/default, null/empty inputs, off-by-one loops, arithmetic overflow, implicit type coercion, race conditions, timeout gaps
 - Add any newly found unhandled paths to findings; discard confirmed-handled ones
 
-### Step 4: Present Findings
+### Step 4: Deletion Check
 
-Output findings as a JSON array following the Output Format specification exactly.
+If the diff removed or replaced meaningful code (ignore pure renames and whitespace): load `references/deletion-check.md` and follow it.
+
+### Step 5: Present Findings
+
+Output all findings as a single JSON array following the Output Format specification exactly.
 
 
 ## OUTPUT FORMAT
 
-Return ONLY a valid JSON array of objects. Each object must contain exactly these four fields and nothing else:
+Return ONLY a valid JSON array of objects. Each edge-case finding contains exactly these four fields:
 
 ```json
 [{
@@ -60,7 +65,7 @@ Return ONLY a valid JSON array of objects. Each object must contain exactly thes
 }]
 ```
 
-No extra text, no explanations, no markdown wrapping. An empty array `[]` is valid when no unhandled paths are found.
+No extra text, no explanations, no markdown wrapping. An empty array `[]` is valid when nothing is found. Deletion findings from Step 4, if any, go in the same array with the extra fields defined in `references/deletion-check.md`.
 
 
 ## HALT CONDITIONS

--- a/src/core-skills/bmad-review-edge-case-hunter/references/deletion-check.md
+++ b/src/core-skills/bmad-review-edge-case-hunter/references/deletion-check.md
@@ -1,0 +1,14 @@
+# Deletion Check
+
+Secondary pass for the Edge Case Hunter — runs only when the diff removed meaningful code. Subordinate to the edge-case pass; findings are usually few or none.
+
+For each chunk of removed or replaced code (ignore pure renames and whitespace), ask: did it carry behavior or a contract that the change neither re-established nor intentionally retired? Add a finding for any resulting regression, orphaned reference, or newly-dead code. Skip anything already covered by your edge-case findings.
+
+Append each finding to the same JSON array as the edge-case findings, with the four standard fields plus:
+
+- `kind`: `"deletion"`
+- `confidence`: `"high"`, `"medium"`, or `"low"` — these are inferences; rate them
+
+For a deletion finding the standard fields read as: `location` = the removed item; `trigger_condition` = the behavior or contract it enforced; `guard_snippet` = where or how to re-establish it; `potential_consequence` = the regression or orphan.
+
+Add nothing if nothing qualifies.


### PR DESCRIPTION
## What

Folds deletion auditing into the **Edge Case Hunter** instead of shipping it as a standalone review layer. When a reviewed diff removes or replaces meaningful code, the hunter runs a brief secondary deletion check on the diff it already holds and emits any deletion findings in the same JSON array, tagged `kind: deletion` with a `confidence`.

## Why

An earlier draft added a standalone `bmad-review-deletion-contract-auditor` layer. Measured on five sample commits, 4 of 5 returned no deletion findings while each paid the cold agent spin-up floor (~22–50k tokens). The hunter already receives the full diff, so a separate detection pass and a context-rebilling continuation turn bought nothing — self-gating inside the hunter's existing turn is cheaper and simpler, and removes the awkward no-subagent fallback divergence.

Deletions are rare and rarely load-bearing, so the check stays strictly secondary to the edge-case pass and is usually empty.

## How

- **Step 4 (Deletion Check)** in the hunter is a gated pointer: if the diff removed or replaced meaningful code (ignoring pure renames and whitespace), `load references/deletion-check.md and follow it`. The deletion method lives in that reference file and is paged into context only when there are deletions — the common path stays lean.
- Output format keeps the original four edge-case fields; deletion findings extend the same array with `kind` + `confidence`, defined in the reference.
- `step-04-review.md` (quick-dev) is unchanged — it invokes the hunter once and triages all findings through the existing categories.
- Docs: one-line note under the hunter in `core-tools.md`.

## Validation

Full `npm run quality` passes (format, lint, markdownlint, docs build, install tests, URL tests, file-ref + skill validators, sidebar order) — 0 errors. `validate:refs` confirms the new `references/deletion-check.md` resolves.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
