### PR TITLE
feat(installer): deprecate automator, add bmad-auto marketplace module

### DIFF
--- a/bmad-modules.yaml
+++ b/bmad-modules.yaml
@@ -7,6 +7,19 @@
 # default_channel (optional) — the install channel when the user does not
 # override with --channel/--pin/--next. Valid values: stable | next.
 # Omit to inherit the installer's hardcoded default (stable).
+#
+# deprecated (optional, default false) — when true, the module is hidden from
+# the installer picker UNLESS it is already installed (so existing users can
+# still see/manage it, but new users are not offered it).
+# deprecation-message (optional) — surfaced in the picker hint for a deprecated
+# module that is still installed; use it to point users to the replacement.
+#
+# marketplace-plugin (optional, default false) — when true, the module's
+# installable skills are resolved from its .claude-plugin/marketplace.json via
+# the plugin resolver (instead of copying the single module-definition dir).
+# Use this for modules whose module.yaml does not sit alongside the skill
+# folders. module-definition should still point at the real module.yaml so
+# config/version lookups work.
 
 modules:
   bmad-method-test-architecture-enterprise:
@@ -41,6 +54,21 @@ modules:
     type: experimental
     npmPackage: bmad-story-automator
     default_channel: next
+    deprecated: true
+    deprecation-message: "BMad Automator has been deprecated and is replaced by BMad Auto (bmad-auto). Install BMad Auto instead."
+
+  bmad-auto:
+    url: https://github.com/bmad-code-org/bmad-auto
+    module-definition: src/automator/data/skills/bmad-auto-setup/assets/module.yaml
+    code: bauto
+    name: "BMad Auto"
+    description: "Automation-mode skills driven by the bmad-auto orchestrator: unattended dev, adversarial review, and deferred-work sweep triage"
+    defaultSelected: false
+    type: bmad-org
+    default_channel: stable
+    # Skills live outside a single module.yaml dir; resolve them from
+    # .claude-plugin/marketplace.json via the plugin resolver (see external-manager).
+    marketplace-plugin: true
 
   bmad-creative-intelligence-suite:
     url: https://github.com/bmad-code-org/bmad-module-creative-intelligence-suite

--- a/bmad-modules.yaml
+++ b/bmad-modules.yaml
@@ -20,6 +20,12 @@
 # Use this for modules whose module.yaml does not sit alongside the skill
 # folders. module-definition should still point at the real module.yaml so
 # config/version lookups work.
+#
+# post-install-message (optional) — an "action needed" notice shown to the user
+# after install completes, once for each install run that includes the module.
+# Interactive installs require the user to acknowledge it (press Enter);
+# non-interactive (--yes) installs print it and continue. Use for required
+# follow-up steps (e.g. "run the X setup skill").
 
 modules:
   bmad-method-test-architecture-enterprise:
@@ -69,6 +75,14 @@ modules:
     # Skills live outside a single module.yaml dir; resolve them from
     # .claude-plugin/marketplace.json via the plugin resolver (see external-manager).
     marketplace-plugin: true
+    post-install-message: |
+      BMad Auto installed. To finish setup, run the bmad-auto-setup skill
+      from your agent:
+
+        > use the bmad-auto-setup skill
+
+      It installs the bmad-auto orchestrator tool and wires up the per-project
+      hooks and policy. The automation skills don't run until setup completes.
 
   bmad-creative-intelligence-suite:
     url: https://github.com/bmad-code-org/bmad-module-creative-intelligence-suite

--- a/tools/installer/core/installer.js
+++ b/tools/installer/core/installer.js
@@ -112,6 +112,11 @@ class Installer {
         preInstallVersions,
       });
 
+      // Surface any "action needed" post-install messages for installed modules
+      // (e.g. run a setup skill). Shown after the summary so they're the last
+      // thing the user sees; interactive installs must acknowledge each one.
+      await this._displayPostInstallMessages(config, officialModules);
+
       return {
         success: true,
         path: paths.bmadDir,
@@ -1244,6 +1249,56 @@ class Installer {
       rounded: true,
       formatBorder: color.green,
     });
