### PR TITLE
feat(dev-auto,quick-dev): audit matrix-row test coverage and execution in step-03

### DIFF
--- a/src/bmm-skills/4-implementation/bmad-dev-auto/step-03-implement.md
+++ b/src/bmm-skills/4-implementation/bmad-dev-auto/step-03-implement.md
@@ -33,6 +33,10 @@ Hand `{spec_file}` to an implementation subagent. Invoke it **synchronously** an
 
 After the implementation subagent returns, verify every task in the `## Tasks & Acceptance` section of `{spec_file}` is complete and every acceptance criterion is satisfied. Mark each finished task `[x]`. If any task is not done or any acceptance criterion is not satisfied, finish the missing work before proceeding. If the missing work cannot be completed, HALT with status `blocked`, blocking condition `implementation verification failed`, and include the unfinished task or failing acceptance criterion and reason.
 
+### Matrix Test Audit
+
+If `{spec_file}`'s intent-contract contains an I/O & Edge-Case Matrix, verify every matrix row is covered by at least one test that verifies its expected behavior, and that each covering test ran and passed in the verification output. A covering test that exists but did not run — unregistered, filtered out, skipped, or disabled — counts as missing. If a test disagrees with the matrix, never edit the expectation to match the code: fix the code, or if the matrix row itself is ambiguous, HALT with status `blocked` and blocking condition `matrix ambiguity`. If the audit cannot otherwise be satisfied, HALT with status `blocked` and blocking condition `matrix test audit failed`.
+
 ## NEXT
 
 Read fully and follow `./step-04-review.md`

--- a/src/bmm-skills/4-implementation/bmad-quick-dev/step-03-implement.md
+++ b/src/bmm-skills/4-implementation/bmad-quick-dev/step-03-implement.md
@@ -36,6 +36,10 @@ Hand `{spec_file}` to a subagent/task and let it implement. If no subagents are 
 
 Before leaving this step, verify every task in the `## Tasks & Acceptance` section of `{spec_file}` is complete and every acceptance criterion is satisfied. Mark each finished task `[x]`. If any task is not done or any acceptance criterion is not satisfied, finish the missing work before proceeding.
 
+### Matrix Test Audit
+
+If `{spec_file}`'s `<frozen-after-approval>` block contains an I/O & Edge-Case Matrix, verify every matrix row is covered by at least one test that verifies its expected behavior, and that each covering test ran and passed in the verification output. A covering test that exists but did not run — unregistered, filtered out, skipped, or disabled — counts as missing. If a test disagrees with the matrix, never edit the expectation to match the code: fix the code, or if the matrix row itself is ambiguous, HALT and ask the human. Fix any other audit failure before proceeding.
+
 ## NEXT
 
 Read fully and follow `./step-04-review.md`


### PR DESCRIPTION
## What

Step-03's Tasks & Acceptance Verification in both `bmad-dev-auto` and `bmad-quick-dev` gains a Matrix Test Audit: when the spec carries an I/O & Edge-Case Matrix, the orchestrator verifies every matrix row is covered by at least one test that verifies its expected behavior, and that each covering test actually ran and passed in the verification output — a covering test that exists but never executed (unregistered, filtered out, skipped, disabled) counts as missing. Test-vs-matrix disagreements must be fixed in code, never by editing the expectation toward observed behavior.

## Why

Implementer-written tests can silently shrink: a test file that never got registered, or a fixture name a verification filter doesn't match, reports green while guarding nothing. In a 3-round A/B experiment (8 Opus/Sonnet implementation agents on real specs from a production C++ codebase), this exists-but-never-ran class was the only audit check with observed near-misses — two agents shipped fixtures invisible to the spec's own gtest filter and caught it late. Deeper checks (expectation provenance, vacuity) found nothing in 8/8 runs at these model tiers, so they are deliberately excluded to keep the always-on cost at a few hundred tokens.

## How

- New `### Matrix Test Audit` subsection in each skill's `step-03-implement.md`, active only when the spec's frozen contract contains an I/O matrix
- dev-auto (unattended): matrix ambiguity or unsatisfiable audit HALT as `blocked` (`matrix ambiguity` / `matrix test audit failed`)
- quick-dev (interactive): matrix ambiguity halts and asks the human

## Testing

`npm ci && npm run quality` clean (0 errors) on this branch.

🤖 Generated with [Claude Code](https://claude.com/claude-code)