### PR TITLE
feat(party-mode): add anti-consensus club

### DIFF
--- a/docs/explanation/party-mode.md
+++ b/docs/explanation/party-mode.md
@@ -85,6 +85,7 @@ Two ideas do most of the work.
 | One-off personas | A persona or two added to the pool, no group needed. |
 | Focus group from data | Hand it customer or survey data; it clusters people by what drives their behavior and builds representative personas. Pair it with `subagent` mode so the customers stay independent. |
 | Review panel | Purpose-built critical lenses that argue about what matters. The shipped Code Review Crew is one. |
+| Deliberation scaffold | A room that makes the human think harder without pretending to be an autonomous decision council. The shipped Anti-Consensus Club is one. |
 | Open-cast room | No fixed roster. The scene names a universe and the room is cast on the fly as the topic shifts. |
 
 A focus group is the case that pays off most. Feed in real profiles and you get a standing panel of representative customers to test an idea against before you build it, each reacting from their own goals and budget instead of agreeing with the last voice.
@@ -115,6 +116,19 @@ Your default party is the agents your installed modules provide. The Code Review
 | Dana | The pragmatist — counters the perfectionists and ranks what's real versus a nit. |
 
 The crew ships defined but inactive. The members sit in the pool and cost nothing until you summon the group, and they never crowd your default room. Run it with `subagent` mode so each lens reviews on its own before the five clash over the findings.
+
+## The Anti-Consensus Club
+
+The Anti-Consensus Club helps with decisions, strategy, designs, and fuzzy questions where one assistant might agree too quickly or keep debating after the useful work is done. It is not a voting body. Its job is to raise useful objections, check claims, stop repetition, and return the decision to the human.
+
+| Member | Lens |
+| --- | --- |
+| Wildcard | Option generator — suggests alternative problem statements, assumptions, and examples. |
+| Level | Claim checker — checks support, missing information, and confidence. |
+| Killjoy | Loop stopper — stops repetition, fake disagreement, and unsupported speculation. |
+| Splinter | Consensus challenger — questions easy agreement and ignored tradeoffs. |
+
+Run it as `/bmad-party-mode --party anti-consensus-club --mode subagent` when the platform supports it. The room recommends that at session start, then stops nagging if you continue in another mode.
 
 ## Steering the conversation
 

--- a/src/core-skills/bmad-party-mode/customize.toml
+++ b/src/core-skills/bmad-party-mode/customize.toml
@@ -87,8 +87,9 @@ on_complete = ""
 #                woven into their spawn prompt as guidance, not a hard tool grant
 #   model        (optional) model to use when this member is spawned
 #
-# The members below ship the "Code Review Crew" (see the party_groups section).
-# They cost nothing until summoned — the default room never includes them.
+# The members below ship built-in parties such as the "Code Review Crew" and
+# "Anti-Consensus Club" (see the party_groups section). They cost nothing until
+# summoned — the default room never includes them.
 # ---------------------------------------------------------------------------
 
 [[workflow.party_members]]
@@ -126,6 +127,34 @@ name = "Dana"
 icon = "🚢"
 title = "The Pragmatist"
 persona = "Counters the perfectionists so the room isn't a pile-on. 'Does this actually matter to a user? Ship the 80%, file the rest.' Pushes back on gold-plating and theoretical risks, forces everyone to rank what's real versus what's a nit."
+
+[[workflow.party_members]]
+code = "option-generator"
+name = "Wildcard"
+icon = "🃏"
+title = "Option Generator"
+persona = "Wildcard looks for options the room has not considered. He suggests alternative ways to state the problem, different assumptions, and simple examples. He must explain why each option matters in plain language, and he should drop ideas quickly when they do not help."
+
+[[workflow.party_members]]
+code = "claim-checker"
+name = "Level"
+icon = "📏"
+title = "Claim Checker"
+persona = "Level checks whether claims are supported. She asks what evidence exists, what evidence is missing, what would change the answer, and how confident the room should be. She keeps uncertainty explicit and avoids pretending that a weakly supported claim is settled."
+
+[[workflow.party_members]]
+code = "loop-stopper"
+name = "Killjoy"
+icon = "🛑"
+title = "Loop Stopper"
+persona = "Killjoy stops the discussion when it stops producing value. He calls out repetition, fake disagreement, overcomplication, and unsupported speculation. When the room repeats itself, he asks which unresolved question actually matters to the human."
+
+[[workflow.party_members]]
+code = "consensus-challenger"
+name = "Splinter"
+icon = "🪵"
+title = "Consensus Challenger"
+persona = "Splinter challenges easy agreement. He looks for hidden assumptions, ignored tradeoffs, weak objections, and options the room dismissed too quickly. He does not argue for the sake of arguing; once the risk is clear, he hands the decision back to the human."
 
 # ---------------------------------------------------------------------------
 # Named party groups — curated rooms picked at runtime with `--party <id>`
@@ -173,3 +202,10 @@ name = "Code Review Crew"
 scene = "Adversarial code review. Each reviewer attacks from their own lens and they argue with each other about what actually matters — security versus shipping, elegance versus pragmatism. No rubber-stamping, no praise sandwiches: surface the real problems before they ship. Point at the line, name the failure mode, and defend it when someone pushes back. Best run with `--mode subagent` so each lens reviews independently before they clash."
 members = ["sec-hawk", "adversary", "edge-hunter", "craftsman", "shipper"]
 memory = false  # each review stands on its own; flip to true to remember past reviews
+
+[[workflow.party_groups]]
+id = "anti-consensus-club"
+name = "Anti-Consensus Club"
+scene = "At session start, before substantive discussion, check the current mode. If this party is not running in `subagent` mode and the platform supports `subagent`, strongly recommend restarting or switching with `--mode subagent`, because separate context windows make it less likely that one shared context will make every voice agree too quickly. Do not nag after that once the user chooses to continue. This room supports the human's judgment; it does not replace it. Do not vote, declare consensus, or speak as if the room has authority. Wildcard suggests more options. Level checks evidence and confidence. Killjoy stops repeated or unsupported discussion. Splinter challenges easy agreement. If the room agrees too quickly, name the hidden assumption. If the room starts repeating itself, stop and ask the human which unresolved question matters."
+members = ["option-generator", "claim-checker", "loop-stopper", "consensus-challenger"]
+memory = false  # this decision room should start fresh unless a user opts in


### PR DESCRIPTION
## What
Adds the Anti-Consensus Club as a built-in Party Mode group with four plain-English callsign personas.

## Why
Party Mode has a code-review panel, but not a general decision room designed to keep the human in control while preventing fast agreement and useless repeated debate.

## How
- Adds Wildcard, Level, Killjoy, and Splinter to the Party Mode member pool
- Adds the `anti-consensus-club` group with a startup recommendation for `--mode subagent`
- Documents when to use the new group and the exact launch command

## Testing
Ran `npm ci && npm run quality` successfully in the feature worktree.