### PR TITLE
feat: isolate delivery plan validation

### DIFF
--- a/docs/explanation/named-agents.md
+++ b/docs/explanation/named-agents.md
@@ -40,6 +40,14 @@ BMad ships six named agents, each anchored to a phase of the BMad Method:
 
 They each have a hardcoded identity (name, title, domain) and a customizable layer (role, principles, communication style, icon, menu). You can rewrite Mary's principles or add menu items; you can't rename her — that's deliberate. Brand recognition survives customization so "hey Mary" always activates the analyst, regardless of how a team has shaped her behavior.
 
+## Internal Roles Beneath Named Agents
+
+Named agents are the stable outward-facing interface, but a skill need not execute every responsibility as one undifferentiated role. When specialization, bounded context, or independent checking is worth the cost, a skill may split bundled work into narrower internal roles.
+
+For example, John remains the Product Manager the user interacts with while an epic-and-story skill separates delivery-plan authoring from delivery-plan auditing. The user does not select or manage another persona. Internal roles exchange declared artifacts and compact results rather than an unrestricted conversation.
+
+The isolated audit in `bmad-create-epics-and-stories` is a narrow pilot of this pattern. It tests whether internal modularization beneath a stable outward persona produces useful additional findings at acceptable context, latency, and maintenance cost. It does not imply that every skill should use multiple roles; broader adoption depends on demonstrated value and graceful fallback where subagent isolation is unavailable.
+
 ## The Activation Flow
 
 When you invoke a named agent, eight steps run in order:

--- a/src/bmm-skills/3-solutioning/bmad-create-epics-and-stories/references/delivery-plan-auditor.md
+++ b/src/bmm-skills/3-solutioning/bmad-create-epics-and-stories/references/delivery-plan-auditor.md
@@ -1,0 +1,149 @@
+# Delivery Plan Auditor
+
+## Purpose
+
+Audit an epic and story breakdown against its declared source artifacts without continuing the author's reasoning or rewriting the plan.
+
+## Role Contract
+
+You are the internal **Delivery Plan Auditor**. You are not a named outward-facing BMad agent. Do not greet the user, adopt the parent persona, or ask the user questions.
+
+Use only:
+
+1. the completed `epics.md`
+2. the documents listed in its `inputDocuments` frontmatter
+3. this audit contract
+
+Do not use the authoring conversation, the author's private reasoning, undeclared project files, or prior claims that the plan is correct.
+
+Read `epics.md`; never edit it. Write the full report to the output path supplied by the parent workflow, creating the parent directory if needed. Return only the compact result defined below.
+
+## Audit Checks
+
+Complete every check. Do not stop after the first defect.
+
+### Traceability
+
+- Verify every FR maps to at least one story.
+- Verify mapped acceptance criteria actually implement the FR.
+- Check applicable NFRs, additional requirements, and UX design requirements.
+- Flag requirements present only in prose with no implementable story or testable criterion.
+- Flag references to requirements absent from the declared sources.
+
+### Architecture
+
+When an architecture source is declared:
+
+- verify stories honor architecture decisions and constraints
+- if a starter template is specified, verify Epic 1 Story 1 sets it up
+- create entities and infrastructure when first needed, not as unjustified upfront work
+- identify architecture decisions with no implementing story
+- identify stories assuming components, interfaces, or data not yet available
+
+### Story Quality
+
+Verify every story:
+
+- is completable by one development agent in one focused cycle
+- provides recognizable user or operational value
+- has specific, observable, and testable acceptance criteria
+- covers relevant error, edge, and state-transition behavior
+- contains enough context to implement without inventing requirements
+- references the requirements it implements
+- has no dependency on a later story
+
+### Epic Cohesion and Dependencies
+
+- Verify each epic delivers a coherent and independently useful capability.
+- Flag epics that are merely technical milestones.
+- Limit foundation work to what later stories need.
+- Treat repeated core-file changes as justified only by feedback loops, risk isolation, or context limits; otherwise recommend consolidation.
+- Verify every dependency points backward and no cycle exists.
+- Flag acceptance criteria that reference functionality scheduled later.
+
+## Findings
+
+Use these severities:
+
+- **Critical** — required coverage is absent, dependency order is impossible, or the plan cannot be implemented safely as written
+- **High** — likely implementation failure, major ambiguity, or substantial architecture/NFR/UX misalignment
+- **Medium** — material quality or maintainability weakness that does not block implementation
+- **Low** — localized clarity, consistency, or optimization issue
+
+Do not inflate severity. Combine observations with one root cause.
+
+Format each finding as:
+
+```markdown
+## Finding DP-001
+
+- Severity: Critical | High | Medium | Low
+- Category: Coverage | Acceptance Criteria | Dependency | Architecture | NFR | UX | Story Size | Epic Cohesion | Ordering
+- Target: Epic or story identifier
+- Source: Requirement or source-artifact reference
+
+### Finding
+
+Concise statement of the defect.
+
+### Evidence
+
+Specific evidence from `epics.md` and declared sources.
+
+### Recommendation
+
+The smallest correction that resolves the defect.
+```
+
+## Report
+
+Write:
+
+```markdown
+# Delivery Plan Audit
+
+- Audit mode: isolated subagent | sequential fallback
+- Source artifact: <path>
+- Declared inputs: <count>
+- Verdict: PASS | PASS WITH FINDINGS | BLOCKED
+
+## Input Limitations
+
+- None
+  <!-- or list missing/unreadable declared sources -->
+
+## Summary
+
+- Critical: <count>
+- High: <count>
+- Medium: <count>
+- Low: <count>
+
+## Findings
+
+<findings in severity order>
+
+## Positive Checks
+
+<brief list of important checks that passed>
+```
+
+Verdicts:
+
+- `PASS` — no findings
+- `PASS WITH FINDINGS` — no critical findings; noncritical findings exist
+- `BLOCKED` — critical findings exist, or missing evidence prevents a reliable coverage verdict
+
+## Return Contract
+
+After writing the report, return only:
+
+```text
+Verdict: <PASS | PASS WITH FINDINGS | BLOCKED>
+Findings: critical=<n>, high=<n>, medium=<n>, low=<n>
+Top findings:
+- <up to five critical or high findings, one line each>
+Report: <path>
+```
+
+Do not return the complete report to the parent context.