+  }
+
+  /**
+   * Display registry-defined post-install messages for the modules installed in
+   * this run. These are "action needed" notices (e.g. "run the bmad-auto-setup
+   * skill") that the user must see to finish setup. They are defined via the
+   * `post-install-message` property on a module's bmad-modules.yaml entry.
+   *
+   * Interactive installs require the user to acknowledge each message (press
+   * Enter); non-interactive (--yes / skipPrompts) installs print the message
+   * and continue without blocking, so CI/scripted installs don't hang.
+   *
+   * @param {Object} config - Install config (config.modules, config.skipPrompts)
+   * @param {Object} officialModules - OfficialModules instance (carries the registry)
+   */
+  async _displayPostInstallMessages(config, officialModules) {
+    const moduleCodes = config.modules || [];
+    if (moduleCodes.length === 0) return;
+
+    const externalManager = officialModules.externalModuleManager;
+    if (!externalManager) return;
+
+    const color = await prompts.getColor();
+
+    for (const code of moduleCodes) {
+      let moduleInfo;
+      try {
+        moduleInfo = await externalManager.getModuleByCode(code);
+      } catch {
+        continue; // Built-in modules (core/bmm) aren't in the registry — skip.
+      }
+
+      const message = moduleInfo && moduleInfo.postInstallMessage;
+      if (!message) continue;
+
+      await prompts.box(String(message).trim(), `⚑ Action needed — ${moduleInfo.name || code}`, {
+        rounded: true,
+        formatBorder: color.yellow,
+      });
+
+      // Interactive: require the user to acknowledge before continuing. Skip the
+      // blocking prompt in non-interactive installs (the message is still shown).
+      if (!config.skipPrompts) {
+        await prompts.text({
+          message: 'Press Enter to acknowledge',
+          placeholder: '',
+          default: '',
+        });
+      }
+    }
   }
 
   /**

--- a/tools/installer/core/installer.js
+++ b/tools/installer/core/installer.js
@@ -102,6 +102,11 @@ class Installer {
 
       const restoreResult = await this._restoreUserFiles(paths, updateState);
 
+      // Surface any "action needed" post-install messages for installed modules
+      // (e.g. run a setup skill) and let the user acknowledge them before the
+      // final summary, so "BMAD is ready to use!" stays the last thing shown.
+      await this._displayPostInstallMessages(config, officialModules);
+
       // Render consolidated summary
       await this.renderInstallSummary(results, {
         bmadDir: paths.bmadDir,
@@ -111,11 +116,6 @@ class Installer {
         modifiedFiles: restoreResult.modifiedFiles.length > 0 ? restoreResult.modifiedFiles : undefined,
         preInstallVersions,
       });
-
-      // Surface any "action needed" post-install messages for installed modules
-      // (e.g. run a setup skill). Shown after the summary so they're the last
-      // thing the user sees; interactive installs must acknowledge each one.
-      await this._displayPostInstallMessages(config, officialModules);
 
       return {
         success: true,

--- a/tools/installer/modules/external-manager.js
+++ b/tools/installer/modules/external-manager.js
@@ -62,6 +62,13 @@ class ExternalModuleManager {
   // ExternalModuleManager) sees resolutions made during install.
   static _resolutions = new Map();
 
+  // moduleCode → ResolvedModule (from PluginResolver). Populated for registry
+  // modules flagged `marketplace-plugin: true`, whose installable skills live
+  // outside a single module.yaml directory and must be resolved from
+  // .claude-plugin/marketplace.json. Shared across instances so install() can
+  // pick up the resolution computed during findExternalModuleSource.
+  static _pluginResolutions = new Map();
+
   constructor() {}
 
   /**
@@ -71,6 +78,15 @@ class ExternalModuleManager {
    */
   getResolution(moduleCode) {
     return ExternalModuleManager._resolutions.get(moduleCode) || null;
+  }
+
+  /**
+   * Get the cached marketplace-plugin resolution for a module (if any).
+   * @param {string} moduleCode
+   * @returns {Object|null} ResolvedModule from PluginResolver, or null
+   */
+  getPluginResolution(moduleCode) {
+    return ExternalModuleManager._pluginResolutions.get(moduleCode) || null;
   }
 
   /**
@@ -113,6 +129,9 @@ class ExternalModuleManager {
       npmPackage: mod.npm_package || mod.npmPackage || null,
       pluginName: mod.plugin_name || mod.pluginName || null,
       defaultChannel: normalizeChannelName(mod.default_channel || mod.defaultChannel) || 'stable',
+      deprecated: mod.deprecated === true,
+      deprecationMessage: mod.deprecation_message || mod['deprecation-message'] || mod.deprecationMessage || null,
+      marketplacePlugin: mod.marketplace_plugin === true || mod['marketplace-plugin'] === true || mod.marketplacePlugin === true,
       builtIn: mod.built_in === true,
       isExternal: mod.built_in !== true,
     };
@@ -468,6 +487,19 @@ class ExternalModuleManager {
       return null;
     }
 
+    // Marketplace-plugin modules (registry entries flagged `marketplace-plugin`)
+    // ship a .claude-plugin/marketplace.json and keep their module.yaml inside a
+    // skill's assets/ rather than in one directory alongside the skills. Resolve
+    // them through the PluginResolver (the same machinery custom-URL installs
+    // use) and return the directory that holds module.yaml so config/version/
+    // directory callers work; install() copies the resolved skill dirs.
+    if (moduleInfo.marketplacePlugin) {
+      const pluginMod = await this.resolvePluginModule(moduleCode, options);
+      if (pluginMod && pluginMod.moduleYamlPath) {
+        return path.dirname(pluginMod.moduleYamlPath);
+      }
+    }
+
     // Clone the external module repo
     const cloneDir = await this.cloneExternalModule(moduleCode, options);
 
@@ -520,6 +552,84 @@ class ExternalModuleManager {
         `Expected '${moduleDefinitionPath}' to exist in ${versionHint}, but it is missing. ` +
         `The repository may have been restructured after this release was tagged.${channelHint}`,
     );
+  }
+
+  /**
+   * Resolve a marketplace-plugin registry module to an installable plugin
+   * definition. Clones the repo (respecting the channel plan), reads its
+   * .claude-plugin/marketplace.json, and runs the PluginResolver against the
+   * plugin matching this module. The result (skillPaths + module.yaml +
+   * module-help.csv) is cached so install() can copy the resolved skill dirs.
+   *
+   * @param {string} moduleCode - Code of the external module
+   * @param {Object} options - Options passed to cloneExternalModule
+   * @returns {Promise<Object|null>} ResolvedModule from PluginResolver, or null
+   *   when the module is not a marketplace plugin or cannot be resolved.
+   */
+  async resolvePluginModule(moduleCode, options = {}) {
+    const moduleInfo = await this.getModuleByCode(moduleCode);
+    if (!moduleInfo || moduleInfo.builtIn || !moduleInfo.marketplacePlugin) {
+      return null;
+    }
+
+    const cloneDir = await this.cloneExternalModule(moduleCode, options);
+
+    const marketplacePath = path.join(cloneDir, '.claude-plugin', 'marketplace.json');
+    if (!(await fs.pathExists(marketplacePath))) {
+      return null;
+    }
+
+    let marketplace;
+    try {
+      marketplace = JSON.parse(await fs.readFile(marketplacePath, 'utf8'));
+    } catch {
+      return null;
+    }
+
+    const plugins = Array.isArray(marketplace.plugins) ? marketplace.plugins : [];
+    if (plugins.length === 0) {
+      return null;
+    }
+
+    // Prefer the plugin whose name matches the registry's plugin_name (or code),
+    // falling back to any plugin that declares skills.
+    const preferredName = moduleInfo.pluginName || moduleInfo.code;
+    const ordered = [...plugins].sort((a, b) => {
+      const am = a?.name === preferredName ? 0 : 1;
+      const bm = b?.name === preferredName ? 0 : 1;
+      return am - bm;
+    });
+
+    const { PluginResolver } = require('./plugin-resolver');
+    const resolver = new PluginResolver();
+
+    for (const plugin of ordered) {
+      if (!plugin || !Array.isArray(plugin.skills) || plugin.skills.length === 0) {
+        continue;
+      }
+      let resolvedMods;
+      try {
+        resolvedMods = await resolver.resolve(cloneDir, plugin);
+      } catch {
+        continue;
+      }
+      if (!resolvedMods || resolvedMods.length === 0) {
+        continue;
+      }
+      // Match the registry code, then the preferred plugin name, then accept a
+      // lone resolved module.
+      const match =
+        resolvedMods.find((mod) => mod.code === moduleCode) ||
+        resolvedMods.find((mod) => mod.code === preferredName) ||
+        (resolvedMods.length === 1 ? resolvedMods[0] : null);
+      if (match) {
+        match.repoUrl = moduleInfo.url;
+        ExternalModuleManager._pluginResolutions.set(moduleCode, match);
+        return match;
+      }
+    }
+
+    return null;
   }
   cachedModules = null;
 }

