### PR TITLE
fix(dev-auto): commit must match the reviewed diff; declare scope expansion

### DIFF
--- a/src/bmm-skills/4-implementation/bmad-dev-auto/customize.toml
+++ b/src/bmm-skills/4-implementation/bmad-dev-auto/customize.toml
@@ -49,7 +49,7 @@ Launch a subagent with no prior conversation context, with this prompt:
 > - Do not revert or overwrite changes unrelated to this spec.
 > - Run the verification described in the spec, plus focused checks for the code you touched.
 >
-> When done, report: files changed with one line each, verification commands run and their outcomes, anything you could not complete and why, and residual risks.
+> When done, report: files changed with one line each, verification commands run and their outcomes, any files changed beyond the spec's tasks and why each was needed, anything you could not complete and why, and residual risks.
 """
 
 # Review layers for the review step. `instruction` is the layer's whole

--- a/src/bmm-skills/4-implementation/bmad-dev-auto/step-04-review.md
+++ b/src/bmm-skills/4-implementation/bmad-dev-auto/step-04-review.md
@@ -86,7 +86,7 @@ Prepare `Auto Run Result` details:
 
 Set `{spec_file}` frontmatter `followup_review_recommended` from the judgment above.
 
-If version control is available, commit. Do not push.
+If version control is available, commit every file in the reviewed diff — tracked and untracked. Do not push. After committing, verify the commit contains each file from the reviewed diff; if any is missing, add it and amend before proceeding. Anything still visible in `git status --porcelain` is by definition not part of the change: leave it in place — do not commit, delete, or gitignore it — and list it under `Auto Run Result` as residual artifacts.
 
 Capture `final_revision` (current HEAD after committing, or `NO_VCS` if version control is unavailable) into `{spec_file}` frontmatter.
 


### PR DESCRIPTION
## What

Two one-line fixes to `bmad-dev-auto`, both from defects observed in a live run:

1. **Commit must match the reviewed diff** (`step-04` Finalize). The commit now explicitly includes every file in the reviewed diff — tracked and untracked — and is verified against the diff's file list afterwards, amending if anything is missing. Anything still visible in `git status --porcelain` after that is by definition not part of the change: it is left in place (never committed, deleted, or gitignored) and declared in the run result as residual artifacts. Enforcement costs zero instructions — step-01's existing clean-tree sanity check blocks the *next* run at zero invested inference, which is the cheap place to fail; the human then repairs the environment defect once (e.g. a missing `.gitignore` entry) and the fix is durable.

2. **Declared scope expansion** (handoff report in `customize.toml`, builds on #2561). The implementation subagent now reports any files changed beyond the spec's tasks and why each was needed. Deliberately witness-not-judge: the worker states facts and reasons, and triage classifies them under the existing intent-authority rule (#2560) — asking the worker whether its own expansion was "required or opportunistic" would invite motivated reasoning and launder expansions with a self-issued "required" stamp. Silent expansion becomes impossible; justified expansion survives with its reasoning on the record.

## Why

Observed in a live run (pylint feature-work task, Opus 4.8): the run created a new test file but left it untracked, so the commit omitted a file the review had approved — `final_revision` claimed to capture the reviewed change and didn't. The same run correctly expanded scope beyond the spec's plan (deeper, repo-native architecture that review confirmed) but with no declaration anywhere distinguishing required expansion from wandering.

Design notes baked into the wording: the invariant checks the actual surface (reviewed-diff file list vs. commit contents) rather than the proxy "tree is clean," which wrongly fails when a run creates unignored junk like `.pytest_cache/`; and neither branch HALTs, because both have mechanical remedies — HALT spends the whole run and is reserved for genuine human-input dependencies.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
