### PR TITLE
feat(dev-auto): make the implementation handoff deterministic

### DIFF
--- a/src/bmm-skills/4-implementation/bmad-dev-auto/customize.toml
+++ b/src/bmm-skills/4-implementation/bmad-dev-auto/customize.toml
@@ -33,6 +33,25 @@ persistent_facts = [
 
 on_complete = ""
 
+# Handoff for the implementation subagent in step 03. The whole execution
+# recipe — a subagent by default, but an override may run anything (e.g. an
+# external coding tool via bash). {spec_file} is substituted at run time.
+
+implementation_handoff = """
+Launch a subagent with no prior conversation context, with this prompt:
+
+> Read {spec_file} fully and implement it. The spec is the sole source of truth for this change; its Spec Change Log entries are binding constraints, not history.
+>
+> Guardrails:
+>
+> - Work in the current project. Before starting, load every file listed in the spec frontmatter `context:`.
+> - Do not edit the spec file itself.
+> - Do not revert or overwrite changes unrelated to this spec.
+> - Run the verification described in the spec, plus focused checks for the code you touched.
+>
+> When done, report: files changed with one line each, verification commands run and their outcomes, anything you could not complete and why, and residual risks.
+"""
+
 # Review layers for the review step. `instruction` is the layer's whole
 # execution recipe — subagents by default, but an override may run anything
 # (e.g. an external reviewer via bash). {diff_output} is substituted at run

--- a/src/bmm-skills/4-implementation/bmad-dev-auto/step-03-implement.md
+++ b/src/bmm-skills/4-implementation/bmad-dev-auto/step-03-implement.md
@@ -23,9 +23,9 @@ Capture `baseline_revision` (current HEAD, or `NO_VCS` if version control is una
 
 Change `{spec_file}` status to `in-progress` in the frontmatter before starting implementation.
 
-If `{spec_file}` has a non-empty `context:` list in its frontmatter, load those files before implementation begins. When handing to a subagent, include them in the subagent prompt so it has access to the referenced context.
+The implementation handoff is `{workflow.implementation_handoff}`, resolved during activation. Substitute the runtime placeholders (e.g. `{spec_file}`) into it, then follow it verbatim. Do not add parent-authored goal restatements, file lists, ownership boundaries, or acceptance criteria to the handoff — the spec is the subagent's sole source of truth. If the resolved handoff conflicts with the spec, HALT with status `blocked` and blocking condition `handoff conflicts with spec`, and include both conflicting passages.
 
-Hand `{spec_file}` to an implementation subagent. Invoke it **synchronously** and wait for it to return in this same turn — do not background/detach it (`run_in_background`) or end your turn to await a notification (see SKILL.md → Subagents). Resume at "Verify" only after it returns.
+Invoke the subagent **synchronously** and wait for it to return in this same turn — do not background/detach it (`run_in_background`) or end your turn to await a notification (see SKILL.md → Subagents). Resume at "Verify" only after it returns.
 
 **Path formatting rule:** Any markdown links written into `{spec_file}` must use paths relative to `{spec_file}`'s directory so they are clickable in VS Code. Any file paths displayed in terminal/conversation output must use CWD-relative format with `:line` notation (e.g., `src/path/file.ts:42`) for terminal clickability. No leading `/` in either case.
 


### PR DESCRIPTION
## What

Step 3 told the parent to "hand `{spec_file}` to an implementation subagent," leaving the parent to improvise the actual prompt. This replaces that with a deterministic, overridable handoff:

- **`customize.toml`**: new `workflow.implementation_handoff` — a literal execution recipe with `{spec_file}` substituted at run time, same idiom as `workflow.review_layers` (#2550). Default recipe: the subagent reads the spec as the **sole source of truth** (change-log entries binding, not history), loads the spec's `context:` files itself, does not edit the spec, does not revert unrelated changes, runs the spec's verification plus focused checks for touched code, and reports in a fixed shape — files changed, verification outcomes, blockers, residual risks — which is exactly what step-03's Verify section consumes.
- **`step-03`**: resolve the handoff, substitute placeholders, follow it verbatim. Explicit ban on parent-authored goal restatements, file lists, ownership boundaries, or acceptance criteria in the handoff. On conflict between handoff and spec: HALT (`blocked` / `handoff conflicts with spec`) with both passages — never resolved by rewriting the implementation intent. Parent-side context pasting deleted.

## Why

Every improvised handoff is an opportunity for a second, unaudited spec to form — a goal restatement here, an inferred file list there. The bad_spec repair loop depends on the worker re-deriving from the *amended* spec; a parent paraphrasing from memory of the first attempt can quietly undo the amendment. Same principle as the Intent Alignment Auditor receiving the verbatim intent (#2560): restatements smuggle the author's frame. A deterministic handoff also makes runs comparable (variance is attributable to spec and code, not prompt improvisation) and, via the customize mechanism, lets an override route implementation to a different engine entirely — e.g. an external coding CLI via bash — without touching the step file.

The worker still runs verification and the parent still re-runs it afterwards; that duplication is deliberate. The worker's run is its inner fix loop; the parent's run is the mechanical gate — a claim that tests pass is not evidence.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
