### PR TITLE
feat(review): make review layers configurable via customize.toml

### DIFF
--- a/src/bmm-skills/4-implementation/bmad-code-review/SKILL.md
+++ b/src/bmm-skills/4-implementation/bmad-code-review/SKILL.md
@@ -1,13 +1,11 @@
 ---
 name: bmad-code-review
-description: 'Review code changes adversarially using parallel review layers (Blind Hunter, Edge Case Hunter, Acceptance Auditor) with structured triage into actionable categories. Use when the user says "run code review" or "review this code"'
+description: 'Adversarial code review using parallel review layers and structured triage. Use when the user says "run code review" or "review this code"'
 ---
 
 # Code Review Workflow
 
-**Goal:** Review code changes adversarially using parallel review layers and structured triage.
-
-**Your Role:** You are an elite code reviewer. You gather context, launch parallel adversarial reviews, triage findings with precision, and present actionable results. No noise, no filler.
+**Goal:** Review code changes adversarially. No noise, no filler.
 
 Subagents, when the capability is available, are an important part of this workflow. Use them as directed by the workflow steps.
 If you need an explicit user instruction to run them, ask once now for the whole workflow run.

--- a/src/bmm-skills/4-implementation/bmad-code-review/customize.toml
+++ b/src/bmm-skills/4-implementation/bmad-code-review/customize.toml
@@ -39,3 +39,55 @@ persistent_facts = [
 # Leave empty for no custom post-completion behavior.
 
 on_complete = ""
+
+# Review layers for the review step. `instruction` is the layer's whole
+# execution recipe — subagents by default, but an override may run anything
+# (e.g. an external reviewer via bash). {diff_output} and {spec_file} are
+# substituted at run time. `when` (optional) gates a layer; empty
+# `instruction` disables it.
+
+[[workflow.review_layers]]
+id = "blind-hunter"
+name = "Blind Hunter"
+instruction = """
+Launch a subagent with no prior conversation context, with this prompt:
+
+> Invoke the `bmad-review-adversarial-general` skill on this diff:
+>
+> {diff_output}
+"""
+
+[[workflow.review_layers]]
+id = "edge-case-hunter"
+name = "Edge Case Hunter"
+instruction = """
+Launch a subagent with no prior conversation context, with this prompt:
+
+> Invoke the `bmad-review-edge-case-hunter` skill on this diff:
+>
+> {diff_output}
+"""
+
+[[workflow.review_layers]]
+id = "verification-gap"
+name = "Verification Gap Reviewer"
+instruction = """
+Launch a subagent with no prior conversation context, with this prompt:
+
+> Invoke the `bmad-review-verification-gap` skill on this diff:
+>
+> {diff_output}
+"""
+
+[[workflow.review_layers]]
+id = "acceptance-auditor"
+name = "Acceptance Auditor"
+when = 'Only when {review_mode} = "full".'
+instruction = """
+Launch a subagent with no prior conversation context, with this prompt:
+
+> You are an Acceptance Auditor. Review the provided diff against `{spec_file}` and any loaded context docs. Check for: violations of acceptance criteria, deviations from spec intent, missing implementation of specified behavior, contradictions between spec constraints and actual code. Output findings as a Markdown list. Each finding: one-line title, which AC/constraint it violates, and evidence from the diff.
+>
+> Diff:
+> {diff_output}
+"""

--- a/src/bmm-skills/4-implementation/bmad-code-review/steps/step-01-gather-context.md
+++ b/src/bmm-skills/4-implementation/bmad-code-review/steps/step-01-gather-context.md
@@ -79,7 +79,6 @@ story_key: '' # set at runtime when discovered from sprint status
 
 Present a summary before proceeding: diff stats (files changed, lines added/removed), `{review_mode}`, and loaded spec/context docs (if any). HALT and wait for user confirmation to proceed.
 
-
 ## NEXT
 
 Read fully and follow `./step-02-review.md`

--- a/src/bmm-skills/4-implementation/bmad-code-review/steps/step-02-review.md
+++ b/src/bmm-skills/4-implementation/bmad-code-review/steps/step-02-review.md
@@ -8,38 +8,24 @@ failed_layers: '' # set at runtime: comma-separated list of layers that failed o
 
 - YOU MUST ALWAYS SPEAK OUTPUT in your Agent communication style with the config `{communication_language}`
 - All review subagents must run at the same model capability as the current session.
+- Run subagents synchronously: launch them together, then wait for all results before continuing.
 
 ## INSTRUCTIONS
 
-1. If `{review_mode}` = `"no-spec"`, note to the user: "Acceptance Auditor skipped — no spec file provided."
+1. The review layers are `{workflow.review_layers}`, resolved during activation.
 
-2. Launch Blind Hunter, Edge Case Hunter, and Verification Gap Reviewer in parallel without prior conversation context. If `{review_mode}` = `"full"`, include the Acceptance Auditor in the same parallel launch. If subagents are not available, generate prompt files in `{implementation_artifacts}` for each applicable reviewer role and HALT. Ask the user to run each in a separate session (ideally a different LLM) and paste back the findings. When findings are pasted, resume from this point and proceed to step 3.
+2. For each layer in `{workflow.review_layers}`:
+   - `instruction` empty or missing → drop the layer silently (an override disabled it).
+   - `when` condition present and not satisfied by the current context (`{review_mode}`, `{spec_file}`) → drop the layer and tell the user, e.g. "Acceptance Auditor skipped — no spec file provided."
+   - otherwise → the layer is active.
 
-   - **Blind Hunter** — prompt:
-     > Invoke the `bmad-review-adversarial-general` skill on this diff:
-     >
-     > {diff_output}
+   If no layer is active, HALT with status `blocked` and blocking condition `no active review layers`.
 
-   - **Edge Case Hunter** — prompt:
-     > Invoke the `bmad-review-edge-case-hunter` skill on this diff:
-     >
-     > {diff_output}
+3. Execute all active layers in parallel wherever their execution methods allow: substitute the runtime placeholders (`{diff_output}`, `{spec_file}`) into each layer's `instruction`, then follow it verbatim. If a layer's instruction requires subagents and subagents are not available, generate prompt files in `{implementation_artifacts}` for each such layer and HALT. Ask the user to run each in a separate session (ideally a different LLM) and paste back the findings. When findings are pasted, treat them as those layers' findings and resume from this point.
 
-   - **Verification Gap Reviewer** — prompt:
-     > Invoke the `bmad-review-verification-gap` skill on this diff:
-     >
-     > {diff_output}
+4. **Layer failure handling**: If any layer fails, times out, or returns empty results, append the layer's `name` to `{failed_layers}` (comma-separated) and proceed with findings from the remaining layers.
 
-   - **Acceptance Auditor** (only if `{review_mode}` = `"full"`) — prompt:
-     > You are an Acceptance Auditor. Review the provided diff against `{spec_file}` and any loaded context docs. Check for: violations of acceptance criteria, deviations from spec intent, missing implementation of specified behavior, contradictions between spec constraints and actual code. Output findings as a Markdown list. Each finding: one-line title, which AC/constraint it violates, and evidence from the diff.
-     >
-     > Diff:
-     > {diff_output}
-
-3. **Subagent failure handling**: If any subagent fails, times out, or returns empty results, append the layer name to `{failed_layers}` (comma-separated) and proceed with findings from the remaining layers.
-
-4. Collect all findings from the completed layers.
-
+5. Collect all findings from the completed layers, keeping track of each finding's originating layer `id`.
 
 ## NEXT
 

--- a/src/bmm-skills/4-implementation/bmad-code-review/steps/step-03-triage.md
+++ b/src/bmm-skills/4-implementation/bmad-code-review/steps/step-03-triage.md
@@ -11,15 +11,15 @@
 
 1. **Normalize** findings from all layers into a unified list where each finding has:
    - `id` -- sequential integer
-   - `source` -- `blind`, `edge`, `vgap`, `auditor`, or merged sources (e.g., `blind+edge`)
+   - `source` -- the `id` of the layer that produced the finding (e.g., `blind-hunter`), or merged sources joined with `+` (e.g., `blind-hunter+edge-case-hunter`)
    - `title` -- one-line summary
    - `detail` -- full description
    - `location` -- file and line reference (if available)
 
 2. **Deduplicate.** Deduplicate only findings with the same claim and same required action. If two or more findings meet both conditions, merge them into one:
-   - Use the most specific finding as the base (prefer edge-case JSON with location over adversarial prose).
+   - Use the most specific finding as the base (prefer findings with a precise location over prose-only findings).
    - Append any unique detail, reasoning, or location references from the other finding(s) into the surviving `detail` field.
-   - Set `source` to the merged sources (e.g., `blind+edge`).
+   - Set `source` to the merged sources (e.g., `blind-hunter+edge-case-hunter`).
 
 3. Then evaluate each remaining finding independently. Do not reject a finding because a related finding was rejected.
 
@@ -44,7 +44,6 @@
 8. If `{failed_layers}` is non-empty, report which layers failed before announcing results. If zero findings remain after dropping dismissed AND `{failed_layers}` is non-empty, warn the user that the review may be incomplete rather than announcing a clean review.
 
 9. If zero findings remain after triage (all rejected or none raised): state "✅ Clean review — all layers passed." (Step 3 already warned if any review layers failed via `{failed_layers}`.)
-
 
 ## NEXT
 

--- a/src/bmm-skills/4-implementation/bmad-dev-auto/customize.toml
+++ b/src/bmm-skills/4-implementation/bmad-dev-auto/customize.toml
@@ -8,6 +8,7 @@
 # - Strings replace the default.
 # - Lists append to the default list.
 # - Tables merge key by key.
+# - Arrays of tables merge by `id`: matching `id` replaces, new `id`s append.
 
 [workflow]
 
@@ -31,3 +32,41 @@ persistent_facts = [
 # Empty means no extra terminal behavior.
 
 on_complete = ""
+
+# Review layers for the review step. `instruction` is the layer's whole
+# execution recipe — subagents by default, but an override may run anything
+# (e.g. an external reviewer via bash). {diff_output} is substituted at run
+# time. `when` (optional) gates a layer; empty `instruction` disables it.
+
+[[workflow.review_layers]]
+id = "blind-hunter"
+name = "Blind Hunter"
+instruction = """
+Launch a subagent with no prior conversation context, with this prompt:
+
+> Invoke the `bmad-review-adversarial-general` skill on this diff:
+>
+> {diff_output}
+"""
+
+[[workflow.review_layers]]
+id = "edge-case-hunter"
+name = "Edge Case Hunter"
+instruction = """
+Launch a subagent with no prior conversation context, with this prompt:
+
+> Invoke the `bmad-review-edge-case-hunter` skill on this diff:
+>
+> {diff_output}
+"""
+
+[[workflow.review_layers]]
+id = "verification-gap"
+name = "Verification Gap Reviewer"
+instruction = """
+Launch a subagent with no prior conversation context, with this prompt:
+
+> Invoke the `bmad-review-verification-gap` skill on this diff:
+>
+> {diff_output}
+"""

--- a/src/bmm-skills/4-implementation/bmad-dev-auto/step-02-plan.md
+++ b/src/bmm-skills/4-implementation/bmad-dev-auto/step-02-plan.md
@@ -26,7 +26,6 @@ Re-read `./SKILL.md`, then re-read `{spec_file}` from disk and verify the spec m
 - **If the spec meets the standard:** set `{spec_file}` frontmatter status to `ready-for-dev`, then continue to step 3.
 - **If the spec does not meet the standard:** repair it once, then re-read it from disk and verify again. If it still does not meet the standard, HALT with status `blocked`, blocking condition `spec failed ready-for-development standard`, and include the failing criteria and evidence gathered.
 
-
 ## NEXT
 
 Read fully and follow `./step-03-implement.md`

--- a/src/bmm-skills/4-implementation/bmad-dev-auto/step-04-review.md
+++ b/src/bmm-skills/4-implementation/bmad-dev-auto/step-04-review.md
@@ -22,20 +22,11 @@ Do NOT `git add` anything — this is read-only inspection.
 
 ### Review
 
-Launch Blind Hunter, Edge Case Hunter, and Verification Gap Reviewer in parallel without prior conversation context.
+The review layers are `{workflow.review_layers}`, resolved during activation.
 
-- **Blind Hunter** — prompt:
-  > Invoke the `bmad-review-adversarial-general` skill on this diff:
-  >
-  > {diff_output}
-- **Edge Case Hunter** — prompt:
-  > Invoke the `bmad-review-edge-case-hunter` skill on this diff:
-  >
-  > {diff_output}
-- **Verification Gap Reviewer** — prompt:
-  > Invoke the `bmad-review-verification-gap` skill on this diff:
-  >
-  > {diff_output}
+Skip every layer whose `instruction` is empty or missing — that is how an override disables a default layer — and every layer whose `when` condition (if present) does not hold in the current context. If no layers remain, HALT with status `blocked` and blocking condition `no active review layers`.
+
+Execute all remaining layers in parallel wherever their execution methods allow: substitute the runtime placeholders (e.g. `{diff_output}`) into each layer's `instruction`, then follow it verbatim.
 
 ### Classify
 

--- a/src/bmm-skills/4-implementation/bmad-quick-dev/customize.toml
+++ b/src/bmm-skills/4-implementation/bmad-quick-dev/customize.toml
@@ -8,6 +8,7 @@
 # - Strings replace the default.
 # - Lists append to the default list.
 # - Tables merge key by key.
+# - Arrays of tables merge by `id`: matching `id` replaces, new `id`s append.
 
 [workflow]
 
@@ -31,3 +32,52 @@ persistent_facts = [
 # Empty means no extra completion behavior.
 
 on_complete = ""
+
+# Review layers for the review step. `instruction` is the layer's whole
+# execution recipe — subagents by default, but an override may run anything
+# (e.g. an external reviewer via bash). {diff_output} is substituted at run
+# time. `when` (optional) gates a layer; empty `instruction` disables it.
+
+[[workflow.review_layers]]
+id = "blind-hunter"
+name = "Blind Hunter"
+instruction = """
+Launch a subagent with no prior conversation context, with this prompt:
+
+> Invoke the `bmad-review-adversarial-general` skill on this diff:
+>
+> {diff_output}
+"""
+
+[[workflow.review_layers]]
+id = "edge-case-hunter"
+name = "Edge Case Hunter"
+instruction = """
+Launch a subagent with no prior conversation context, with this prompt:
+
+> Invoke the `bmad-review-edge-case-hunter` skill on this diff:
+>
+> {diff_output}
+"""
+
+[[workflow.review_layers]]
+id = "verification-gap"
+name = "Verification Gap Reviewer"
+instruction = """
+Launch a subagent with no prior conversation context, with this prompt:
+
+> Invoke the `bmad-review-verification-gap` skill on this diff:
+>
+> {diff_output}
+"""
+
+# Review layers for the one-shot route.
+
+[[workflow.oneshot_review_layers]]
+id = "blind-hunter"
+name = "Blind Hunter"
+instruction = """
+Launch a subagent with no prior conversation context, with this prompt:
+
+> Invoke the `bmad-review-adversarial-general` skill on the changed files.
+"""

--- a/src/bmm-skills/4-implementation/bmad-quick-dev/step-01-clarify-and-route.md
+++ b/src/bmm-skills/4-implementation/bmad-quick-dev/step-01-clarify-and-route.md
@@ -99,7 +99,6 @@ If the spec is an epic story and `{sprint_status}` exists: find the `development
 
    **b) Plan-code-review** — everything else. When uncertain whether blast radius is truly zero, choose this path.
 
-
 ## NEXT
 
 Read fully and follow `./step-02-plan.md`

--- a/src/bmm-skills/4-implementation/bmad-quick-dev/step-02-plan.md
+++ b/src/bmm-skills/4-implementation/bmad-quick-dev/step-02-plan.md
@@ -46,7 +46,6 @@ HALT and ask human: `[A] Approve` | `[E] Edit`
   - **If the file exists:** Compare the content to what you wrote. If it has changed since you wrote it, acknowledge the external edits — show a brief summary of what changed — and proceed with the updated version. Then set status `ready-for-dev` in `{spec_file}`. Everything inside `<frozen-after-approval>` is now locked — only the human can change it. → Step 3.
 - **E**: Apply changes, then return to CHECKPOINT 1.
 
-
 ## NEXT
 
 Read fully and follow `./step-03-implement.md`

--- a/src/bmm-skills/4-implementation/bmad-quick-dev/step-04-review.md
+++ b/src/bmm-skills/4-implementation/bmad-quick-dev/step-04-review.md
@@ -8,6 +8,7 @@ deferred_work_file: '{implementation_artifacts}/deferred-work.md'
 
 - YOU MUST ALWAYS SPEAK OUTPUT in your Agent communication style with the config `{communication_language}`
 - All review subagents must run at the same model capability as the current session.
+- Run subagents synchronously: launch them together, then wait for all results before continuing.
 
 ## INSTRUCTIONS
 
@@ -21,20 +22,13 @@ Do NOT `git add` anything — this is read-only inspection.
 
 ### Review
 
-Launch Blind Hunter, Edge Case Hunter, and Verification Gap Reviewer in parallel without prior conversation context. If no subagents are available, generate three review prompt files in `{implementation_artifacts}` — one per reviewer role below — and HALT. Ask the human to run each in a separate session (ideally a different LLM) and paste back the findings.
+The review layers are `{workflow.review_layers}`, resolved during activation.
 
-- **Blind Hunter** — prompt:
-  > Invoke the `bmad-review-adversarial-general` skill on this diff:
-  >
-  > {diff_output}
-- **Edge Case Hunter** — prompt:
-  > Invoke the `bmad-review-edge-case-hunter` skill on this diff:
-  >
-  > {diff_output}
-- **Verification Gap Reviewer** — prompt:
-  > Invoke the `bmad-review-verification-gap` skill on this diff:
-  >
-  > {diff_output}
+Skip every layer whose `instruction` is empty or missing — that is how an override disables a default layer — and every layer whose `when` condition (if present) does not hold in the current context. If no layers remain, HALT with status `blocked` and blocking condition `no active review layers`.
+
+Execute all remaining layers in parallel wherever their execution methods allow: substitute the runtime placeholders (e.g. `{diff_output}`) into each layer's `instruction`, then follow it verbatim.
+
+If a layer's instruction requires subagents and none are available, generate one review prompt file per such layer in `{implementation_artifacts}` and HALT. Ask the human to run each in a separate session (ideally a different LLM) and paste back the findings.
 
 ### Classify
 

--- a/src/bmm-skills/4-implementation/bmad-quick-dev/step-oneshot.md
+++ b/src/bmm-skills/4-implementation/bmad-quick-dev/step-oneshot.md
@@ -9,6 +9,7 @@ deferred_work_file: '{implementation_artifacts}/deferred-work.md'
 - YOU MUST ALWAYS SPEAK OUTPUT in your Agent communication style with the config `{communication_language}`
 - NEVER auto-push.
 - All review subagents must run at the same model capability as the current session.
+- Run subagents synchronously: launch them together, then wait for all results before continuing.
 
 ## INSTRUCTIONS
 
@@ -20,9 +21,11 @@ Implement the clarified intent directly.
 
 ### Review
 
-Launch Blind Hunter without prior conversation context. If no subagents are available, generate one review prompt file in `{implementation_artifacts}` and HALT. Ask the human to run it in a separate session and paste back the findings.
+The review layers for this route are `{workflow.oneshot_review_layers}`, resolved during activation.
 
-- **Blind Hunter** — prompt: "Invoke the `bmad-review-adversarial-general` skill on the changed files."
+Skip every layer whose `instruction` is empty or missing, and every layer whose `when` condition (if present) does not hold. If no layers remain, HALT with status `blocked` and blocking condition `no active review layers`. Execute all remaining layers in parallel wherever their execution methods allow, following each layer's `instruction` verbatim after substituting any runtime placeholders.
+
+If a layer's instruction requires subagents and none are available, generate one review prompt file per such layer in `{implementation_artifacts}` and HALT. Ask the human to run each in a separate session and paste back the findings.
 
 ### Classify
 


### PR DESCRIPTION
## What

Quick-dev, dev-auto, and code-review hardcoded the same agentic review layers (Blind Hunter, Edge Case Hunter, Verification Gap Reviewer, plus code-review's Acceptance Auditor) in their review steps. This moves them into each skill's `customize.toml` as `[[workflow.review_layers]]` defaults — quick-dev's one-shot route gets its own `[[workflow.oneshot_review_layers]]` — so they become configurable defaults instead of fixed prose.

## How it works

Each layer is a keyed table: `id` (merge key), `name`, `instruction`, optional `when`. The `instruction` is the **complete execution recipe** for the layer, not just a skill name. The defaults launch review subagents, but because the whole instruction is the override unit, a team or user override in `_bmad/custom/<skill>.toml` / `.user.toml` can:

- **add** a layer (new `id` appends — e.g. a security auditor),
- **replace** a default wholesale — including running an external review tool in a separate process via bash (potentially a different LLM) instead of a subagent,
- **disable** a default (override a matching `id` with an empty `instruction`; the review steps skip instruction-less layers).

This rides the existing structural merge in `resolve_customization.py` (keyed arrays-of-tables: matching `id` replaces, new `id`s append) — no resolver changes, no new merge semantics, and no extra resolver runs: the layers come from the workflow block each skill already resolves once at activation. The review steps skip empty and `when`-failing layers and execute the rest in parallel. Code-review's Acceptance Auditor conditionality is now a `when` condition on the layer; triage tags findings by layer `id` instead of the fixed `blind`/`edge`/`vgap`/`auditor` labels.

Default behavior is unchanged: the default entries reproduce the previous hardcoded prompts verbatim.

Also trims the code-review SKILL.md description and preamble to their load-bearing text.

## Verification

- All three `customize.toml` files parse (tomllib) and resolve to the expected default layer sets.
- End-to-end resolver test: a scratch project override adding a bash-based `security-auditor` and disabling `edge-case-hunter` via empty `instruction` merged and filtered exactly as intended.
- `npm ci && npm run quality` passed on HEAD in this worktree (0 errors, includes `validate:skills`).
- Live end-to-end dogfood: installed this branch into a harness and ran `bmad-code-review` on this PR'''s own diff with a user override adding a bash-based TODO-scanner layer and disabling `verification-gap`. Activation resolved the merged layers, the disabled layer dropped silently, the Acceptance Auditor was skipped with the announcement (no-spec mode), both default subagent layers and the custom bash layer executed, and triage tagged findings by layer `id`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
