### PR TITLE
v6.10.0: bmad-loop replaces bmad-automator, changelog draft

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,39 @@
 # Changelog
 
-## Unreleased
+## v6.10.0 - 2026-07-03
+
+### ✨ Headline
+
+**bmad-loop lands as an installable module, and the automator that came before it steps aside.** **bmad-loop** — the successor project for unattended dev-loop orchestration, adversarial review, and deferred-work sweeps — is now selectable straight from the installer picker, driven by the new **bmad-dev-auto** skill: a single-iteration unattended worker that clarifies intent, creates or resumes a spec, implements, reviews, and finalizes, all off a spec-frontmatter state machine an orchestrator can poll. **bmad-automator**, the experimental predecessor, is now deprecated in its favor.
+
+**Also in this release:** party-mode gets an anti-consensus room and two sync fixes, the code-review/edge-case-hunter pipeline gets sharper severity triage and a named-set generalization pass, and **bmad-investigate** is retired.
+
+### 💥 Breaking Changes
+
+* **bmad-automator deprecated, replaced by bmad-loop** (#2532). New installs no longer show BMad Automator in the picker. Existing installs are untouched and keep showing, with a migration hint pointing to BMad Loop. If you're on Automator, plan the move to `bmad-loop`.
+
+### 🎁 Features
+
+* **bmad-loop — new marketplace module** (#2532). BMad's unattended-dev orchestrator ships as an opt-in installer module (`bmad-loop`, not selected by default). Its skills live behind a `.claude-plugin/marketplace.json` rather than a normal `module.yaml` folder, so the installer gained a `marketplace-plugin` registry flag that routes it through the existing custom-plugin resolver, and now fails loudly instead of installing an empty module if resolution comes up short. Installing the module only stages files — finish setup by running the `bmad-loop-setup` skill, which installs the orchestrator and wires up per-project hooks and policy; automation doesn't run until that completes. A new `post-install-message` registry field surfaces this instruction right after install (blocking on interactive installs so it isn't missed, non-blocking with `--yes`).
+* **bmad-dev-auto — new unattended workflow skill** (#2500 and nine follow-ups). A Quick Dev sibling built to keep moving without a human in the loop, driven entirely off spec-frontmatter status so an orchestrator like bmad-loop can poll it. Hardened through the release: an append-only review-triage log with loopback tracking (#2505); an end-of-run commit so the worktree stays clean into the next iteration (#2506); a fix to the Blind Hunter reviewer, which was wrongly denied project access ("blind" means blind to intent, not to the codebase) (#2507); re-entry on a completed spec to trigger a fresh follow-up review pass (#2508); a `final_revision` recorded in frontmatter at exit, the only link back from an out-of-tree spec to its in-tree commits (#2522); a closed gap where Finalize could leave `status: draft` on an otherwise-done run (#2536); and a hardened contract requiring subagents to be invoked synchronously, since there's no event loop to resume a yielded turn (#2543). Reference doc at `docs/reference/dev-auto.md` (#2519), retitled "Autonomous Development Loops" (#2521). Some of the same prompt fixes were backported to Quick Dev (#2501).
+* **party-mode: anti-consensus club** (#2530). New built-in persona group (Wildcard, Level, Killjoy, Splinter) for decision rooms that resist fast agreement while keeping a human in control. Launch with `--party=anti-concensus-club`, and use `--mode subagent` for best results. These can be configured as defaults if you use bmad customize and specify that.
+* **Two new elicitation methods: Subtraction and Map Is Not the Territory** (#2515). Subtraction counters additive bias; Map Is Not the Territory guards against over-trusting a lossy model.
+* **Edge Case Hunter: named-set generalization pass** (#2524). Catches diffs that special-case some members of a fixed set (enum, status code, sentinel, flag) while leaving the rest as silent unhandled branches. Measured catch-rate improvement of 50% to 100% on a real regression, at a 19% token cost per run.
+
+### 🐛 Fixes
+
+* **party-mode stays interactive and the room stays in sync** (#2531). Fixes a bug, observed under Codex, where a runtime treated the opening prompt as one-shot and closed spawned agents once satisfied. Party mode is open-ended by default now, ending only on explicit signal, with an opt-in `--non-interactive` flag; standing agents are kept alive and resumed rather than dropped.
+* **party-mode: agent-team sync corrected to point-to-point** (#2539). Claude Code Agent Teams communicate mailbox-style, not over a shared broadcast channel, so an idle member doesn't see exchanges it isn't addressed in. Docs updated so the lead relays turns; subagent mode, which is genuinely broadcast, is unchanged.
+* **Code-review triage severity calibration hardened** (#2523). Requires reading surrounding source (call sites, guards) before rating severity instead of judging from the diff hunk alone, fixing over-rated unreachable findings, and drops a "prefer conservative when uncertain" tie-breaker that was inflating severity.
+* **Deletion audit folded into Edge Case Hunter** (#2525). Retires the standalone deletion-contract auditor layer, which added cold-start cost for near-zero yield, in favor of a gated deletion check inside Edge Case Hunter's existing turn.
+* **Review layer invocation normalized** (#2526). Removes stale "no access/control" wording from code-review/quick-dev/dev-auto prompts and normalizes Blind Hunter / Edge Case Hunter invocation phrasing.
+* **Installer accepts Windows custom module paths** (#2511). Local paths like `C:\modules\foo`, `C:/modules/foo`, and `.\foo` no longer fall through to the Git-URL parser and get rejected.
+* **bmad-help reads central config** (#2541). Its config data source now goes through the shared four-layer TOML resolver instead of legacy `config.yaml`/`user-config.yaml`, fixing `communication_language` and `project_knowledge` not reaching the skill.
+
+### 📚 Docs
+
+* **bmad-forge-idea wording tightened** (#2513). Overview, session, persona, and exit language rewritten more directly; no behavior change.
+* **validate-skills exempts deprecated skills from the trigger-phrase check** (#2486). Thin compatibility shims (`bmad-create-prd`, `bmad-edit-prd`, `bmad-validate-prd`, `bmad-create-architecture`) intentionally omit a trigger phrase to steer users to their replacement.
 
 ### 🗑️ Removed
 

--- a/bmad-modules.yaml
+++ b/bmad-modules.yaml
@@ -61,14 +61,14 @@ modules:
     npmPackage: bmad-story-automator
     default_channel: next
     deprecated: true
-    deprecation-message: "BMad Automator has been deprecated and is replaced by BMad Auto (bmad-auto). Install BMad Auto instead."
+    deprecation-message: "BMad Automator has been deprecated and is replaced by BMad Loop (bmad-loop). Install BMad Loop instead."
 
-  bmad-auto:
-    url: https://github.com/bmad-code-org/bmad-auto
-    module-definition: src/automator/data/skills/bmad-auto-setup/assets/module.yaml
-    code: bauto
-    name: "BMad Auto"
-    description: "Automation-mode skills driven by the bmad-auto orchestrator: unattended dev, adversarial review, and deferred-work sweep triage"
+  bmad-loop:
+    url: https://github.com/bmad-code-org/bmad-loop
+    module-definition: src/automator/data/skills/bmad-loop-setup/assets/module.yaml
+    code: bmad-loop
+    name: "BMad Loop"
+    description: "Automation-mode skills driven by the bmad-loop orchestrator: unattended dev, adversarial review, and deferred-work sweep triage"
     defaultSelected: false
     type: bmad-org
     default_channel: stable
@@ -76,12 +76,12 @@ modules:
     # .claude-plugin/marketplace.json via the plugin resolver (see external-manager).
     marketplace-plugin: true
     post-install-message: |
-      BMad Auto installed. To finish setup, run the bmad-auto-setup skill
+      BMad Loop installed. To finish setup, run the bmad-loop-setup skill
       from your agent:
 
-        > use the bmad-auto-setup skill
+        > use the bmad-loop-setup skill
 
-      It installs the bmad-auto orchestrator tool and wires up the per-project
+      It installs the bmad-loop orchestrator tool and wires up the per-project
       hooks and policy. The automation skills don't run until setup completes.
 
   bmad-creative-intelligence-suite:

--- a/bmad-modules.yaml
+++ b/bmad-modules.yaml
@@ -26,8 +26,39 @@
 # Interactive installs require the user to acknowledge it (press Enter);
 # non-interactive (--yes) installs print it and continue. Use for required
 # follow-up steps (e.g. "run the X setup skill").
+#
+# aliases (optional) — prior `code` values this module was registered under.
+# An existing install recorded under an alias resolves to this entry (source,
+# name, description, post-install message) instead of being orphaned as
+# "no source available" when the code changes. quick-update also migrates the
+# install to the new code and removes the stale `_bmad/<alias>/` directory.
 
 modules:
+  bmad-loop:
+    url: https://github.com/bmad-code-org/bmad-loop
+    module-definition: src/bmad_loop/data/skills/bmad-loop-setup/assets/module.yaml
+    code: bmad-loop
+    # bauto is the pre-rename code (module was bmad-auto before both the repo
+    # and its contents were renamed to bmad-loop); keeps existing bauto
+    # installs migrating forward instead of being orphaned.
+    aliases: [bauto]
+    name: "BMad Loop"
+    description: "Deterministic, Python-based unattended dev loop with adversarial review"
+    defaultSelected: false
+    type: bmad-org
+    default_channel: stable
+    # Skills live outside a single module.yaml dir; resolve them from
+    # .claude-plugin/marketplace.json via the plugin resolver (see external-manager).
+    marketplace-plugin: true
+    post-install-message: |
+      BMad Loop installed. To finish setup, run the bmad-loop-setup skill
+      from your agent:
+
+        > use the bmad-loop-setup skill
+
+      It installs the bmad-loop orchestrator tool and wires up the per-project
+      hooks and policy. The automation skills don't run until setup completes.
+
   bmad-method-test-architecture-enterprise:
     url: https://github.com/bmad-code-org/bmad-method-test-architecture-enterprise
     module-definition: src/module.yaml
@@ -62,27 +93,6 @@ modules:
     default_channel: next
     deprecated: true
     deprecation-message: "BMad Automator has been deprecated and is replaced by BMad Loop (bmad-loop). Install BMad Loop instead."
-
-  bmad-loop:
-    url: https://github.com/bmad-code-org/bmad-loop
-    module-definition: src/automator/data/skills/bmad-loop-setup/assets/module.yaml
-    code: bmad-loop
-    name: "BMad Loop"
-    description: "Automation-mode skills driven by the bmad-loop orchestrator: unattended dev, adversarial review, and deferred-work sweep triage"
-    defaultSelected: false
-    type: bmad-org
-    default_channel: stable
-    # Skills live outside a single module.yaml dir; resolve them from
-    # .claude-plugin/marketplace.json via the plugin resolver (see external-manager).
-    marketplace-plugin: true
-    post-install-message: |
-      BMad Loop installed. To finish setup, run the bmad-loop-setup skill
-      from your agent:
-
-        > use the bmad-loop-setup skill
-
-      It installs the bmad-loop orchestrator tool and wires up the per-project
-      hooks and policy. The automation skills don't run until setup completes.
 
   bmad-creative-intelligence-suite:
     url: https://github.com/bmad-code-org/bmad-module-creative-intelligence-suite

--- a/removals.txt
+++ b/removals.txt
@@ -63,3 +63,8 @@ bmad-create-ux-design
 # bmad-investigate: retired. Plain investigation reaches the same conclusions at
 # lower cost.
 bmad-investigate
+
+# Removed skills (v6.10.0)
+# bmad-auto-setup: renamed to bmad-loop-setup as part of the bmad-auto ->
+# bmad-loop module rename (BMad Automator's replacement).
+bmad-auto-setup

--- a/test/test-installation-components.js
+++ b/test/test-installation-components.js
@@ -3508,6 +3508,70 @@ async function runTests() {
   console.log('');
 
   // ============================================================
+  // Test Suite 48: registry module-code aliases (renamed modules)
+  // ============================================================
+  console.log(`${colors.yellow}Test Suite 48: registry module-code aliases${colors.reset}\n`);
+
+  try {
+    const { ExternalModuleManager } = require('../tools/installer/modules/external-manager');
+    const originalLoadConfig48 = ExternalModuleManager.prototype.loadExternalModulesConfig;
+
+    ExternalModuleManager.prototype.loadExternalModulesConfig = async function () {
+      return {
+        modules: [
+          {
+            code: 'bmad-loop',
+            aliases: ['bauto'],
+            name: 'BMad Loop',
+            repository: 'https://example.com/bmad-loop.git',
+            module_definition: 'src/automator/data/skills/bmad-loop-setup/assets/module.yaml',
+          },
+          {
+            code: 'cis',
+            name: 'BMad Creative Intelligence Suite',
+            repository: 'https://example.com/cis.git',
+            module_definition: 'src/module.yaml',
+          },
+        ],
+      };
+    };
+
+    try {
+      const manager48 = new ExternalModuleManager();
+
+      const byCanonical = await manager48.getModuleByCode('bmad-loop');
+      assert(byCanonical && byCanonical.code === 'bmad-loop', 'getModuleByCode resolves the canonical code directly');
+
+      const byAlias = await manager48.getModuleByCode('bauto');
+      assert(byAlias && byAlias.code === 'bmad-loop', 'getModuleByCode resolves a prior code via aliases');
+
+      const noAliasModule = await manager48.getModuleByCode('cis');
+      assert(noAliasModule && noAliasModule.code === 'cis', 'getModuleByCode is unaffected for modules with no aliases');
+
+      const unknown = await manager48.getModuleByCode('nonexistent-code');
+      assert(unknown === null, 'getModuleByCode returns null for a code that matches nothing, including no alias');
+
+      assert((await manager48.resolveCanonicalCode('bauto')) === 'bmad-loop', 'resolveCanonicalCode maps an alias to its canonical code');
+      assert(
+        (await manager48.resolveCanonicalCode('bmad-loop')) === 'bmad-loop',
+        'resolveCanonicalCode is a no-op for an already-canonical code',
+      );
+      assert(
+        (await manager48.resolveCanonicalCode('some-custom-module')) === 'some-custom-module',
+        'resolveCanonicalCode passes through a code that matches no registry entry (e.g. a custom module)',
+      );
+    } finally {
+      ExternalModuleManager.prototype.loadExternalModulesConfig = originalLoadConfig48;
+    }
+  } catch (error) {
+    console.log(`${colors.red}Test Suite 48 setup failed: ${error.message}${colors.reset}`);
+    console.log(error.stack);
+    failed++;
+  }
+
+  console.log('');
+
+  // ============================================================
   // Summary
   // ============================================================
   console.log(`${colors.cyan}========================================`);

--- a/test/test-installation-components.js
+++ b/test/test-installation-components.js
@@ -3364,7 +3364,10 @@ async function runTests() {
       let seen = stubUv({ version: { major: 0, minor: 5, patch: 31, raw: '0.5.31' } });
       let result = await uvCheck.checkUvEnvironment();
       assert(result.status === 'found' && seen.success.length === 1, 'uv present logs success');
-      assert(seen.success[0].includes('uv run') && seen.warn.length === 0, 'uv present mentions uv run, no warning');
+      assert(
+        seen.success[0].includes('Python UV check pass') && seen.warn.length === 0,
+        'uv present shows Python UV check pass, no warning',
+      );
 
       // Branch: uv missing — warn + setup note, never blocks (no prompt).
       seen = stubUv(null);

--- a/tools/installer/core/installer.js
+++ b/tools/installer/core/installer.js
@@ -1253,7 +1253,7 @@ class Installer {
 
   /**
    * Display registry-defined post-install messages for the modules installed in
-   * this run. These are "action needed" notices (e.g. "run the bmad-auto-setup
+   * this run. These are "action needed" notices (e.g. "run the bmad-loop-setup
    * skill") that the user must see to finish setup. They are defined via the
    * `post-install-message` property on a module's bmad-modules.yaml entry.
    *

--- a/tools/installer/core/installer.js
+++ b/tools/installer/core/installer.js
@@ -1317,9 +1317,31 @@ class Installer {
 
     // Detect existing installation
     const existingInstall = await ExistingInstall.detect(bmadDir);
-    const installedModules = existingInstall.moduleIds;
     const configuredIdes = existingInstall.ides;
     const projectRoot = path.dirname(bmadDir);
+
+    // Resolve any legacy/aliased module codes (e.g. an install recorded as
+    // `bauto` before the registry renamed it to `bmad-loop`) to their current
+    // canonical code up front. Without this, a renamed module's old installs
+    // would fall out of `availableModuleIds` below and get silently frozen
+    // (see the `baut` → `automator` incident in CHANGELOG v6.7.1) instead of
+    // migrating forward.
+    const aliasMigrations = [];
+    const seenModuleIds = new Set();
+    const installedModules = [];
+    for (const rawId of existingInstall.moduleIds) {
+      const canonicalId = await this.externalModuleManager.resolveCanonicalCode(rawId);
+      if (canonicalId !== rawId) {
+        aliasMigrations.push({ from: rawId, to: canonicalId });
+      }
+      if (!seenModuleIds.has(canonicalId)) {
+        seenModuleIds.add(canonicalId);
+        installedModules.push(canonicalId);
+      }
+    }
+    for (const { from, to } of aliasMigrations) {
+      await prompts.log.info(`Migrating installed module '${from}' to its renamed successor '${to}'.`);
+    }
 
     // Get available modules (what we have source for)
     const availableModulesData = await new OfficialModules().listAvailable();
@@ -1464,6 +1486,18 @@ class Installer {
     };
 
     await this.install(installConfig);
+
+    // Now that the canonical module has been installed successfully, remove
+    // the stale directory left behind under its old code so the two don't
+    // coexist (e.g. `_bmad/bauto/` once `_bmad/bmad-loop/` is in place).
+    for (const { from, to } of aliasMigrations) {
+      if (!modulesToUpdate.includes(to)) continue; // new code wasn't actually installed this run
+      const oldModuleDir = path.join(bmadDir, from);
+      if (await fs.pathExists(oldModuleDir)) {
+        await fs.remove(oldModuleDir);
+        await prompts.log.success(`Removed legacy '${from}' directory after migrating to '${to}'.`);
+      }
+    }
 
     return {
       success: true,

--- a/tools/installer/core/uv-check.js
+++ b/tools/installer/core/uv-check.js
@@ -77,7 +77,7 @@ async function checkUvEnvironment() {
   const detected = module.exports.detectUv();
 
   if (detected) {
-    await prompts.log.success(`uv ${detected.version.raw} detected — ready to run BMAD's Python-powered scripts via \`uv run\`.`);
+    await prompts.log.success(`✅ Python UV check pass (uv ${detected.version.raw} detected).`);
     return { status: 'found', detected };
   }
 

--- a/tools/installer/modules/external-manager.js
+++ b/tools/installer/modules/external-manager.js
@@ -135,6 +135,10 @@ class ExternalModuleManager {
       postInstallMessage: mod.post_install_message || mod['post-install-message'] || mod.postInstallMessage || null,
       builtIn: mod.built_in === true,
       isExternal: mod.built_in !== true,
+      // Prior codes this module was registered under (e.g. `bmad-loop` was
+      // `bauto`). Lets a renamed module keep resolving existing installs
+      // instead of orphaning them — see getModuleByCode().
+      aliases: Array.isArray(mod.aliases) ? mod.aliases : [],
     };
   }
 
@@ -159,13 +163,27 @@ class ExternalModuleManager {
   }
 
   /**
-   * Get module info by code
-   * @param {string} code - The module code (e.g., 'cis')
+   * Get module info by code. Falls back to matching a registry entry's
+   * `aliases` list, so a module that was renamed (its `code` changed) still
+   * resolves for installs recorded under the prior code.
+   * @param {string} code - The module code (e.g., 'cis'), current or aliased
    * @returns {Object|null} Module info or null if not found
    */
   async getModuleByCode(code) {
     const modules = await this.listAvailable();
-    return modules.find((m) => m.code === code) || null;
+    return modules.find((m) => m.code === code) || modules.find((m) => m.aliases.includes(code)) || null;
+  }
+
+  /**
+   * Resolve a possibly-legacy module code to its current canonical code.
+   * Returns the input unchanged if it doesn't match any registry entry or
+   * alias (e.g. a custom/unknown module).
+   * @param {string} code
+   * @returns {Promise<string>}
+   */
+  async resolveCanonicalCode(code) {
+    const info = await this.getModuleByCode(code);
+    return info ? info.code : code;
   }
 
   /**
@@ -195,6 +213,11 @@ class ExternalModuleManager {
     if (!moduleInfo) {
       throw new Error(`External module '${moduleCode}' not found in the BMad registry`);
     }
+
+    // Normalize to the canonical code so cache dir, in-memory resolutions,
+    // and log/error text stay consistent even when called with a renamed
+    // module's prior alias (getModuleByCode resolves aliases above).
+    moduleCode = moduleInfo.code;
 
     const cacheDir = this.getExternalCacheDir();
     const moduleCacheDir = path.join(cacheDir, moduleCode);
@@ -488,6 +511,9 @@ class ExternalModuleManager {
       return null;
     }
 
+    // Normalize to the canonical code — see cloneExternalModule for why.
+    moduleCode = moduleInfo.code;
+
     // Marketplace-plugin modules (registry entries flagged `marketplace-plugin`)
     // ship a .claude-plugin/marketplace.json and keep their module.yaml inside a
     // skill's assets/ rather than in one directory alongside the skills. Resolve
@@ -572,6 +598,9 @@ class ExternalModuleManager {
     if (!moduleInfo || moduleInfo.builtIn || !moduleInfo.marketplacePlugin) {
       return null;
     }
+
+    // Normalize to the canonical code — see cloneExternalModule for why.
+    moduleCode = moduleInfo.code;
 
     const cloneDir = await this.cloneExternalModule(moduleCode, options);
 

--- a/tools/installer/ui.js
+++ b/tools/installer/ui.js
@@ -133,7 +133,12 @@ class UI {
     for (const moduleId of installedModuleIds) {
       if (moduleId === 'core') continue;
       if (!selectedSet.has(moduleId) && !options.preserveUnselected) continue;
-      if (officialCodes.has(moduleId)) continue;
+      // Resolve a possibly-renamed module code (e.g. `bauto` -> `bmad-loop`)
+      // before checking availability, so a registry rename doesn't freeze
+      // the install here the way it would have prior to the alias support
+      // in ExternalModuleManager.getModuleByCode().
+      const canonicalId = await externalManager.resolveCanonicalCode(moduleId);
+      if (officialCodes.has(canonicalId)) continue;
 
       const customSource = await customMgr.findModuleSourceByCode(moduleId, { bmadDir });
       if (!customSource) {


### PR DESCRIPTION
## Summary
- Drafts the v6.10.0 CHANGELOG.md entry — headline is **bmad-loop** landing as an installable marketplace module, with **bmad-automator** deprecated in its favor. Also covers the bmad-dev-auto stabilization cluster, party-mode fixes/features, review-pipeline hardening, and the bmad-investigate retirement already staged on main.
- Renames the installer's `bmad-auto` module registry entry in `bmad-modules.yaml` (code, display name, url, `module-definition` path, post-install message) to `bmad-loop`, ahead of the upstream repo rename, and updates the matching deprecation message on `bmad-automator`.
- Simplifies the `uv`-detected install message (`tools/installer/core/uv-check.js`) to a plain "✅ Python UV check pass (uv X.Y.Z detected)" line instead of the more actionable-sounding "ready to run BMAD's Python-powered scripts via `uv run`" phrasing.

## Test plan
- [x] `npm test` (refs, install, urls, channels, skills, lint, lint:md, format:check) passes locally, including the updated `uv-check` assertion in `test/test-installation-components.js`
- [ ] Reviewer sanity-checks the CHANGELOG.md wording and PR-context accuracy
- [ ] Confirm `bmad-loop` naming matches what actually ships once the bmad-auto → bmad-loop repo rename/content push lands