### PR TITLE
fix(dev-auto): require synchronous subagent invocation

### DIFF
--- a/src/bmm-skills/4-implementation/bmad-dev-auto/SKILL.md
+++ b/src/bmm-skills/4-implementation/bmad-dev-auto/SKILL.md
@@ -33,6 +33,8 @@ To HALT with a final status and optional blocking condition:
 
 Using subagents when instructed is mandatory. If you cannot, HALT with status `blocked` and blocking condition `no subagents`.
 
+Invoke every subagent **synchronously**: launch it, wait for it to return within the same turn, then continue with its result. When a step says to run subagents "in parallel" (e.g. the reviewers), that means several **blocking** calls awaited together in one turn — not detached execution. Never run a subagent in the background / detached / async (e.g. `run_in_background: true`), and never end your turn to "await a completion notification." This workflow runs unattended: there is no event loop to resume a yielded turn, so a backgrounded subagent never hands control back and the run stalls. The only sanctioned way to end a turn is the HALT protocol above with an explicit terminal `status`.
+
 ## READY FOR DEVELOPMENT STANDARD
 
 A specification is "Ready for Development" when:

--- a/src/bmm-skills/4-implementation/bmad-dev-auto/step-03-implement.md
+++ b/src/bmm-skills/4-implementation/bmad-dev-auto/step-03-implement.md
@@ -25,7 +25,7 @@ Change `{spec_file}` status to `in-progress` in the frontmatter before starting 
 
 If `{spec_file}` has a non-empty `context:` list in its frontmatter, load those files before implementation begins. When handing to a subagent, include them in the subagent prompt so it has access to the referenced context.
 
-Hand `{spec_file}` to an implementation subagent.
+Hand `{spec_file}` to an implementation subagent. Invoke it **synchronously** and wait for it to return in this same turn — do not background/detach it (`run_in_background`) or end your turn to await a notification (see SKILL.md → Subagents). Resume at "Tasks & Acceptance Verification" only after it returns.
 
 **Path formatting rule:** Any markdown links written into `{spec_file}` must use paths relative to `{spec_file}`'s directory so they are clickable in VS Code. Any file paths displayed in terminal/conversation output must use CWD-relative format with `:line` notation (e.g., `src/path/file.ts:42`) for terminal clickability. No leading `/` in either case.
 


### PR DESCRIPTION
## Summary

The `bmad-dev-auto` workflow runs **unattended** — there is no event loop to resume a yielded turn. If a subagent is launched detached/backgrounded (e.g. `run_in_background: true`), or the turn ends to await a completion notification, control is never handed back and the run stalls.

This PR makes the subagent-invocation contract explicit:

- **`SKILL.md`** — adds a Subagents rule requiring every subagent to be invoked **synchronously** (launch, await within the same turn, then continue). Clarifies that running reviewers "in parallel" means several **blocking** calls awaited together in one turn — not detached execution. The only sanctioned way to end a turn remains the HALT protocol with an explicit terminal `status`.
- **`step-03-implement.md`** — updates the implementation hand-off to state the subagent must be invoked synchronously and awaited in the same turn (no `run_in_background`, no yielding to await a notification), resuming at "Tasks & Acceptance Verification" only after it returns.

## Test plan

- Docs-only change to workflow skill instructions; no runtime code touched.
- Pre-commit hook ran the full test suite + markdownlint — all passed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)