### PR TITLE
docs: update package description branding

### DIFF
--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
   "$schema": "https://json.schemastore.org/package.json",
   "name": "bmad-method",
   "version": "6.9.0",
-  "description": "Breakthrough Method of Agile AI-driven Development",
+  "description": "Build More Architect Dreams",
   "keywords": [
     "agile",
     "ai",


### PR DESCRIPTION
## What
Updated the root package description to use the current BMAD expansion: "Build More Architect Dreams".

## Why
The package metadata still used the previous wording, while the README and current docs use the updated branding. Fixes #2497.

## How
- Changed the `description` field in `package.json`.

## Testing
Ran `npm ci && npm run quality` successfully.