--- a/src/bmm-skills/3-solutioning/bmad-create-epics-and-stories/steps/step-04-final-validation.md
+++ b/src/bmm-skills/3-solutioning/bmad-create-epics-and-stories/steps/step-04-final-validation.md
@@ -93,6 +93,8 @@ The parent workflow owns accepted edits to `epics.md`; the auditor remains read-
 
 Critical findings demonstrating missing required coverage, impossible dependency order, or an unimplementable plan block completion. High findings may remain only with explicit user risk acceptance.
 
+If the verdict is `BLOCKED`, do not proceed to completion. Resolve unavailable evidence or blocking findings and rerun the audit before showing the final menu.
+
 ### 4. Confirm Material Corrections Once
 
 Material corrections change epic or story boundaries, ordering, requirements coverage, acceptance criteria, or architecture/NFR/UX alignment.
@@ -108,6 +110,7 @@ Do not start an automatic author-auditor loop. If the confirmation audit still r
 Completion requires:
 
 - the audit report exists
+- the audit verdict is not `BLOCKED`
 - no unresolved critical findings remain
 - remaining high findings have explicit user risk acceptance
 - accepted corrections are saved in `{planning_artifacts}/epics.md`

--- a/src/bmm-skills/3-solutioning/bmad-create-epics-and-stories/steps/step-04-final-validation.md
+++ b/src/bmm-skills/3-solutioning/bmad-create-epics-and-stories/steps/step-04-final-validation.md
@@ -2,139 +2,128 @@
 
 ## STEP GOAL:
 
-To validate complete coverage of all requirements and ensure stories are ready for development.
+To independently audit requirements coverage and delivery-plan readiness without changing the outward-facing workflow or persona.
 
 ## MANDATORY EXECUTION RULES (READ FIRST):
 
 ### Universal Rules:
 
-- 🛑 NEVER generate content without user input
+- 🛑 NEVER generate product content without user input
 - 📖 CRITICAL: Read the complete step file before taking any action
 - 🔄 CRITICAL: Process validation sequentially without skipping
-- 📋 YOU ARE A FACILITATOR, not a content generator
+- 📋 YOU ARE THE OUTWARD-FACING FACILITATOR, not the internal auditor
 - ✅ YOU MUST ALWAYS SPEAK OUTPUT In your Agent communication style with the config `{communication_language}`
-
-### Role Reinforcement:
-
-- ✅ You are a product strategist and technical specifications writer
-- ✅ If you already have been given communication or persona patterns, continue to use those while playing this new role
-- ✅ We engage in collaborative dialogue, not command-response
-- ✅ You bring validation expertise and quality assurance
-- ✅ User brings their implementation priorities and final review
 
 ### Step-Specific Rules:
 
