### PR TITLE
feat: add Antigravity CLI (AGY) as supported installer platform

### DIFF
--- a/test/test-installation-components.js
+++ b/test/test-installation-components.js
@@ -245,6 +245,14 @@ async function runTests() {
     const antigravityCliInstaller = platformCodes6b.platforms['antigravity-cli']?.installer;
 
     assert(antigravityCliInstaller?.target_dir === '.agents/skills', 'Antigravity CLI target_dir uses shared skills path');
+    assert(
+      antigravityCliInstaller?.global_target_dir === '~/.gemini/antigravity-cli/skills',
+      'Antigravity CLI global_target_dir uses the CLI-specific skills path',
+    );
+    assert(
+      antigravityCliInstaller?.global_target_dir !== platformCodes6b.platforms.antigravity?.installer?.global_target_dir,
+      'Antigravity CLI global_target_dir differs from the Antigravity IDE so installs never collide',
+    );
 
     const tempProjectDir6b = await fs.mkdtemp(path.join(os.tmpdir(), 'bmad-antigravity-cli-test-'));
     const installedBmadDir6b = await createTestBmadFixture();

--- a/test/test-installation-components.js
+++ b/test/test-installation-components.js
@@ -235,6 +235,41 @@ async function runTests() {
   console.log('');
 
   // ============================================================
+  // Test 6b: Antigravity CLI Native Skills Install
+  // ============================================================
+  console.log(`${colors.yellow}Test Suite 6b: Antigravity CLI Native Skills${colors.reset}\n`);
+
+  try {
+    clearCache();
+    const platformCodes6b = await loadPlatformCodes();
+    const antigravityCliInstaller = platformCodes6b.platforms['antigravity-cli']?.installer;
+
+    assert(antigravityCliInstaller?.target_dir === '.agents/skills', 'Antigravity CLI target_dir uses shared skills path');
+
+    const tempProjectDir6b = await fs.mkdtemp(path.join(os.tmpdir(), 'bmad-antigravity-cli-test-'));
+    const installedBmadDir6b = await createTestBmadFixture();
+
+    const ideManager6b = new IdeManager();
+    await ideManager6b.ensureInitialized();
+    const result6b = await ideManager6b.setup('antigravity-cli', tempProjectDir6b, installedBmadDir6b, {
+      silent: true,
+      selectedModules: ['bmm'],
+    });
+
+    assert(result6b.success === true, 'Antigravity CLI setup succeeds against temp project');
+
+    const skillFile6b = path.join(tempProjectDir6b, '.agents', 'skills', 'bmad-master', 'SKILL.md');
+    assert(await fs.pathExists(skillFile6b), 'Antigravity CLI install writes SKILL.md directory output');
+
+    await fs.remove(tempProjectDir6b);
+    await fs.remove(path.dirname(installedBmadDir6b));
+  } catch (error) {
+    assert(false, 'Antigravity CLI native skills migration test succeeds', error.message);
+  }
+
+  console.log('');
+
+  // ============================================================
   // Test 7: Auggie Native Skills Install
   // ============================================================
   console.log(`${colors.yellow}Test Suite 7: Auggie Native Skills${colors.reset}\n`);

--- a/tools/installer/ide/platform-codes.yaml
+++ b/tools/installer/ide/platform-codes.yaml
@@ -35,6 +35,13 @@ platforms:
       target_dir: .agent/skills
       global_target_dir: ~/.gemini/antigravity/skills
 
+  antigravity-cli:
+    name: "Antigravity CLI (AGY)"
+    preferred: false
+    installer:
+      target_dir: .agents/skills
+      global_target_dir: ~/.gemini/antigravity-cli/skills
+
   auggie:
     name: "Auggie"
     preferred: false


### PR DESCRIPTION
Adds the Antigravity CLI (`agy`) as its own selectable tool. The existing `antigravity` entry targets the IDE (`.agent/skills`, `~/.gemini/antigravity/skills`); the CLI is a separate surface that reads workspace skills from the shared `.agents/skills` standard and its global skills from `~/.gemini/antigravity-cli/skills` (per the CLI's `/skills` command). Different dirs, so the two installs never collide.

Installer is config-driven, so this is one `platform-codes.yaml` entry plus a test — no installer logic changes.

Verified `npm test` passes and `--list-tools` now shows `antigravity-cli`.

Closes #2440.

Related:
- #1453 — Antigravity missing from the installer picker
- #1472 — Antigravity/OpenCode agent switching & missing workflows
- Discussion #944 — Google Antigravity + Gemini 3.0 w/ BMAD
- Discussion #1752 — installing BMAD across Antigravity + OpenCode
