### PR TITLE
feat(review): add verification-gap reviewer as a third review layer

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -29,7 +29,8 @@
         "./src/core-skills/bmad-editorial-review-structure",
         "./src/core-skills/bmad-index-docs",
         "./src/core-skills/bmad-review-adversarial-general",
-        "./src/core-skills/bmad-review-edge-case-hunter"
+        "./src/core-skills/bmad-review-edge-case-hunter",
+        "./src/core-skills/bmad-review-verification-gap"
       ]
     },
     {

--- a/src/bmm-skills/4-implementation/bmad-code-review/steps/step-02-review.md
+++ b/src/bmm-skills/4-implementation/bmad-code-review/steps/step-02-review.md
@@ -13,7 +13,7 @@ failed_layers: '' # set at runtime: comma-separated list of layers that failed o
 
 1. If `{review_mode}` = `"no-spec"`, note to the user: "Acceptance Auditor skipped — no spec file provided."
 
-2. Launch Blind Hunter and Edge Case Hunter in parallel without prior conversation context. If `{review_mode}` = `"full"`, include the Acceptance Auditor in the same parallel launch. If subagents are not available, generate prompt files in `{implementation_artifacts}` for each applicable reviewer role and HALT. Ask the user to run each in a separate session (ideally a different LLM) and paste back the findings. When findings are pasted, resume from this point and proceed to step 3.
+2. Launch Blind Hunter, Edge Case Hunter, and Verification Gap Reviewer in parallel without prior conversation context. If `{review_mode}` = `"full"`, include the Acceptance Auditor in the same parallel launch. If subagents are not available, generate prompt files in `{implementation_artifacts}` for each applicable reviewer role and HALT. Ask the user to run each in a separate session (ideally a different LLM) and paste back the findings. When findings are pasted, resume from this point and proceed to step 3.
 
    - **Blind Hunter** — prompt:
      > Invoke the `bmad-review-adversarial-general` skill on this diff:
@@ -22,6 +22,11 @@ failed_layers: '' # set at runtime: comma-separated list of layers that failed o
 
    - **Edge Case Hunter** — prompt:
      > Invoke the `bmad-review-edge-case-hunter` skill on this diff:
+     >
+     > {diff_output}
+
+   - **Verification Gap Reviewer** — prompt:
+     > Invoke the `bmad-review-verification-gap` skill on this diff:
      >
      > {diff_output}
 

--- a/src/bmm-skills/4-implementation/bmad-code-review/steps/step-03-triage.md
+++ b/src/bmm-skills/4-implementation/bmad-code-review/steps/step-03-triage.md
@@ -9,16 +9,9 @@
 
 ## INSTRUCTIONS
 
-1. **Normalize** findings into a common format. Expected input formats:
-   - Adversarial (Blind Hunter): markdown list of descriptions
-   - Edge Case Hunter: JSON array with `location`, `trigger_condition`, `guard_snippet`, `potential_consequence` fields
-   - Acceptance Auditor: markdown list with title, AC/constraint reference, and evidence
-
-   If a layer's output does not match its expected format, attempt best-effort parsing. Note any parsing issues for the user.
-
-   Convert all to a unified list where each finding has:
+1. **Normalize** findings from all layers into a unified list where each finding has:
    - `id` -- sequential integer
-   - `source` -- `blind`, `edge`, `auditor`, or merged sources (e.g., `blind+edge`)
+   - `source` -- `blind`, `edge`, `vgap`, `auditor`, or merged sources (e.g., `blind+edge`)
    - `title` -- one-line summary
    - `detail` -- full description
    - `location` -- file and line reference (if available)

--- a/src/bmm-skills/4-implementation/bmad-dev-auto/step-04-review.md
+++ b/src/bmm-skills/4-implementation/bmad-dev-auto/step-04-review.md
@@ -22,7 +22,7 @@ Do NOT `git add` anything — this is read-only inspection.
 
 ### Review
 
-Launch Blind Hunter and Edge Case Hunter in parallel without prior conversation context.
+Launch Blind Hunter, Edge Case Hunter, and Verification Gap Reviewer in parallel without prior conversation context.
 
 - **Blind Hunter** — prompt:
   > Invoke the `bmad-review-adversarial-general` skill on this diff:
@@ -30,6 +30,10 @@ Launch Blind Hunter and Edge Case Hunter in parallel without prior conversation 
   > {diff_output}
 - **Edge Case Hunter** — prompt:
   > Invoke the `bmad-review-edge-case-hunter` skill on this diff:
+  >
+  > {diff_output}
+- **Verification Gap Reviewer** — prompt:
+  > Invoke the `bmad-review-verification-gap` skill on this diff:
   >
   > {diff_output}
 

--- a/src/bmm-skills/4-implementation/bmad-quick-dev/step-04-review.md
+++ b/src/bmm-skills/4-implementation/bmad-quick-dev/step-04-review.md
@@ -21,7 +21,7 @@ Do NOT `git add` anything — this is read-only inspection.
 
 ### Review
 
-Launch Blind Hunter and Edge Case Hunter in parallel without prior conversation context. If no subagents are available, generate two review prompt files in `{implementation_artifacts}` — one per reviewer role below — and HALT. Ask the human to run each in a separate session (ideally a different LLM) and paste back the findings.
+Launch Blind Hunter, Edge Case Hunter, and Verification Gap Reviewer in parallel without prior conversation context. If no subagents are available, generate three review prompt files in `{implementation_artifacts}` — one per reviewer role below — and HALT. Ask the human to run each in a separate session (ideally a different LLM) and paste back the findings.
 
 - **Blind Hunter** — prompt:
   > Invoke the `bmad-review-adversarial-general` skill on this diff:
@@ -29,6 +29,10 @@ Launch Blind Hunter and Edge Case Hunter in parallel without prior conversation 
   > {diff_output}
 - **Edge Case Hunter** — prompt:
   > Invoke the `bmad-review-edge-case-hunter` skill on this diff:
+  >
+  > {diff_output}
+- **Verification Gap Reviewer** — prompt:
+  > Invoke the `bmad-review-verification-gap` skill on this diff:
   >
   > {diff_output}
 

--- a/src/core-skills/bmad-review-verification-gap/SKILL.md
+++ b/src/core-skills/bmad-review-verification-gap/SKILL.md
@@ -18,6 +18,7 @@ The main verification gap shapes are:
 - Read a test before claiming what it covers, runs, asserts, or misses.
 - Before claiming no test exists, search the whole repo by the symbol under test and by import references; expected file locations are not enough.
 - Never assert what you did not verify. If a finding cannot be grounded, drop it.
+- In a finding, say what you actually checked — "none of the tests I read cover this" — and show how far you looked. Say a test doesn't exist anywhere only when the symbol/import-reference search actually shows that.
 - Do not assign severity, confidence, priority, or ranking.
 
 ## Review Sequence
@@ -42,12 +43,15 @@ Follow a path only while the changed behavior is reachable and unverified. Stop 
 
 ### Step 4: Qualify the consumer, then check its test
 
-For each consumer, name the smallest realistic regression this consumer would observe: invert the branch, drop the default, omit the field, return the old error code, skip the integration call, etc. This is the Demonstration. If no such regression exists, drop the path; untested downstream code is not a finding. A `Missing-adoption gap` qualifies by the adoption failure itself.
+For each consumer, name the smallest realistic regression this consumer would observe: invert the branch, drop the default, omit the field, return the old error code, skip the integration call, etc. This is the Demonstration. If no such regression exists, drop the path; untested downstream code is not a finding.
+
+A `Missing-adoption gap` qualifies not by the adoption failure alone but by a supersession signal: the change gives clear evidence the new behavior is meant to replace the local one — PR intent, naming or docs, a replaced sibling site, deleted duplicate logic, or a test defining the new rule — and the local site shares the same observable contract. Without a supersession signal and a shared observable contract, it is a refactor suggestion, not a verification-gap finding. Once both hold, check whether any test for that site would flag the non-adoption; missing coverage of the non-adoption is the gap itself, not a disqualifier.
 
 Find and read the relevant test. Ask whether the Demonstration would make an assertion fail.
 
 - If yes, the behavior is verified. No finding.
-- If no test runs the path, the test is skipped/flaky/not run normally, or the test runs the code without checking the changed result, report a `Regression gap` or `Broken-verification gap`.
+- For a regression-style Demonstration: if no test runs the path, the test is skipped/flaky/not run normally, or the test runs the code without checking the changed result, report a `Regression gap` or `Broken-verification gap`.
+- For a qualifying Missing-adoption case: if none of the site tests you found assert it adopts the new behavior, report a `Missing-adoption gap`.
 
 A test counts only if it runs normally and an assertion observes the changed output, branch, or contract. These do not count: no execution; success/no-throw/snapshot-only checks; mock/log-call checks; human-only checks; tests that mock away the integration; e2e tests that pass through without checking the changed output; stale assertions or fixtures.
 
@@ -62,7 +66,7 @@ Common patterns:
 
 ### Step 5: Confirm each finding is real
 
-Before writing a finding, re-open the specific tests or search results the finding relies on. Verify the Demonstration would not make any test fail, or that the absence claim is backed by the symbol/import-reference search. Do not claim more than you verified; drop any finding you cannot ground.
+Before writing a finding, re-open the specific tests or search results the finding relies on. Verify the Demonstration would not make any test you checked fail, or that the absence claim is backed by the symbol/import-reference search. Do not claim more than you verified; drop any finding you cannot ground.
 
 Do not report: compiler/type-checker-enforced cases; behavior already verified by an integration, contract, or e2e test; implementation-detail or mock-only tests; low coverage or a missing test file by itself; legacy untested code the change did not affect.
 
@@ -83,9 +87,9 @@ Emit each verification-gap finding as one block. No general advice, no severity 
   - `Broken-verification gap`: the apparent test or verification path, and why it does not count.
 - **Missing verification:** the precise assertion or check that's absent.
 - **Demonstration:**
-  - `Regression gap` / `Broken-verification gap`: the concrete regression that would ship undetected, and why the tests would not fail.
-  - `Missing-adoption gap`: the case the site mishandles by not adopting the new behavior, and that no test asserts adoption.
-- **Consequence:** the concrete thing that ships wrong — a regression no test would catch, or a site that should use the new behavior and doesn't.
+  - `Regression gap` / `Broken-verification gap`: the concrete regression that would ship undetected, and why the tests you checked would not fail.
+  - `Missing-adoption gap`: the case the site mishandles by not adopting the new behavior, and that none of the tests you read assert adoption.
+- **Consequence:** the concrete thing that ships wrong — a regression the checked evidence would not catch, or a site that should use the new behavior and doesn't.
 - **Suggested test shape:** (optional) the kind of test that would close the gap, fit to the repo's own way of verifying — don't impose a generic test pyramid.
 ```
 

--- a/src/core-skills/bmad-review-verification-gap/SKILL.md
+++ b/src/core-skills/bmad-review-verification-gap/SKILL.md
@@ -1,0 +1,87 @@
+---
+name: bmad-review-verification-gap
+description: 'Review a diff for changed behavior that no test would catch regressing — verification gaps. It asks whether a regression in the changed behavior would be caught by a test, never whether the code is wrong. Use when reviewing a code change for missing or weak verification of the behavior it alters.'
+---
+
+# Verification Gap Review
+
+**Goal:** Find one kind of problem in a code change: behavior the change introduces or alters that nothing would catch if it broke. You ask one question — "if the behavior this change is supposed to produce stopped holding where it's actually used, would any test fail?" — and only this one: you never decide whether the code is right or wrong, only whether a regression would be caught. Assume the behavior could regress and check whether anything would notice; a change can be perfectly correct today and still be your finding if nothing pins it down. Two ways behavior goes unverified:
+
+1. The changed code regresses where it's used, and no test covering that use would fail.
+2. A place that should now use the new behavior doesn't — it handles the same case its own way, or not at all — and no test would flag the omission.
+
+**Inputs:**
+- **content** — the change to review: a diff, plus access to the repository to read source, callers, and tests
+- **also_consider** (optional) — areas to keep in mind alongside the normal verification-gap analysis
+
+**MANDATORY: Execute the steps in order. Read the real test before claiming anything about it — never assert a test exists, runs, or passes unless you found and read it. Never claim a test is absent unless you searched the whole repo by the symbol under test and by its import references — checking expected file locations alone is never sufficient. Inventing evidence is the one thing this layer must never do; staying quiet is always acceptable. Do not assign severity, confidence, priority, or ranking.**
+
+## EXECUTION
+
+### Step 1: Triage the change (cheap, first)
+
+Most changes are not your concern. Decide quickly whether the change alters behavior at all. If it doesn't, stop and emit the clean result (see Output Format). These almost never do: formatting, comments, whitespace; pure renames and IDE refactors; trivial getters/setters and pass-throughs; changes the compiler or type-checker fully enforces (a type change, a removed `throws`, a tightened access modifier, a deleted unused method).
+
+Decide "no behavioral change" only when the change alters none of these: return values, thrown errors, caller-visible side effects, or observable state (including iteration order and emitted messages). Establish that from the changed hunk plus any existing test that already pins the surface; if it holds, stop there. Do not trace consumers to prove a neutral change neutral.
+
+### Step 2: Find the behavior that changed
+
+Look past the changed files to the behavior or contract they change: a return value, a side effect, a branch, an error path, a schema, an event shape, a config default, a validation or authorization rule. Decompose the change into the surfaces it touches — e.g. a public API, a schema or migration, an event payload, a config default or feature flag, a route or UI behavior, an error/retry path — and treat each separately, compared to its previous state.
+
+Watch for small diffs with wide reach — a dependency upgrade, a compiler/toolchain upgrade or build-config change, an external-service contract, a data-file change. They don't look behavioral at any one site but can shift behavior broadly. Treat them as behavioral; don't assume a tool already flagged them.
+
+### Step 3: Trace where that behavior is used
+
+A gap lives where behavior is exercised, often not in the file that changed. Follow the change to its consumers: callers, through static references (call sites, route/command/DI registries, generated clients); contract consumers (schema, event, and API subscribers; database readers); cheap reverse-dependency info from the build graph if it is already available. Trace the changed behavior, not the whole call graph, and follow each path only while the behavior stays both unverified and still reachable. Stop a path as soon as one of these holds: it's verified (a test at this boundary would fail if the behavior regressed — no finding); the consumer doesn't actually observe what changed (not perturbed — drop it, per Step 4's gate); or the next hop can't be established from the code (dynamic dispatch, reflection, a consumer outside the repo — stay quiet about it rather than guess). In practice that lands at the nearest boundary where the change becomes observable — usually one to three hops — and you prioritize paths that cross a contract, integration, or service edge, since that's where unit tests stop covering. Across breadth, follow the few consumers where the behavior could regress observably, not every caller.
+
+### Step 4: Qualify the consumer, then check its test
+
+For each consumer you traced, first **name the one small, realistic change to the new behavior that would alter what this consumer observes** — invert the new branch, drop the new default, null a boundary, omit or rename a new field, return the old error code, skip the integration call. That named regression is the consumer's Demonstration, and it is a gate: if you cannot name a change this consumer would observe, the change does not perturb it — it is untested downstream code, a place to look, not a finding, so drop it. (The missing-adoption shape below qualifies differently — through the shape itself, not this perturbation gate.)
+
+For each consumer that survives the gate, **find the real test, read it, and ask: would the Demonstration make any assertion in it fail?**
+
+- If an assertion would fail, the behavior is verified. No finding.
+- If nothing would fail — the test runs the code but never checks the changed result, or nothing runs the consumer's path at all — that's your gap.
+
+A test counts only if some assertion actually observes the specific output, branch, or contract that changed. These do not count: **no execution** (nothing runs the changed surface); **weak check** (only asserts success, no-throw, "a snapshot exists," that a log or mock was called, or the only real check is a person eyeballing the result); **wrong level** (a unit test mocks away the changed integration, or an end-to-end test passes through without checking the changed output); **stale check** (asserts the old behavior, or fixture data skips the new branch). A test merely existing, touching the module, or being "relevant" proves nothing.
+
+The recurring shapes of a gap:
+
+- **Caller-path gap** — the helper's own unit test covers the new branch, but the caller drives it with values that skip that branch, so the integration regresses while the helper test stays green.
+- **Contract drift** — a payload, schema, or event-shape change; the gap is at the consumer that reads it, not the provider's unit tests. Verify the consumer.
+- **Migration compatibility** — tests create only new-format rows or a fresh schema, so a backfill or mixed-version read breaks on deploy with nothing failing in CI.
+- **Phantom exception** — a partial-failure path the code already handles (primary call succeeds, a secondary or telemetry call times out) that no test checks. The gap is the missing verification of a branch the code already reaches.
+- **Missing adoption** — the change makes a new function or rule the intended way to handle some case, but another site handling the same case doesn't use it. Report the site, the behavior it lacks, and that no test would catch its absence — whether or not it's also a bug.
+- **Removed verification** — the change deletes a test that was covering a real case, or drops or weakens an assertion that pinned behavior, so something once verified no longer is. (Whether removing a guard is itself a bug is not your call; your gap is the lost verification.)
+
+### Step 5: Confirm each finding is real
+
+Before writing a finding, re-derive the exact regression and confirm that no test you actually found and read would catch it. If you couldn't confirm a specific test, say exactly what you checked and report the finding anyway — but never assert what you didn't verify. If you can't ground a finding at all, drop it.
+
+What is not yours to report: a test the compiler or type-checker already makes unnecessary; a test when an integration, contract, or end-to-end test already pins the changed behavior; tests of implementation details or of mocks; low coverage or a missing test file as a finding on its own (it only tells you where to look); legacy untested code the change didn't route new traffic through or change the assumptions of.
+
+Report everything you reach. Don't hold back a real concern because it seems redundant or because it isn't strictly a verification gap — if you noticed a genuine problem while reasoning about the change, report it. Staying silent about something you actually reached is the costly mistake; an extra report is cheap. This licenses reporting what you already noticed, not extra hunting.
+
+## OUTPUT FORMAT
+
+For each finding, one block. No prose outside the blocks, no general advice, no severity or confidence.
+
+```markdown
+### <one-line title naming the gap>
+
+- **Changed surface:** the exact behavior or contract that changed — `file:line`.
+- **Impacted consumer or site:** named concretely with `file:line` (e.g. "the `createInvoice` mutation used by the billing dashboard at `billing/dashboard.ts:88`," not "callers of this function").
+- **Existing test evidence:** what the relevant test actually asserts, with its `file:line` — or, if none, the symbol and import-reference searches you ran and their result (e.g. "none — searched `createInvoice` and its imports across the repo, 0 hits").
+- **Missing verification:** the precise assertion or check that's absent.
+- **Demonstration:** the one concrete change that would regress the behavior and ship undetected (e.g. flip `>=` to `>`, drop a field, return the old error code), and the fact that nothing in the tests you read would catch it. For a missing-adoption gap nothing regresses, so state instead the case the site mishandles by not adopting the new behavior, and that no test asserts the site adopts it.
+- **Consequence:** the concrete thing that ships wrong — a regression no test would catch, or a site that should use the new behavior and doesn't.
+- **Suggested test shape:** (optional) the kind of test that would close the gap, fit to the repo's own way of verifying — don't impose a generic test pyramid.
+```
+
+When you find nothing, output exactly this single line, not an empty response:
+
+`No verification gaps found.`
+
+## HALT CONDITIONS
+
+- If content is empty or cannot be decoded as text, output `No verification gaps found.` with a one-line note that no reviewable change was provided, and stop.

--- a/src/core-skills/bmad-review-verification-gap/SKILL.md
+++ b/src/core-skills/bmad-review-verification-gap/SKILL.md
@@ -1,87 +1,102 @@
 ---
 name: bmad-review-verification-gap
-description: 'Review a diff for changed behavior that no test would catch regressing — verification gaps. It asks whether a regression in the changed behavior would be caught by a test, never whether the code is wrong. Use when reviewing a code change for missing or weak verification of the behavior it alters.'
+description: 'Review a code change for changed behavior that could regress without reliable verification catching it. Use when checking whether a change is adequately verified.'
 ---
 
 # Verification Gap Review
 
-**Goal:** Find one kind of problem in a code change: behavior the change introduces or alters that nothing would catch if it broke. You ask one question — "if the behavior this change is supposed to produce stopped holding where it's actually used, would any test fail?" — and only this one: you never decide whether the code is right or wrong, only whether a regression would be caught. Assume the behavior could regress and check whether anything would notice; a change can be perfectly correct today and still be your finding if nothing pins it down. Two ways behavior goes unverified:
+**Goal:** Find changed behavior that could break without reliable verification catching it. Ask one question — "if the behavior this change is supposed to produce broke where it's actually used, would verification fail?" Do not hunt for correctness bugs, but report genuine problems you notice while tracing verification.
 
-1. The changed code regresses where it's used, and no test covering that use would fail.
-2. A place that should now use the new behavior doesn't — it handles the same case its own way, or not at all — and no test would flag the omission.
+The main verification gap shapes are:
 
-**Inputs:**
-- **content** — the change to review: a diff, plus access to the repository to read source, callers, and tests
-- **also_consider** (optional) — areas to keep in mind alongside the normal verification-gap analysis
+1. **Regression gap:** the changed code regresses where it's used, and no test covering that use would fail.
+2. **Missing-adoption gap:** a place that should now use the new behavior doesn't; it handles the same case its own way, or not at all, and no test would flag the omission.
+3. **Broken-verification gap:** a test appears to cover the changed behavior, but would not actually protect it because it is skipped, flaky, not run in the normal verification path, or too weak to observe the regression.
 
-**MANDATORY: Execute the steps in order. Read the real test before claiming anything about it — never assert a test exists, runs, or passes unless you found and read it. Never claim a test is absent unless you searched the whole repo by the symbol under test and by its import references — checking expected file locations alone is never sufficient. Inventing evidence is the one thing this layer must never do; staying quiet is always acceptable. Do not assign severity, confidence, priority, or ranking.**
+## Evidence Rules
 
-## EXECUTION
+- Read a test before claiming what it covers, runs, asserts, or misses.
+- Before claiming no test exists, search the whole repo by the symbol under test and by import references; expected file locations are not enough.
+- Never assert what you did not verify. If a finding cannot be grounded, drop it.
+- Do not assign severity, confidence, priority, or ranking.
 
-### Step 1: Triage the change (cheap, first)
+## Review Sequence
 
-Most changes are not your concern. Decide quickly whether the change alters behavior at all. If it doesn't, stop and emit the clean result (see Output Format). These almost never do: formatting, comments, whitespace; pure renames and IDE refactors; trivial getters/setters and pass-throughs; changes the compiler or type-checker fully enforces (a type change, a removed `throws`, a tightened access modifier, a deleted unused method).
+### Step 1: Screen for behavioral change
 
-Decide "no behavioral change" only when the change alters none of these: return values, thrown errors, caller-visible side effects, or observable state (including iteration order and emitted messages). Establish that from the changed hunk plus any existing test that already pins the surface; if it holds, stop there. Do not trace consumers to prove a neutral change neutral.
+If the change is non-behavioral, stop here and output the clean result (see Output Format). Call it non-behavioral only when the changed code does not alter return values, thrown errors, caller-visible side effects, or observable state (including iteration order and emitted messages). After the changed code meets that test, stop; do not inspect callers or tests for extra confirmation.
+
+Common non-behavioral examples: formatting, comments, whitespace; pure renames; trivial getters/setters and pass-throughs; type-only or compiler-enforced changes with no runtime effect; etc.
 
 ### Step 2: Find the behavior that changed
 
-Look past the changed files to the behavior or contract they change: a return value, a side effect, a branch, an error path, a schema, an event shape, a config default, a validation or authorization rule. Decompose the change into the surfaces it touches — e.g. a public API, a schema or migration, an event payload, a config default or feature flag, a route or UI behavior, an error/retry path — and treat each separately, compared to its previous state.
+Identify what behavior changed compared to the previous version: output, side effect, branch, error path, schema/event shape, config default, validation/authorization rule, external contract, etc. If the change affects more than one behavior, handle each separately.
 
-Watch for small diffs with wide reach — a dependency upgrade, a compiler/toolchain upgrade or build-config change, an external-service contract, a data-file change. They don't look behavioral at any one site but can shift behavior broadly. Treat them as behavioral; don't assume a tool already flagged them.
+Treat broad-impact changes as behavioral even when no single changed line looks important: dependency, toolchain, build/config, data-file, etc.
 
 ### Step 3: Trace where that behavior is used
 
-A gap lives where behavior is exercised, often not in the file that changed. Follow the change to its consumers: callers, through static references (call sites, route/command/DI registries, generated clients); contract consumers (schema, event, and API subscribers; database readers); cheap reverse-dependency info from the build graph if it is already available. Trace the changed behavior, not the whole call graph, and follow each path only while the behavior stays both unverified and still reachable. Stop a path as soon as one of these holds: it's verified (a test at this boundary would fail if the behavior regressed — no finding); the consumer doesn't actually observe what changed (not perturbed — drop it, per Step 4's gate); or the next hop can't be established from the code (dynamic dispatch, reflection, a consumer outside the repo — stay quiet about it rather than guess). In practice that lands at the nearest boundary where the change becomes observable — usually one to three hops — and you prioritize paths that cross a contract, integration, or service edge, since that's where unit tests stop covering. Across breadth, follow the few consumers where the behavior could regress observably, not every caller.
+Trace the changed behavior to the places that observe it. Start with direct callers and registered entry points (routes, commands, DI), contract consumers (schemas, events, APIs, database readers), and reverse-dependency info if already available.
+
+Follow a path only while the changed behavior is reachable and unverified. Stop when a test at that boundary would fail, the consumer does not observe the changed behavior, or the next hop is guesswork (dynamic dispatch, reflection, outside-repo consumers, etc.). Prefer the nearest observable boundary, often one to three hops away, especially across contract, integration, or service edges. If there are more than five similar consumers, group obvious repeats and check representative paths; expand only when a consumer observes the behavior differently.
 
 ### Step 4: Qualify the consumer, then check its test
 
-For each consumer you traced, first **name the one small, realistic change to the new behavior that would alter what this consumer observes** — invert the new branch, drop the new default, null a boundary, omit or rename a new field, return the old error code, skip the integration call. That named regression is the consumer's Demonstration, and it is a gate: if you cannot name a change this consumer would observe, the change does not perturb it — it is untested downstream code, a place to look, not a finding, so drop it. (The missing-adoption shape below qualifies differently — through the shape itself, not this perturbation gate.)
+For each consumer, name the smallest realistic regression this consumer would observe: invert the branch, drop the default, omit the field, return the old error code, skip the integration call, etc. This is the Demonstration. If no such regression exists, drop the path; untested downstream code is not a finding. A `Missing-adoption gap` qualifies by the adoption failure itself.
 
-For each consumer that survives the gate, **find the real test, read it, and ask: would the Demonstration make any assertion in it fail?**
+Find and read the relevant test. Ask whether the Demonstration would make an assertion fail.
 
-- If an assertion would fail, the behavior is verified. No finding.
-- If nothing would fail — the test runs the code but never checks the changed result, or nothing runs the consumer's path at all — that's your gap.
+- If yes, the behavior is verified. No finding.
+- If no test runs the path, the test is skipped/flaky/not run normally, or the test runs the code without checking the changed result, report a `Regression gap` or `Broken-verification gap`.
 
-A test counts only if some assertion actually observes the specific output, branch, or contract that changed. These do not count: **no execution** (nothing runs the changed surface); **weak check** (only asserts success, no-throw, "a snapshot exists," that a log or mock was called, or the only real check is a person eyeballing the result); **wrong level** (a unit test mocks away the changed integration, or an end-to-end test passes through without checking the changed output); **stale check** (asserts the old behavior, or fixture data skips the new branch). A test merely existing, touching the module, or being "relevant" proves nothing.
+A test counts only if it runs normally and an assertion observes the changed output, branch, or contract. These do not count: no execution; success/no-throw/snapshot-only checks; mock/log-call checks; human-only checks; tests that mock away the integration; e2e tests that pass through without checking the changed output; stale assertions or fixtures.
 
-The recurring shapes of a gap:
+Common patterns:
 
-- **Caller-path gap** — the helper's own unit test covers the new branch, but the caller drives it with values that skip that branch, so the integration regresses while the helper test stays green.
-- **Contract drift** — a payload, schema, or event-shape change; the gap is at the consumer that reads it, not the provider's unit tests. Verify the consumer.
-- **Migration compatibility** — tests create only new-format rows or a fresh schema, so a backfill or mixed-version read breaks on deploy with nothing failing in CI.
-- **Phantom exception** — a partial-failure path the code already handles (primary call succeeds, a secondary or telemetry call times out) that no test checks. The gap is the missing verification of a branch the code already reaches.
-- **Missing adoption** — the change makes a new function or rule the intended way to handle some case, but another site handling the same case doesn't use it. Report the site, the behavior it lacks, and that no test would catch its absence — whether or not it's also a bug.
-- **Removed verification** — the change deletes a test that was covering a real case, or drops or weakens an assertion that pinned behavior, so something once verified no longer is. (Whether removing a guard is itself a bug is not your call; your gap is the lost verification.)
+- **Caller-path gap** — helper test covers the branch, but caller values skip it.
+- **Contract drift** — payload/schema/event changes must be verified at the consumer.
+- **Migration compatibility** — tests only create new-format rows or fresh schemas.
+- **Phantom exception** — handled partial-failure path has no test.
+- **Missing-adoption gap** — sibling site should use the new rule/helper and does not.
+- **Removed verification** — deleted test or weakened assertion leaves behavior unpinned.
 
 ### Step 5: Confirm each finding is real
 
-Before writing a finding, re-derive the exact regression and confirm that no test you actually found and read would catch it. If you couldn't confirm a specific test, say exactly what you checked and report the finding anyway — but never assert what you didn't verify. If you can't ground a finding at all, drop it.
+Before writing a finding, re-open the specific tests or search results the finding relies on. Verify the Demonstration would not make any test fail, or that the absence claim is backed by the symbol/import-reference search. Do not claim more than you verified; drop any finding you cannot ground.
 
-What is not yours to report: a test the compiler or type-checker already makes unnecessary; a test when an integration, contract, or end-to-end test already pins the changed behavior; tests of implementation details or of mocks; low coverage or a missing test file as a finding on its own (it only tells you where to look); legacy untested code the change didn't route new traffic through or change the assumptions of.
+Do not report: compiler/type-checker-enforced cases; behavior already verified by an integration, contract, or e2e test; implementation-detail or mock-only tests; low coverage or a missing test file by itself; legacy untested code the change did not affect.
 
-Report everything you reach. Don't hold back a real concern because it seems redundant or because it isn't strictly a verification gap — if you noticed a genuine problem while reasoning about the change, report it. Staying silent about something you actually reached is the costly mistake; an extra report is cheap. This licenses reporting what you already noticed, not extra hunting.
+Report genuine problems you noticed while tracing verification, even if they are not verification gaps. Put them under `Other findings` in the output. This permits reporting what you already reached, not extra hunting.
 
 ## OUTPUT FORMAT
 
-For each finding, one block. No prose outside the blocks, no general advice, no severity or confidence.
+Emit each verification-gap finding as one block. No general advice, no severity or confidence.
 
 ```markdown
 ### <one-line title naming the gap>
 
 - **Changed surface:** the exact behavior or contract that changed — `file:line`.
 - **Impacted consumer or site:** named concretely with `file:line` (e.g. "the `createInvoice` mutation used by the billing dashboard at `billing/dashboard.ts:88`," not "callers of this function").
-- **Existing test evidence:** what the relevant test actually asserts, with its `file:line` — or, if none, the symbol and import-reference searches you ran and their result (e.g. "none — searched `createInvoice` and its imports across the repo, 0 hits").
+- **Existing test evidence:**
+  - `Regression gap`: what the relevant test actually asserts, with `file:line`; or, if none, the symbol/import-reference searches run and their result.
+  - `Missing-adoption gap`: tests for the impacted site, and whether any assert it adopts the new behavior.
+  - `Broken-verification gap`: the apparent test or verification path, and why it does not count.
 - **Missing verification:** the precise assertion or check that's absent.
-- **Demonstration:** the one concrete change that would regress the behavior and ship undetected (e.g. flip `>=` to `>`, drop a field, return the old error code), and the fact that nothing in the tests you read would catch it. For a missing-adoption gap nothing regresses, so state instead the case the site mishandles by not adopting the new behavior, and that no test asserts the site adopts it.
+- **Demonstration:**
+  - `Regression gap` / `Broken-verification gap`: the concrete regression that would ship undetected, and why the tests would not fail.
+  - `Missing-adoption gap`: the case the site mishandles by not adopting the new behavior, and that no test asserts adoption.
 - **Consequence:** the concrete thing that ships wrong — a regression no test would catch, or a site that should use the new behavior and doesn't.
 - **Suggested test shape:** (optional) the kind of test that would close the gap, fit to the repo's own way of verifying — don't impose a generic test pyramid.
 ```
 
-When you find nothing, output exactly this single line, not an empty response:
+If you noticed genuine non-gap problems while tracing verification, append:
+
+```markdown
+## Other findings
+
+- <description only; no severity, confidence, priority, or ranking>
+```
+
+When you find no verification gaps and no other findings, output exactly this single line, not an empty response:
 
 `No verification gaps found.`
-
-## HALT CONDITIONS
-
-- If content is empty or cannot be decoded as text, output `No verification gaps found.` with a one-line note that no reviewable change was provided, and stop.


### PR DESCRIPTION
## What

Adds a third code-review layer, **`bmad-review-verification-gap`**, alongside the existing adversarial bug-hunter (`bmad-review-adversarial-general`) and edge-case hunter (`bmad-review-edge-case-hunter`).

The two existing layers ask *"is this code wrong?"*. This one asks the orthogonal question: *"if the behavior this change introduces or alters stopped holding where it's actually used, would any test fail?"* It hunts for **verification gaps** — changed behavior that nothing would catch regressing, and sites that should adopt a new rule but don't — never for bugs.

## How it works

- **Cheap-by-default triage:** non-behavioral changes exit at near-zero cost; equivalence for a candidate-neutral change is established locally (the changed hunk plus any test already pinning the surface) without tracing consumers.
- **Mutation-style reasoning, no mutator:** name the one concrete regression a consumer would observe, then read the real test and ask whether any assertion would fail.
- **The named regression gates consumer qualification** — an untested downstream consumer the change doesn't actually reach is a place to look, not a finding.
- **No severity or confidence** on findings — the downstream triage owns scoring. Emits `No verification gaps found.` on a clean run so it isn't mistaken for a failed layer.

## Wiring

- Registered in `.claude-plugin/marketplace.json` (bmad-pro-skills).
- Added to the review step of **bmad-code-review**, **bmad-quick-dev**, and **bmad-dev-auto**, launched in parallel without prior context like the other layers.
- **bmad-code-review** triage normalizes its output, adds the `vgap` source, and treats the clean sentinel as a clean run rather than a failed layer.

## Not included (intentional)

- **Documentation** (`docs/**/core-tools.md`) is deliberately not updated yet — to follow.
- Empirical validation against real diffs is still pending; hence draft.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
