### PR TITLE
fix(review): harden finding triage independence

### DIFF
--- a/src/bmm-skills/4-implementation/bmad-code-review/steps/step-03-triage.md
+++ b/src/bmm-skills/4-implementation/bmad-code-review/steps/step-03-triage.md
@@ -16,20 +16,22 @@
    - `detail` -- full description
    - `location` -- file and line reference (if available)
 
-2. **Deduplicate.** If two or more findings describe the same issue, merge them into one:
+2. **Deduplicate.** Deduplicate only findings with the same claim and same required action. If two or more findings meet both conditions, merge them into one:
    - Use the most specific finding as the base (prefer edge-case JSON with location over adversarial prose).
    - Append any unique detail, reasoning, or location references from the other finding(s) into the surviving `detail` field.
    - Set `source` to the merged sources (e.g., `blind+edge`).
 
-3. **Read the code before rating.** Before assigning severity, open the source at each finding's location and read enough surrounding code to judge reachability -- call sites, guards, and validation that live outside the diff hunk. Do not rate from the diff hunk alone. Severity reflects the real consequence at a real call site, not the worst theoretical reading.
+3. Then evaluate each remaining finding independently. Do not reject a finding because a related finding was rejected.
 
-4. **Assign severity** to each finding by consequence for the artifact's main consumer (software user, document reader, etc).
+4. **Read the code before rating.** Before assigning severity, open the source at each finding's location and read enough surrounding code to judge reachability -- call sites, guards, and validation that live outside the diff hunk. Do not rate from the diff hunk alone. Severity reflects the real consequence at a real call site, not the worst theoretical reading.
+
+5. **Assign severity** to each finding by consequence for the artifact's main consumer (software user, document reader, etc).
    Disregard any severity assigned by a reviewing subagent. Review subagents operate under by-design information asymmetry and do not have enough context to set final severity for this workflow.
    - `low` -- none or cosmetic
    - `medium` -- tolerable
    - `high` -- intolerable
 
-5. **Route** each finding into exactly one triage bucket:
+6. **Route** each finding into exactly one triage bucket:
    - **decision_needed** -- There is an ambiguous choice that requires human input. The code cannot be correctly patched without knowing the user's intent. Only possible if `{review_mode}` = `"full"`.
    - **patch** -- Code issue that is fixable without human input. The correct fix is unambiguous.
    - **defer** -- Pre-existing issue not caused by the current change. Real but not actionable now.
@@ -37,11 +39,11 @@
 
    If `{review_mode}` = `"no-spec"` and a finding would otherwise be `decision_needed`, reclassify it as `patch` (if the fix is unambiguous) or `defer` (if not).
 
-6. **Drop** all `dismiss` findings. Record the dismiss count for the summary.
+7. **Drop** all `dismiss` findings. Record the dismiss count for the summary.
 
-7. If `{failed_layers}` is non-empty, report which layers failed before announcing results. If zero findings remain after dropping dismissed AND `{failed_layers}` is non-empty, warn the user that the review may be incomplete rather than announcing a clean review.
+8. If `{failed_layers}` is non-empty, report which layers failed before announcing results. If zero findings remain after dropping dismissed AND `{failed_layers}` is non-empty, warn the user that the review may be incomplete rather than announcing a clean review.
 
-8. If zero findings remain after triage (all rejected or none raised): state "✅ Clean review — all layers passed." (Step 3 already warned if any review layers failed via `{failed_layers}`.)
+9. If zero findings remain after triage (all rejected or none raised): state "✅ Clean review — all layers passed." (Step 3 already warned if any review layers failed via `{failed_layers}`.)
 
 
 ## NEXT

--- a/src/bmm-skills/4-implementation/bmad-dev-auto/step-04-review.md
+++ b/src/bmm-skills/4-implementation/bmad-dev-auto/step-04-review.md
@@ -39,7 +39,7 @@ Launch Blind Hunter, Edge Case Hunter, and Verification Gap Reviewer in parallel
 
 ### Classify
 
-1. Deduplicate all review findings.
+1. Deduplicate only findings with the same claim and same required action. Then evaluate each remaining finding independently. Do not reject a finding because a related finding was rejected.
 2. Assign severity to each finding by consequence for the artifact's main consumer (software user, document reader, etc).
    Disregard any severity assigned by a reviewing subagent. Review subagents operate under by-design information asymmetry and do not have enough context to set final severity for this workflow.
    - `low`: none or cosmetic

--- a/src/bmm-skills/4-implementation/bmad-quick-dev/step-04-review.md
+++ b/src/bmm-skills/4-implementation/bmad-quick-dev/step-04-review.md
@@ -38,7 +38,7 @@ Launch Blind Hunter, Edge Case Hunter, and Verification Gap Reviewer in parallel
 
 ### Classify
 
-1. Deduplicate all review findings.
+1. Deduplicate only findings with the same claim and same required action. Then evaluate each remaining finding independently. Do not reject a finding because a related finding was rejected.
 2. Assign severity to each finding by consequence for the artifact's main consumer (software user, document reader, etc).
    Disregard any severity assigned by a reviewing subagent. Review subagents operate under by-design information asymmetry and do not have enough context to set final severity for this workflow.
    - `low`: none or cosmetic


### PR DESCRIPTION
## What
Tighten review triage instructions so only findings with the same claim and required action are deduplicated, and each remaining finding is evaluated independently.

## Why
The existing triage wording allowed a lazy failure mode where similar-looking findings could be collapsed or rejected without being judged on their own merits.

## How
- update code review triage instructions to use the stricter dedupe rule
- apply the same wording to quick dev and dev auto review triage
- preserve the user's exact hardening sentence across all three skills

## Testing
Ran `npm ci && npm run quality` in the feature worktree. Also ran `node tools/validate-skills.js --json` against the three edited skills.
