### PR TITLE
perf(dev-auto): make review-layer fan-out atomic

### DIFF
--- a/src/bmm-skills/4-implementation/bmad-dev-auto/step-04-review.md
+++ b/src/bmm-skills/4-implementation/bmad-dev-auto/step-04-review.md
@@ -28,7 +28,7 @@ Skip every layer whose `instruction` is empty or missing — that is how an over
 
 Runtime placeholders: `{diff_output}` is the diff constructed above. `{verbatim_intent}` is the invocation intent exactly as this run received it at step-01; if the run started from an existing spec file rather than a fresh intent, it is the spec's `<intent-contract>` block instead.
 
-Execute all remaining layers in parallel wherever their execution methods allow: substitute the runtime placeholders (e.g. `{diff_output}`) into each layer's `instruction`, then follow it verbatim.
+Execute all remaining layers in parallel wherever their execution methods allow: substitute the runtime placeholders (e.g. `{diff_output}`) into each layer's `instruction`, then follow it verbatim. Spawn every reviewer subagent before reading or reacting to any of their output; begin collection and triage only once all are launched.
 
 ### Classify
 


### PR DESCRIPTION
## What

Tighten the dev-auto review step so reviewer subagents launch as one atomic fan-out.

`step-04-review.md` previously said only to "execute all remaining layers in parallel wherever their execution methods allow" — wording that permits an orchestrator to spawn one reviewer, react to its output, then spawn the next.

## Why

Observed in a real run: four reviewers (adversarial, edge-case, verification-gap, intent-alignment) launched ~2m14s apart end to end because the parent reacted to earlier output before spawning the rest. Pure wall-clock waste with no quality benefit.

## Change

One added sentence:

> Spawn every reviewer subagent before reading or reacting to any of their output; begin collection and triage only once all are launched.

No change to reasoning structure or review discipline — only the launch ordering.

🤖 Generated with [Claude Code](https://claude.com/claude-code)