### PR TITLE
fix(installer): ignore generated BMAD configuration

### DIFF
--- a/test/test-installation-components.js
+++ b/test/test-installation-components.js
@@ -1901,6 +1901,52 @@ async function runTests() {
   console.log('');
 
   // ============================================================
+  // Test Suite 36b: Root .gitignore keeps generated config uncommitted
+  // ============================================================
+  console.log(`${colors.yellow}Test Suite 36b: Root .gitignore for installer-generated config${colors.reset}\n`);
+
+  {
+    const tempBmadDir36b = await fs.mkdtemp(path.join(os.tmpdir(), 'bmad-root-gitignore-'));
+
+    try {
+      const generator36b = new ManifestGenerator();
+      const gitignorePath = path.join(tempBmadDir36b, '.gitignore');
+
+      // First install: _bmad/.gitignore is created with root-anchored patterns
+      await generator36b.ensureRootGitignore(tempBmadDir36b);
+      assert(await fs.pathExists(gitignorePath), 'ensureRootGitignore creates _bmad/.gitignore');
+
+      const gitignore = await fs.readFile(gitignorePath, 'utf8');
+      assert(/^\/config\.user\.toml$/m.test(gitignore), '.gitignore excludes /config.user.toml (holds personal user_name)');
+      assert(/^\/config\.toml$/m.test(gitignore), '.gitignore excludes /config.toml');
+      assert(/^\/\*\/config\.yaml$/m.test(gitignore), '.gitignore excludes /*/config.yaml (churn + spread user_name)');
+      // Personal custom overrides are ignored here too, so the documented guarantee
+      // holds even without _bmad/custom/.gitignore
+      assert(/^\/custom\/\*\.user\.toml$/m.test(gitignore), '.gitignore excludes /custom/*.user.toml (personal, documented as gitignored)');
+      // Patterns are root-anchored so committed _bmad/custom/config.toml is NOT ignored
+      assert(!/^config\.toml$/m.test(gitignore), '.gitignore does not use unanchored config.toml (would ignore custom/config.toml)');
+
+      // Idempotent: a second install does not duplicate the managed block
+      await generator36b.ensureRootGitignore(tempBmadDir36b);
+      const afterSecond = await fs.readFile(gitignorePath, 'utf8');
+      const markerCount = (afterSecond.match(/installer-managed \(do not edit\)/g) || []).length;
+      assert(markerCount === 1, 'ensureRootGitignore does not duplicate its managed block on reinstall');
+
+      // Upgrade path: a pre-existing .gitignore WITHOUT the block gets it appended,
+      // and the user's own lines are preserved.
+      await fs.writeFile(gitignorePath, '# my project rules\nlocal-notes.md\n');
+      await generator36b.ensureRootGitignore(tempBmadDir36b);
+      const upgraded = await fs.readFile(gitignorePath, 'utf8');
+      assert(/^local-notes\.md$/m.test(upgraded), 'ensureRootGitignore preserves user-added lines when upgrading');
+      assert(/^\/config\.user\.toml$/m.test(upgraded), 'ensureRootGitignore appends managed rules to an existing .gitignore');
+    } finally {
+      await fs.remove(tempBmadDir36b).catch(() => {});
+    }
+  }
+
+  console.log('');
+
+  // ============================================================
   // Test Suite 37: Agent Preservation for Non-Contributing Modules
   // ============================================================
   console.log(`${colors.yellow}Test Suite 37: Agent Preservation for Non-Contributing Modules${colors.reset}\n`);

--- a/tools/installer/core/manifest-generator.js
+++ b/tools/installer/core/manifest-generator.js
@@ -91,6 +91,7 @@ class ManifestGenerator {
     ];
 
     await this.ensureCustomConfigStubs(bmadDir);
+    await this.ensureRootGitignore(bmadDir);
 
     return {
       skills: this.skills.length,
@@ -655,6 +656,63 @@ class ManifestGenerator {
     for (const { file, header } of stubs) {
       if (await fs.pathExists(file)) continue;
       await fs.writeFile(file, header.join('\n'));
+    }
+  }
+
+  /**
+   * Keep _bmad/.gitignore excluding installer-generated config so it stays
+   * out of version control. These files are regenerated on every install
+   * (per-module config.yaml even restamps a timestamp header) and
+   * config.user.toml / the spread user_name in each config.yaml are personal
+   * — committing them causes per-developer merge churn on shared repos.
+   * Team-wide customization belongs in _bmad/custom/ (committed) instead.
+   *
+   * Patterns are root-anchored (leading `/`) so they match ONLY the generated
+   * files at _bmad/ root and not _bmad/custom/config.toml, which is committed.
+   * Personal overrides under _bmad/custom/ (*.user.toml) are ignored here too,
+   * so the documented "gitignored" guarantee holds even if the separate
+   * _bmad/custom/.gitignore is absent (e.g. deleted, or an older install).
+   *
+   * The rules live in a marked, installer-managed block that is refreshed on
+   * every install (so existing installs pick up rule changes), while any lines
+   * the user added outside the block are preserved.
+   */
+  async ensureRootGitignore(bmadDir) {
+    const gitignorePath = path.join(bmadDir, '.gitignore');
+    const START = '# >>> bmad-method installer-managed (do not edit) >>>';
+    const END = '# <<< bmad-method installer-managed <<<';
+    const block = [
+      START,
+      '# Installer-generated — regenerated on every `bmad-method install`.',
+      '# Personal (user_name) and churn-prone (timestamps); do not commit.',
+      '# Commit team-wide customization under _bmad/custom/ instead.',
+      '/config.toml',
+      '/config.user.toml',
+      '/*/config.yaml',
+      '/custom/*.user.toml',
+      END,
+    ].join('\n');
+
+    let existing = '';
+    if (await fs.pathExists(gitignorePath)) {
+      existing = await fs.readFile(gitignorePath, 'utf8');
+    }
+
+    let next;
+    const startIdx = existing.indexOf(START);
+    const endIdx = existing.indexOf(END);
+    if (startIdx !== -1 && endIdx !== -1 && endIdx > startIdx) {
+      // Replace the managed block in place, preserving surrounding user lines.
+      next = existing.slice(0, startIdx) + block + existing.slice(endIdx + END.length);
+    } else if (existing.trim() === '') {
+      next = block + '\n';
+    } else {
+      // Append the managed block after the user's existing content.
+      next = existing.replace(/\n*$/, '') + '\n\n' + block + '\n';
+    }
+
+    if (next !== existing) {
+      await fs.writeFile(gitignorePath, next, 'utf8');
     }
   }
 


### PR DESCRIPTION
## What
Added an installer-managed _bmad/.gitignore block that excludes generated configuration and personal override files while keeping team configuration commit-able. #2533 

## Why
Generated configuration contains personal values and changing timestamps that create unnecessary diffs and merge conflicts in shared repositories.

## How

- Added root-anchored ignore rules for generated config files.
- Preserved user-defined .gitignore content during installs and upgrades.
- Added tests for creation, upgrades, idempotency, and pattern safety.

## Testing
Ran node test/test-installation-components.js; all 388 tests passed.