-- 🎯 Focus ONLY on validating complete requirements coverage
-- 🚫 FORBIDDEN to skip any validation checks
-- 💬 Validate FR coverage, story completeness, and dependencies
-- 🚪 ENSURE all stories are ready for development
+- 🎯 Focus ONLY on requirements coverage and delivery-plan readiness
+- 🔒 Separate the audit from the Step 1-3 authoring context
+- 📄 Give the auditor only `epics.md`, its declared `inputDocuments`, and the audit contract
+- ✍️ The auditor MUST NOT modify `epics.md`
+- 🚫 Do not complete while unresolved critical findings remain
+- 🚫 Do not present the auditor as another named agent the user must manage
 
-## EXECUTION PROTOCOLS:
+## CONTEXT BOUNDARY:
 
-- 🎯 Validate every requirement has story coverage
-- 💾 Check story dependencies and flow
-- 📖 Verify architecture compliance
-- 🚫 FORBIDDEN to approve incomplete coverage
+The authoring and audit responsibilities share declared artifacts, not unrestricted conversation.
 
-## CONTEXT BOUNDARIES:
+**Auditor inputs:**
 
-- Available context: Complete epic and story breakdown from previous steps
-- Focus: Final validation of requirements coverage and story readiness
-- Limits: Validation only, no new content creation
-- Dependencies: Completed story generation from Step 3
+- `{planning_artifacts}/epics.md`
+- Every source path listed in its `inputDocuments` frontmatter
+- `{skill-root}/references/delivery-plan-auditor.md`
+
+**Auditor exclusions:**
+
+- The Step 1-3 authoring conversation
+- The author's private reasoning or confidence assessments
+- Project documents not declared in `inputDocuments`
+- Instructions to rewrite or repair `epics.md`
 
 ## VALIDATION PROCESS:
 
-### 1. FR Coverage Validation
+### 1. Verify Inputs
 
-Review the complete epic and story breakdown to ensure EVERY FR is covered:
+Confirm that `epics.md` and the audit contract exist. Read the `inputDocuments` frontmatter and resolve every declared source.
 
-**CRITICAL CHECK:**
+Do not hide unavailable sources. The auditor must record them as input limitations and reduce the confidence of its verdict.
 
-- Go through each FR from the Requirements Inventory
-- Verify it appears in at least one story
-- Check that acceptance criteria fully address the FR
-- No FRs should be left uncovered
+### 2. Run the Audit
 
-### 2. Architecture Implementation Validation
+**Preferred path — isolated subagent:**
 
-**Check for Starter Template Setup:**
+Dispatch a fresh subagent with this task:
 
-- Does Architecture document specify a starter template?
-- If YES: Epic 1 Story 1 must be "Set up initial project from starter template"
-- This includes cloning, installing dependencies, initial configuration
+> Read fully and follow `{skill-root}/references/delivery-plan-auditor.md`.
+> Audit `{planning_artifacts}/epics.md` using only that artifact and its
+> declared `inputDocuments`. Record the audit mode as `isolated subagent`.
+> Write the complete report to
+> `{planning_artifacts}/reviews/delivery-plan-audit.md`. Do not modify
+> `epics.md`. Return only the compact result required by the audit contract.
 
-**Database/Entity Creation Validation:**
+Do not pass the authoring conversation to the subagent.
 
-- Are database tables/entities created ONLY when needed by stories?
-- ❌ WRONG: Epic 1 creates all tables upfront
-- ✅ RIGHT: Tables created as part of the first story that needs them
-- Each story should create/modify ONLY what it needs
+**Fallback path — reduced-isolation sequential audit:**
 
-### 3. Story Quality Validation
+If subagents are unavailable:
 
-**Each story must:**
+1. Load `{skill-root}/references/delivery-plan-auditor.md`.
+2. Restrict evidence to `epics.md` and its declared `inputDocuments`.
+3. Record the audit mode as `sequential fallback`.
+4. Write the complete report before continuing.
+5. Flush the detailed review from working context as far as the platform permits.
+6. Continue using only the compact result required by the audit contract.
 
-- Be completable by a single dev agent
-- Have clear acceptance criteria
-- Reference specific FRs it implements
-- Include necessary technical details
-- **Not have forward dependencies** (can only depend on PREVIOUS stories)
-- Be implementable without waiting for future stories
+The fallback preserves the file and role contract, but it is not equivalent independence. Do not silently revert to ordinary in-context self-validation.
 
-### 4. Epic Structure Validation
+### 3. Present and Triage Findings
 
-**Check that:**
+The compact result must include:
 
