### PR TITLE
fix(installer): preserve existing core config (#2435)

### DIFF
--- a/test/test-installation-components.js
+++ b/test/test-installation-components.js
@@ -3615,6 +3615,48 @@ async function runTests() {
   console.log('');
 
   // ============================================================
+  // Test Suite 49: CLI core overrides preserve existing config (#2435)
+  // ============================================================
+  console.log(`${colors.yellow}Test Suite 49: CLI core overrides preserve existing config${colors.reset}\n`);
+
+  let root49;
+  try {
+    const { UI } = require('../tools/installer/ui');
+    root49 = await fs.mkdtemp(path.join(os.tmpdir(), 'bmad-core-override-'));
+    const bmadDir49 = path.join(root49, '_bmad');
+    await fs.ensureDir(path.join(bmadDir49, '_config'));
+    await fs.writeFile(path.join(bmadDir49, '_config', 'manifest.yaml'), 'installation:\n  version: 6.10.0\n', 'utf8');
+    await fs.writeFile(
+      path.join(bmadDir49, 'config.toml'),
+      '[core]\nproject_name = "Existing Project"\ndocument_output_language = "French"\noutput_folder = "existing-output"\n',
+      'utf8',
+    );
+    await fs.writeFile(path.join(bmadDir49, 'config.user.toml'), '[core]\nuser_name = "Existing User"\n', 'utf8');
+
+    const { moduleConfigs } = await new UI().collectModuleConfigs(root49, ['core'], {
+      userName: 'Updated User',
+      communicationLanguage: 'Spanish',
+      documentOutputLanguage: 'English',
+      outputFolder: 'updated-output',
+      yes: true,
+    });
+
+    assert(moduleConfigs.core.project_name === 'Existing Project', 'CLI core overrides preserve existing project_name');
+    assert(moduleConfigs.core.user_name === 'Updated User', 'CLI core overrides replace explicitly supplied user_name');
+    assert(moduleConfigs.core.communication_language === 'Spanish', 'CLI core overrides add explicitly supplied communication language');
+    assert(moduleConfigs.core.document_output_language === 'English', 'CLI core overrides replace document output language');
+    assert(moduleConfigs.core.output_folder === 'updated-output', 'CLI core overrides replace output folder');
+  } catch (error) {
+    console.log(`${colors.red}Test Suite 49 setup failed: ${error.message}${colors.reset}`);
+    console.log(error.stack);
+    failed++;
+  } finally {
+    if (root49) await fs.remove(root49).catch(() => {});
+  }
+
+  console.log('');
+
+  // ============================================================
   // Summary
   // ============================================================
   console.log(`${colors.cyan}========================================`);

--- a/tools/installer/ui.js
+++ b/tools/installer/ui.js
@@ -830,7 +830,7 @@ class UI {
 
       // Load existing config to merge with provided options
       await configCollector.loadExistingConfig(directory);
-      const existingConfig = configCollector.collectedConfig.core || {};
+      const existingConfig = configCollector._existingConfig?.core || {};
       configCollector.collectedConfig.core = { ...existingConfig, ...coreConfig };
 
       // If not all options are provided, collect the missing ones interactively (unless --yes flag)


### PR DESCRIPTION
## What
Preserve existing core configuration when an update supplies core command-line overrides. Add regression coverage for the update path.

## Why
The existing configuration loader stores prior values separately, but the override merge read the new collection instead. As a result, values such as `project_name` were dropped.

Fixes #2435

## How
- Merge supplied overrides on top of the loaded core configuration
- Cover preserved values and explicit replacements through the installer UI path

## Testing
- `npm ci`
- `npm run test:install`
- `npm run quality`
