### PR TITLE
chore(dev-auto): restore 'isolate' framing for plan-step exploration

### DIFF
--- a/src/bmm-skills/4-implementation/bmad-dev-auto/step-02-plan.md
+++ b/src/bmm-skills/4-implementation/bmad-dev-auto/step-02-plan.md
@@ -12,7 +12,7 @@ deferred_work_file: '{implementation_artifacts}/deferred-work.md'
 ## INSTRUCTIONS
 
 1. Draft resume check. If `{spec_file}` exists with `status: draft`, read it and capture the verbatim `<intent-contract>...</intent-contract>` block as `preserved_intent_contract`. Otherwise `preserved_intent_contract` is empty.
-2. Investigate codebase. _Use subagents for deep exploration. To prevent context snowballing, instruct subagents to give you distilled summaries only._
+2. Investigate codebase. _Read the code yourself for narrow, localized tasks. Isolate deep exploration in subagents: instruct them to give you distilled summaries only, and plan from those summaries._
 3. Read `./spec-template.md` fully. Fill it out based on the intent and investigation. If `{preserved_intent_contract}` is non-empty, substitute it for the `<intent-contract>` block in your filled spec before writing. Write the result to `{spec_file}`.
 4. Self-review against READY FOR DEVELOPMENT standard.
 5. If intent gaps exist, do not fantasize and do not leave open questions. HALT with status `blocked`, blocking condition `intent gaps`, and include the unanswered questions and evidence gathered.


### PR DESCRIPTION
## What

Rewords the step-02 investigation instruction in `bmad-dev-auto`:

> _Read the code yourself for narrow, localized tasks. Isolate deep exploration in subagents: instruct them to give you distilled summaries only, and plan from those summaries._

## Why

Dev Auto forked quick-dev with the original `Isolate deep exploration in sub-agents/tasks where available` wording, but 682a2005 rewrote it to `Use subagents for deep exploration`. That reads as a compliance step rather than a context-isolation strategy, and produced a new failure mode in unattended runs: the agent spawns an explorer subagent, then explores the same code itself and plans without waiting for the subagent to return — duplicated exploration with zero context compression.

This restores quick-dev's proven "isolate" framing (minus "where available", since dev-auto halts without subagents) and adds two clarifications:

- narrow, localized tasks are read inline by the planning agent — no subagent overhead;
- when exploration is delegated, the plan is built from the returned summaries, which rules out racing ahead of the subagent or repeating its sweep.

Quick Dev keeps its own wording unchanged; it never exhibited this failure mode.

🤖 Generated with [Claude Code](https://claude.com/claude-code)