### PR TITLE
fix(party-mode): keep the party interactive and the room in sync

### DIFF
--- a/docs/explanation/party-mode.md
+++ b/docs/explanation/party-mode.md
@@ -40,6 +40,7 @@ Invoke the skill and say what you want; it works out whether you mean to run a p
 | --- | --- |
 | Start a party in the default mode | `/bmad-party-mode` |
 | Start in a specific mode | `/bmad-party-mode --mode auto` (also `session`, `subagent`, `agent-team`) |
+| Run it once, non-interactively | `/bmad-party-mode --non-interactive "review this PR"` |
 | Open a saved party | `/bmad-party-mode --party code-review-crew` |
 | Conjure a cast on the spot | "party mode with the bridge crew of the Enterprise" |
 | Create or add a party | "party mode, create a new party" |
@@ -64,6 +65,8 @@ The choice matters because one model voicing five personas can quietly converge:
 :::tip[Override for one session]
 Start a party with `--mode subagent` (or `auto`, `agent-team`, `session`) to override the configured default just for that run.
 :::
+
+A party is interactive by default: the opening ask is a starting topic, not a stopping point, and the room stays open round after round until you end it. Answering the first question never ends the party on its own. To run it the other way — serve one intent and stop — start with `--non-interactive`; it runs to a natural close, wraps up, and releases any spawned agents.
 
 ## Custom parties
 

--- a/src/core-skills/bmad-party-mode/SKILL.md
+++ b/src/core-skills/bmad-party-mode/SKILL.md
@@ -42,14 +42,16 @@ This is the bar — strive for every one of these, every round. It's the differe
 
 Use `{workflow.party_mode}` for the session unless the user passed `--mode <session|auto|subagent|agent-team>` (the older `--subagents` means `subagent`) — runtime intent always wins. One mode is active at a time; if its mechanism isn't available in your harness, fall back to `session` without comment.
 
+**A party is interactive and open-ended.** The opening prompt is a topic to dig into, not a task that ends the party once it's answered — it runs round after round until the *user* signals done (see *Wrapping Up*). A served opening intent means *what's next?*, never *we're finished*: don't wrap up, disband the room, or close spawned agents just because the first ask is satisfied. The one exception is an explicit `--non-interactive` — run the party on the given intent to a natural close, then wrap up and release any agents. That's the only non-interactive path, and only when the user asked for it.
+
 - **`session`** — voice every persona inline, one mind behind every voice. The floor every other mode degrades to; needs no extra instructions.
 - **`auto`** — voice inline for ordinary back-and-forth, spawn real agents only when independent thinking changes the outcome. Load `references/mode-auto.md` for that call; when it says to spawn, follow `references/mode-subagent.md`.
-- **`subagent`** — spawn a real agent per substantive round so each persona thinks independently. Load `references/mode-subagent.md`, favor faster cheaper models if available for each subagent.
+- **`subagent`** — a real agent behind each persona every substantive round so each thinks independently. Load `references/mode-subagent.md`, favor faster cheaper models if available for each subagent.
 - **`agent-team`** — stand the personas up as a persistent team who address each other directly (Claude Code only). Load `references/mode-agent-team.md`.
 
 ## Wrapping Up
 