--- a/tools/installer/modules/external-manager.js
+++ b/tools/installer/modules/external-manager.js
@@ -132,6 +132,7 @@ class ExternalModuleManager {
       deprecated: mod.deprecated === true,
       deprecationMessage: mod.deprecation_message || mod['deprecation-message'] || mod.deprecationMessage || null,
       marketplacePlugin: mod.marketplace_plugin === true || mod['marketplace-plugin'] === true || mod.marketplacePlugin === true,
+      postInstallMessage: mod.post_install_message || mod['post-install-message'] || mod.postInstallMessage || null,
       builtIn: mod.built_in === true,
       isExternal: mod.built_in !== true,
     };

--- a/tools/installer/modules/official-modules.js
+++ b/tools/installer/modules/official-modules.js
@@ -279,22 +279,24 @@ class OfficialModules {
 
     // Marketplace-plugin registry modules keep their installable skills outside
     // the directory that holds module.yaml (sourcePath points at the -setup
-    // skill's assets/). Copy each resolved skill directory and place
-    // module-help.csv at the module root, matching how custom marketplace
+    // skill's assets/), so they cannot be installed by copying sourcePath. Copy
+    // the resolved skill directories instead, matching how custom marketplace
     // installs lay out a module. Everything else (manifest, version info) flows
     // through the standard external-module path below.
-    const pluginResolution = this.externalModuleManager.getPluginResolution(moduleName);
-    if (pluginResolution && Array.isArray(pluginResolution.skillPaths) && pluginResolution.skillPaths.length > 0) {
-      await fs.ensureDir(targetPath);
-      for (const skillPath of pluginResolution.skillPaths) {
-        const skillTarget = path.join(targetPath, path.basename(skillPath));
-        await this.copyModuleWithFiltering(skillPath, skillTarget, fileTrackingCallback, options.moduleConfig);
+    const moduleInfo = await this.externalModuleManager.getModuleByCode(moduleName);
+    if (moduleInfo && moduleInfo.marketplacePlugin) {
+      const pluginResolution = this.externalModuleManager.getPluginResolution(moduleName);
+      // Fail loud: copying sourcePath here would install only the -setup skill's
+      // assets/ (module.yaml + module-help.csv) and none of the skills — a
+      // silent, broken partial install. Abort instead.
+      if (!pluginResolution || !Array.isArray(pluginResolution.skillPaths) || pluginResolution.skillPaths.length === 0) {
+        throw new Error(
+          `Module '${moduleName}' is registered as a marketplace plugin but its skills could not be resolved ` +
+            `from .claude-plugin/marketplace.json (missing or malformed on the selected channel). ` +
+            `Aborting to avoid a partial install with no skills.`,
+        );
       }
-      if (pluginResolution.moduleHelpCsvPath) {
-        const helpTarget = path.join(targetPath, 'module-help.csv');
-        await fs.copy(pluginResolution.moduleHelpCsvPath, helpTarget, { overwrite: true });
-        if (fileTrackingCallback) fileTrackingCallback(helpTarget);
-      }
+      await this._copyResolvedSkills(pluginResolution, targetPath, fileTrackingCallback, options.moduleConfig);
     } else {
       await this.copyModuleWithFiltering(sourcePath, targetPath, fileTrackingCallback, options.moduleConfig);
     }
@@ -324,6 +326,51 @@ class OfficialModules {
   }
 
   /**
+   * Lay out a PluginResolver resolution on disk: copy each resolved skill
+   * directory (flattened by leaf name) into targetPath and place module-help.csv
+   * at the module root. Shared by both custom marketplace installs
+   * (installFromResolution) and official marketplace-plugin registry installs
+   * (install), so the two paths cannot drift.
+   * @param {Object} resolved - ResolvedModule from PluginResolver
+   * @param {string} targetPath - Destination module directory (e.g. bmadDir/<code>)
+   * @param {Function} fileTrackingCallback - Optional callback to track installed files
+   * @param {Object} moduleConfig - Module configuration passed to copy filtering
+   */
+  async _copyResolvedSkills(resolved, targetPath, fileTrackingCallback = null, moduleConfig = {}) {
+    await fs.ensureDir(targetPath);
+
+    // Copy each skill directory, flattened by leaf name. Leaf names must be
+    // unique — two skills that flatten to the same directory would silently
+    // overwrite each other, so fail loud instead.
+    const seenLeaves = new Map();
+    for (const skillPath of resolved.skillPaths) {
+      const skillDirName = path.basename(skillPath);
+      if (seenLeaves.has(skillDirName)) {
+        throw new Error(
+          `Cannot install module '${resolved.code}': skill directories '${seenLeaves.get(skillDirName)}' and ` +
+            `'${skillPath}' share the leaf name '${skillDirName}' and would overwrite each other. ` +
+            `Skill directory names must be unique.`,
+        );
+      }
+      seenLeaves.set(skillDirName, skillPath);
+      const skillTarget = path.join(targetPath, skillDirName);
+      await this.copyModuleWithFiltering(skillPath, skillTarget, fileTrackingCallback, moduleConfig);
+    }
+
+    // Place module-help.csv at the module root.
+    const helpTarget = path.join(targetPath, 'module-help.csv');
+    if (resolved.moduleHelpCsvPath) {
+      // Strategies 1-4: copy the existing file.
+      await fs.copy(resolved.moduleHelpCsvPath, helpTarget, { overwrite: true });
+      if (fileTrackingCallback) fileTrackingCallback(helpTarget);
+    } else if (resolved.synthesizedHelpCsv) {
+      // Strategy 5: write synthesized content.
+      await fs.writeFile(helpTarget, resolved.synthesizedHelpCsv, 'utf8');
+      if (fileTrackingCallback) fileTrackingCallback(helpTarget);
+    }
+  }
+
+  /**
    * Install a module from a PluginResolver resolution result.
    * Copies specific skill directories and places module-help.csv at the target root.
    * @param {Object} resolved - ResolvedModule from PluginResolver
@@ -338,27 +385,7 @@ class OfficialModules {
       await fs.remove(targetPath);
     }
 
-    await fs.ensureDir(targetPath);
-
-    // Copy each skill directory, flattened by leaf name
-    for (const skillPath of resolved.skillPaths) {
-      const skillDirName = path.basename(skillPath);
-      const skillTarget = path.join(targetPath, skillDirName);
-      await this.copyModuleWithFiltering(skillPath, skillTarget, fileTrackingCallback, options.moduleConfig);
-    }
-
-    // Place module-help.csv at the module root
-    if (resolved.moduleHelpCsvPath) {
-      // Strategies 1-4: copy the existing file
-      const helpTarget = path.join(targetPath, 'module-help.csv');
-      await fs.copy(resolved.moduleHelpCsvPath, helpTarget, { overwrite: true });
-      if (fileTrackingCallback) fileTrackingCallback(helpTarget);
-    } else if (resolved.synthesizedHelpCsv) {
-      // Strategy 5: write synthesized content
-      const helpTarget = path.join(targetPath, 'module-help.csv');
-      await fs.writeFile(helpTarget, resolved.synthesizedHelpCsv, 'utf8');
-      if (fileTrackingCallback) fileTrackingCallback(helpTarget);
-    }
+    await this._copyResolvedSkills(resolved, targetPath, fileTrackingCallback, options.moduleConfig);
 
     // Create directories declared in module.yaml (strategies 1-4 may have these)
     if (!options.skipModuleInstaller) {

--- a/tools/installer/modules/official-modules.js
+++ b/tools/installer/modules/official-modules.js
@@ -277,7 +277,27 @@ class OfficialModules {
       await fs.remove(targetPath);
     }
 
-    await this.copyModuleWithFiltering(sourcePath, targetPath, fileTrackingCallback, options.moduleConfig);
+    // Marketplace-plugin registry modules keep their installable skills outside
+    // the directory that holds module.yaml (sourcePath points at the -setup
+    // skill's assets/). Copy each resolved skill directory and place
+    // module-help.csv at the module root, matching how custom marketplace
+    // installs lay out a module. Everything else (manifest, version info) flows
+    // through the standard external-module path below.
+    const pluginResolution = this.externalModuleManager.getPluginResolution(moduleName);
+    if (pluginResolution && Array.isArray(pluginResolution.skillPaths) && pluginResolution.skillPaths.length > 0) {
+      await fs.ensureDir(targetPath);
+      for (const skillPath of pluginResolution.skillPaths) {
+        const skillTarget = path.join(targetPath, path.basename(skillPath));
+        await this.copyModuleWithFiltering(skillPath, skillTarget, fileTrackingCallback, options.moduleConfig);
+      }
+      if (pluginResolution.moduleHelpCsvPath) {
+        const helpTarget = path.join(targetPath, 'module-help.csv');
+        await fs.copy(pluginResolution.moduleHelpCsvPath, helpTarget, { overwrite: true });
+        if (fileTrackingCallback) fileTrackingCallback(helpTarget);
+      }
+    } else {
+      await this.copyModuleWithFiltering(sourcePath, targetPath, fileTrackingCallback, options.moduleConfig);
+    }
 
     if (!options.skipModuleInstaller) {
       await this.createModuleDirectories(moduleName, bmadDir, options);

--- a/tools/installer/ui.js
+++ b/tools/installer/ui.js
@@ -944,25 +944,32 @@ class UI {
       }
     }
 
-    // Add external registry modules (skip built-in duplicates)
-    const externalRegistryModules = registryModules.filter((mod) => !mod.builtIn && !builtInCodes.has(mod.code));
+    // Add external registry modules (skip built-in duplicates and deprecated
+    // modules that are not already installed — deprecated modules stay visible
+    // only so existing users can continue to manage them).
+    const externalRegistryModules = registryModules.filter(
+      (mod) => !mod.builtIn && !builtInCodes.has(mod.code) && (!mod.deprecated || installedModuleIds.has(mod.code)),
+    );
     let externalRegistryEntries = [];
     if (externalRegistryModules.length > 0) {
       const spinner = await prompts.spinner();
       spinner.start('Checking latest module versions...');
 
       externalRegistryEntries = await Promise.all(
-        externalRegistryModules.map(async (mod) => ({
-          code: mod.code,
-          entry: await buildModuleEntry(
+        externalRegistryModules.map(async (mod) => {
+          const entry = await buildModuleEntry(
             mod.code,
             mod.name,
             mod.description,
             mod.defaultSelected,
             mod.url || null,
             mod.defaultChannel || null,
-          ),
-        })),
+          );
+          if (mod.deprecated && mod.deprecationMessage) {
+            entry.hint = entry.hint ? `${entry.hint} — ${mod.deprecationMessage}` : mod.deprecationMessage;
+          }
+          return { code: mod.code, entry };
+        }),
       );
 
       spinner.stop('Checked latest module versions.');


### PR DESCRIPTION
## What

- **Deprecation support in the module registry.** New `deprecated` + `deprecation-message` properties in `bmad-modules.yaml`. A deprecated module is hidden from the installer picker **unless it is already installed** (so existing users can still manage it, but new users aren't offered it), and its `deprecation-message` is surfaced in the picker hint.
- **`bmad-automator` marked deprecated**, pointing users to its replacement, **BMad Auto**.
- **New `bmad-auto` official module** (`code: bauto`).

## Why bmad-auto needed installer changes

bmad-auto isn't structured like the old automator. It's a **marketplace/plugin** module:
- skills live under `src/automator/data/skills/`
- its `module.yaml` is inside the `bmad-auto-setup` skill's `assets/`
- it ships `.claude-plugin/marketplace.json` declaring plugin `bauto`

The registry's standard install path copies *the directory that holds `module.yaml`*, which can't install this layout, and it never consulted `marketplace.json` — only custom user-URL installs did.

So this adds an **opt-in** `marketplace-plugin: true` registry flag that routes such modules through the existing `PluginResolver` (the same machinery custom-URL installs use) to copy the resolved skill dirs + `module-help.csv`. Manifest/version handling is unchanged (`source: external`, real tag/channel/sha). Because it's gated behind the flag, existing modules (e.g. WDS, which also ships a `marketplace.json` but installs fine via `module-definition`) are unaffected.

## Changes

- `bmad-modules.yaml` — documented new properties; `bmad-automator` deprecated; added `bmad-auto` entry (`marketplace-plugin: true`, no `npmPackage` since it's a Python/uv tool, not on npm).
- `tools/installer/modules/external-manager.js` — normalize `deprecated` / `deprecation-message` / `marketplace-plugin`; new `resolvePluginModule()` + `getPluginResolution()`; `findExternalModuleSource()` routes flagged modules through plugin resolution.
- `tools/installer/modules/official-modules.js` — `install()` copies resolved skill dirs + `module-help.csv` for plugin modules; manifest logic unchanged.
- `tools/installer/ui.js` — hide deprecated modules from the picker unless installed; append deprecation message to the hint.

## Testing

- End-to-end install of `bauto` at resolved stable tag `v0.7.6` produces `bauto/{bmad-auto-setup, bmad-auto-resolve, bmad-auto-sweep}` + `module-help.csv`, with a correct manifest entry.
- Verified non-flagged modules return early (no clone, no behavior change).
- `npm run test:install` (379) and `npm run test:channels` (83) pass; lint + prettier clean. Full pre-commit suite passed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)