### PR TITLE
fix(dev-auto): write frontmatter status explicitly at Finalize

### DIFF
--- a/src/bmm-skills/4-implementation/bmad-dev-auto/step-04-review.md
+++ b/src/bmm-skills/4-implementation/bmad-dev-auto/step-04-review.md
@@ -92,4 +92,6 @@ If version control is available, commit. Do not push.
 
 Capture `final_revision` (current HEAD after committing, or `NO_VCS` if version control is unavailable) into `{spec_file}` frontmatter.
 
+Set `{spec_file}` frontmatter `status: done`.
+
 HALT with status `done`.


### PR DESCRIPTION
## What

In `bmad-dev-auto`'s `step-04-review.md` Finalize block, add an explicit
`Set {spec_file} frontmatter status: done.` instruction, right next to the
existing `followup_review_recommended` and `final_revision` frontmatter writes.

## Why

On a successful run the skill appends a `## Auto Run Result` block (with
`Status: done`) to the spec **body**, but the terminal frontmatter `status`
advance lives only in the shared `SKILL.md` HALT macro, conflated into one
sentence with "append missing result details under `## Auto Run Result`". The
Finalize block the agent actually reads at terminal time describes the prose in
detail and explicitly writes `followup_review_recommended` and (since #2522)
`final_revision`, but never explicitly writes `status`. An agent that satisfies
the prominent prose/field clauses can skip the terse macro `status` write,
leaving the frontmatter at the template default `draft` on an otherwise-complete,
tested run.

That breaks downstream automation that reads frontmatter `status` as the
machine-consumable completion signal (the spec frontmatter is the only
out-of-tree → in-tree link once `implementation-artifacts` is gitignored — the
same rationale #2522 gives for recording `final_revision` there). We observed a
fully-completed run left at `status: draft`, which a consumer treated as
unfinished. #2522 actually sharpened the asymmetry by adding a second explicit
Finalize frontmatter write while still leaving `status` to the macro.

## Change

```diff
 Capture `final_revision` ... into `{spec_file}` frontmatter.

+Set `{spec_file}` frontmatter `status: done`.
+
 HALT with status `done`.
```

One line, no behavior change for already-compliant runs — it just makes the
terminal `status` write explicit at the point the agent finalizes, consistent
with how `final_revision`/`followup_review_recommended` are already handled.

## Note (optional follow-up, not in this PR)

The same coupling in the `SKILL.md` HALT macro makes the in-flight transitions
(`ready-for-dev`, `in-progress`, `in-review`) skip-prone, and applies to blocked
exits too. De-conflating the macro's "update status AND append result details"
into two distinct steps would harden those paths; happy to follow up if desired.

🤖 Generated with [Claude Code](https://claude.com/claude-code)