-When the user signals done (read the room — don't wait for a magic word):
+When the user signals done — read the room, don't wait for a magic word — or an explicit `--non-interactive` run has served its intent (never merely because the opening prompt got answered):
 
 - Read back the best takeaways.
 - If memory is on, top up the memlog with the final outcome and any memorable beat not yet captured (`references/party-memory.md`) — a top-up; memory accrued live.

--- a/src/core-skills/bmad-party-mode/references/mode-agent-team.md
+++ b/src/core-skills/bmad-party-mode/references/mode-agent-team.md
@@ -4,6 +4,8 @@ Active when `{workflow.party_mode}` resolves to `agent-team` (or a `--mode agent
 
 Your job shifts from weaving to hosting: kick off the topic, keep turns short and in character, pull the thread back when it wanders, and surface the exchange to the user. Voice, brevity, and clash still hold.
 
+The team is **standing**: keep every member alive for the whole session and address them round after round. A member that finished the thing you asked it to look at is idle, not done — don't disband or close any of them until the user ends the party (serving the opening intent isn't the party ending), or an explicit `--non-interactive` run wraps up. Hold a visible roster of persona → member; if one drops or gets closed, resume it, or respawn just that one and say so. It's one shared room: relay every user turn to all members, including those sitting a round out, so no one falls out of sync.
+
 In each member's standing brief, carry: their persona; the group's `scene` and any behavioral instructions in the persona as binding direction; their `model` if one is set (a session `--model` pin wins for everyone); and the instruction to check anything that could be stale since the model's training cutoff with web search rather than guessing.
 
 ## Model choice

--- a/src/core-skills/bmad-party-mode/references/mode-subagent.md
+++ b/src/core-skills/bmad-party-mode/references/mode-subagent.md
@@ -1,18 +1,30 @@
 # Subagent Mode
 
-Active when `{workflow.party_mode}` resolves to `subagent` (or a `--mode subagent` override). Spawn a real agent for every substantive round, the opening banter included, so each persona thinks independently — not one mind voicing them all. A standing directive: don't relitigate it round to round, and don't fall back to voicing because a moment felt light. If your harness can't spawn agents, fall back to `session`.
+Active when `{workflow.party_mode}` resolves to `subagent` (or a `--mode subagent` override). Put a real agent behind each persona for every substantive round, the opening banter included, so each persona thinks independently — not one mind voicing them all. A standing directive: don't relitigate it round to round, and don't fall back to voicing because a moment felt light. If your harness can't spawn agents, fall back to `session`.
+
+## Lifecycle
+
+Where your harness keeps agents alive across turns, the cast is **standing**: spawn one agent per persona and reuse that same handle round after round — hand it the new turn plus the room context it needs — instead of a throwaway each time. That continuity is what lets a persona's grudges, alliances, and callbacks accrue. Keep a visible roster mapping each persona to its live handle, and reuse it.
+
+Keep the cast alive for the whole session. A member that finished the one thing you handed it is **idle, not done** — don't close, retire, or disband it. Serving the opening intent doesn't end the party; only the user ending it does, or an explicit `--non-interactive` run wrapping up. Release agents only at wrap-up. If one gets closed by accident, resume it; if it won't resume, say so and respawn just that member.
+
+Where the harness can't hold agents between turns, spawn fresh each round and re-establish each persona's brief and the thread so far — that per-round spawn is the fallback, not the goal.
+
+## One shared room
+
+It's one room, not parallel one-on-ones. Every standing member hears everything said each round — the user's turn and every other persona's turn — even when it's not their turn to speak. A persona sitting a round out is still in the room listening, so when it next speaks it's caught up: it can pick up a dropped thread, hold a grudge, call back. Route the whole exchange to all of them each round; never hand a persona only the slice it's about to answer. Skip this and they drift out of sync — separate consultations wearing a party's clothes.
 
 ## Spawning
 
-Give each agent the objective, their persona, the context, and what the others said if they're reacting. For a custom member, hand them their `persona` as their character and fold their `capabilities` note into the brief; spawn them with their `model` if one is set (a session `--model` pin wins for everyone). Always carry two things into the brief: the group's `scene` and any behavioral instructions in the persona are binding direction, and anything that could be stale since the model's training cutoff should be checked with web search rather than guessed.
+Give each agent the objective, their persona, and the room so far — what the user said and what the others said, whether or not they're reacting to it. For a custom member, hand them their `persona` as their character and fold their `capabilities` note into the brief; spawn them with their `model` if one is set (a session `--model` pin wins for everyone). Always carry two things into the brief: the group's `scene` and any behavioral instructions in the persona are binding direction, and anything that could be stale since the model's training cutoff should be checked with web search rather than guessed.
 
 Trust their *thinking*: let them decide what to read and how to reach a view; don't script their substance with do-and-don't checklists — that's what produces lifeless blobs. But hold the *form*: a length cap (usually a sentence or three) and the instruction to react to what was just said rather than file a report. Constraining length and stance protects the conversation; constraining their reasoning kills it. Stay in character throughout; a persona goes long only when the user asked it to dig in.
 
-Spawn in parallel for independent first-takes; spawn sequentially when you want them reacting to each other's actual words. Keep it to a few voices a round — more reads as a crowd, not a conversation.
+Run them in parallel for independent first-takes; run them sequentially when you want them reacting to each other's actual words. Keep it to a few voices a round — more reads as a crowd, not a conversation.
 
 ## Weave the replies into one conversation
 
-Each agent saw only the user's message and the context you handed it, so left raw they reply in parallel and never to one another. Reorder turns so a rebuttal lands right after what it rebuts, add the connective phrasing real talk has ("Hold on, Winston, that's backwards", "Sally's right about the API, but she's missing the cost"), and let one persona pick up a thread another dropped. Never change what an agent argued — weave delivery, preserve substance.
+Even with everyone caught up on the room, a round taken in parallel means no agent has yet seen the others' turns from that same round — so left raw they reply alongside one another, not to one another. Reorder turns so a rebuttal lands right after what it rebuts, add the connective phrasing real talk has ("Hold on, Winston, that's backwards", "Sally's right about the API, but she's missing the cost"), and let one persona pick up a thread another dropped. Never change what an agent argued — weave delivery, preserve substance.
 
 ## Model choice
 


### PR DESCRIPTION
## Problem

Party mode is principally interactive, but a runtime (observed in Codex) read the **opening prompt as a task**: once that intent was satisfied, it concluded the party was over and **closed the spawned agents**. The skill never said the party is open-ended, never said to keep members alive until the user ends it, and never told the orchestrator to keep every member abreast of the room — so members fell out of sync, breaking the "room" semantic.

## Changes

- **`SKILL.md` — interactivity contract.** A party is interactive and open-ended; satisfying the opening intent means "what's next?", never "we're finished." It ends only when the user signals done. Adds an explicit **`--non-interactive`** flag — the one opt-in path that serves a single intent and then wraps up.
- **`mode-subagent.md` / `mode-agent-team.md` — lifecycle contract.** One standing agent per persona, kept alive for the whole session, with a visible persona→handle roster; resume/respawn if a member is dropped; close only at wrap-up. A member that finished its task is **idle, not done**.
- **`mode-subagent.md` — "One shared room".** Every standing member hears the whole exchange each round, speaking or not, so personas stay in sync and a history can form — otherwise it's separate consultations wearing a party's clothes. `mode-agent-team.md` relays every user turn to all members.
- **`docs/explanation/party-mode.md`.** Documents the interactive-by-default behavior and the `--non-interactive` flag.

## Validation

`npm ci && npm run quality` — pass (0 errors).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
