### PR TITLE
fix(dev-auto): make followup_review_recommended converge

### DIFF
--- a/docs/reference/dev-auto.md
+++ b/docs/reference/dev-auto.md
@@ -114,7 +114,7 @@ On successful completion, the workflow writes or updates the spec with:
   - Review findings breakdown
   - Verification performed
   - Residual risks
-- `followup_review_recommended` flag. True if LLM decided another review pass seems worthwhile. It's a suggestion, not a must. Simplest way to give it a second review pass is to re-run the skill pointing it at the spec file.
+- `followup_review_recommended` flag. Default false; true only when the final review pass leaves a specific unverified risk — a patched high-severity finding, or first-run patches that changed behavior across module boundaries — named under Auto Run Result. Patch volume alone never sets it, and a follow-up pass that patches no new high-severity finding sets it back to false, so repeated re-runs converge. It's a suggestion, not a must. Simplest way to give it a second review pass is to re-run the skill pointing it at the spec file.
 - `baseline_revision` and `final_revision` — HEAD before implementation and after the final commit. Together they bracket the run's commits: `git log baseline_revision..final_revision` lists exactly what it produced, and equal values mean no commits were made. Both are `NO_VCS` when version control is unavailable.
 
 If version control is available, the workflow commits the change. It does not push.

--- a/src/bmm-skills/4-implementation/bmad-dev-auto/spec-template.md
+++ b/src/bmm-skills/4-implementation/bmad-dev-auto/spec-template.md
@@ -4,7 +4,7 @@ type: 'feature' # feature | bugfix | refactor | chore
 created: '{date}'
 status: 'draft' # draft | ready-for-dev | in-progress | in-review | done | blocked
 review_loop_iteration: 0 # incremented by step-04 before each review loopback
-followup_review_recommended: false # set by step-04 on status: done from the final review pass significance judgment
+followup_review_recommended: false # set by step-04 at done; true ONLY for a named unverified risk (high patch, or first-run cross-module behavioral patches) — never from patch volume
 context: [] # optional: `{project-root}/`-prefixed paths to project-wide standards/docs the implementation agent should load. Keep short — only what isn't already distilled into the spec body.
 warnings: [] # optional: machine-readable warnings for orchestration, e.g. oversized, multiple-goals
 ---

--- a/src/bmm-skills/4-implementation/bmad-dev-auto/step-04-review.md
+++ b/src/bmm-skills/4-implementation/bmad-dev-auto/step-04-review.md
@@ -80,7 +80,11 @@ Prepare `Auto Run Result` details:
 - Summary of implemented change
 - Files changed with one-line descriptions
 - Review findings breakdown: patches applied, items deferred, items rejected
-- Follow-up review recommendation: `true` when the final review pass made review-driven changes significant enough to benefit from an independent follow-up review; otherwise `false`. Use judgment, not a fixed numeric threshold. Base the judgment on the final pass's triage log and fixes, including patched-finding volume, consequence/severity, breadth, behavior/API/security/data impact, and implementation complexity. Many low-severity patched findings can be significant by volume. Do not recommend follow-up for only a few localized low-consequence fixes.
+- Follow-up review recommendation: default `false`. Judge only from this session's final `## Review Triage Log` entry — the one this pass appended; earlier loopback entries do not count. Set `true` ONLY when:
+  - (a) this pass patched a `high` finding, or
+  - (b) this is a first run — `{spec_file}` frontmatter `final_revision` not yet present (only a completed prior run sets it) — and this pass's patches changed runtime behavior across module boundaries. Patches land after step-03's verification and are never re-verified, so such changes are unverified by definition. Cosmetic or non-behavioral patches (naming, comments, formatting, message text) do not qualify.
+
+  If `final_revision` is already present, this session is itself the follow-up review: without a patched `high` finding, set `false` — the work has converged. Record any remaining nameable polish in `{deferred_work_file}` using the defer entry format above (permitted here even though it is this story's own residue, not pre-existing). Patch volume is NEVER grounds for `true`: `low`/`medium` patches outside (b) are settled work regardless of count. A `true` recommendation MUST name the specific unverified risk under `Auto Run Result`; if none can be named, it is `false`. Do not recommend a follow-up merely because this pass made review-driven changes — every pass does.
 - Verification performed, including command outcomes or manual inspection notes
 - Any residual risks
 


### PR DESCRIPTION
## What

Replace the `Follow-up review recommendation` rule in `bmad-dev-auto` step-04 Finalize so `followup_review_recommended` converges: default `false`; `true` ONLY for (a) a patched `high` finding, or (b) first-run patches that changed runtime behavior across module boundaries — with the unverified risk named under `Auto Run Result`. A follow-up pass without a new `high` patch sets `false` and routes residual polish to the deferred-work ledger. Sync `spec-template.md` frontmatter comment and `docs/reference/dev-auto.md`.

## Why

Fixes #2576. Step-04 auto-applies every `patch` finding, and the old rule judged "significant review-driven changes" from those very patches — pass N's patches justified pass N+1 forever. Observed: 10/10 stories burned the full 3-cycle driver budget while verify-green with zero high/intent_gap/bad_spec from round 1.

## How

Deviations from the issue's proposed text: first-run-ness is folded into clause (b), so the follow-up case needs no precedence language; the follow-up detector is `final_revision` presence (durable across a crashed follow-up resumed at `in-review`, and `NO_VCS`) rather than "arrived with status `done`"; the "zero intent_gap / zero bad_spec" conditions are dropped (structurally guaranteed at Finalize — those routes never reach it); and (b) states patches are never re-verified rather than implying they "ran green" — step-04 runs no verification. Post-patch re-verification is deliberately out of scope: candidate follow-up issue.

## Testing

`npm run lint:md`, `npm run validate:skills`, `npm run docs:validate-links` green; pre-commit ran full `npm test` and the docs build.

🤖 Generated with [Claude Code](https://claude.com/claude-code)