-- Epics deliver user value, not technical milestones
-- Dependencies flow naturally
-- Foundation stories only setup what's needed
-- No big upfront technical work
-- **File Churn Check:** Do multiple epics repeatedly modify the same core files?
-  - Assess whether the overlap pattern suggests unnecessary churn or is incidental
-  - If overlap is significant: Validate that splitting provides genuine value (risk mitigation, feedback loops, context size limits)
-  - If no justification for the split: Recommend consolidation into fewer epics
-  - ❌ WRONG: Multiple epics each modify the same core files with no feedback loop between them
-  - ✅ RIGHT: Epics target distinct files/components, OR consolidation was explicitly considered and rejected with rationale
+- verdict: `PASS`, `PASS WITH FINDINGS`, or `BLOCKED`
+- finding counts by severity
+- no more than five critical or high findings
+- the full report path
 
-### 5. Dependency Validation (CRITICAL)
+If the report was not written, the audit is incomplete.
 
-**Epic Independence Check:**
+Present the verdict and finding counts. Walk critical and high findings one at a time. Let the user apply the recommendation, discuss it, defer it with explicit risk acceptance, or dismiss it with a reason. Summarize medium and low findings in one line with the report path.
 
-- Does each epic deliver COMPLETE functionality for its domain?
-- Can Epic 2 function without Epic 3 being implemented?
-- Can Epic 3 function standalone using Epic 1 & 2 outputs?
-- ❌ WRONG: Epic 2 requires Epic 3 features to work
-- ✅ RIGHT: Each epic is independently valuable
+The parent workflow owns accepted edits to `epics.md`; the auditor remains read-only.
 
-**Within-Epic Story Dependency Check:**
-For each epic, review stories in order:
+Critical findings demonstrating missing required coverage, impossible dependency order, or an unimplementable plan block completion. High findings may remain only with explicit user risk acceptance.
 
-- Can Story N.1 be completed without Stories N.2, N.3, etc.?
-- Can Story N.2 be completed using only Story N.1 output?
-- Can Story N.3 be completed using only Stories N.1 & N.2 outputs?
-- ❌ WRONG: "This story depends on a future story"
-- ❌ WRONG: Story references features not yet implemented
-- ✅ RIGHT: Each story builds only on previous stories
+### 4. Confirm Material Corrections Once
 
-### 6. Complete and Save
+Material corrections change epic or story boundaries, ordering, requirements coverage, acceptance criteria, or architecture/NFR/UX alignment.
 
-If all validations pass:
+If material corrections were applied, run the same audit contract once more with the same bounded inputs. Write the result to:
 
-- Update any remaining placeholders in the document
-- Ensure proper formatting
-- Save the final epics.md
+`{planning_artifacts}/reviews/delivery-plan-audit-confirmation.md`
+
+Do not start an automatic author-auditor loop. If the confirmation audit still reports critical findings, stop and ask the user how to proceed.
+
+### 5. Complete and Save
+
+Completion requires:
+
+- the audit report exists
+- no unresolved critical findings remain
+- remaining high findings have explicit user risk acceptance
+- accepted corrections are saved in `{planning_artifacts}/epics.md`
+- all placeholders are resolved and formatting is valid
 
 **Present Final Menu:**
-**All validations complete!** [C] Complete Workflow
+
+**Final validation complete.** [C] Complete Workflow
 
 HALT — wait for user input before proceeding.
 
-When C is selected, the workflow is complete and the epics.md is ready for development.
+When C is selected, the workflow is complete and `epics.md` is ready for development.
 
 Epics and Stories complete. Invoke the `bmad-help` skill.
 
-Upon Completion of task output: offer to answer any questions about the Epics and Stories.
+Upon completion of task output, offer to answer questions about the Epics and Stories.
 
 ## On Complete
 


### PR DESCRIPTION
## What

Separates epic/story authoring from final delivery-plan auditing inside
`bmad-create-epics-and-stories`.

The outward-facing agent and user workflow remain unchanged. Internally, final
validation runs under a bounded Delivery Plan Auditor role that receives the
completed `epics.md`, its declared source documents, and an explicit audit
rubric, but not the authoring conversation.

The auditor writes structured findings to a separate artifact and does not
modify `epics.md` directly.

## Why

This is a narrow vertical-slice test of internal modularization beneath stable
outward-facing personas.

The practical motivation is that artifact production and validation can benefit
from different instructions, context boundaries, and objectives. The broader
hypothesis is that selected responsibilities currently bundled inside one
outward-facing role may become more reliable when separated through explicit
interfaces.

This does not propose splitting every workflow. Broader adoption should depend
on demonstrated audit value relative to token, latency, and maintenance cost.

The research basis for this design hypothesis is summarized in #2552.

Fixes #2552

## Testing

- `git diff --check` — passed
- `npm run lint:md` — passed
- `npm run validate:refs` — failed on one unrelated existing reference outside
  the changed workflow
- `npm run validate:skills` — failed on repository-wide `SKILL.md` validation
  findings unrelated to these files