### PR TITLE
fix(installer): complete partial headless defaults

### DIFF
--- a/test/test-installation-components.js
+++ b/test/test-installation-components.js
@@ -3615,6 +3615,139 @@ async function runTests() {
   console.log('');
 
   // ============================================================
+  // Test Suite 49: partial headless core CLI defaults
+  // ============================================================
+  console.log(`${colors.yellow}Test Suite 49: partial headless core CLI defaults${colors.reset}\n`);
+
+  {
+    const { UI } = require('../tools/installer/ui');
+    const fixtureRoot49 = await fs.mkdtemp(path.join(os.tmpdir(), 'bmad-partial-cli-defaults-'));
+
+    try {
+      const ui49 = new UI();
+      const { moduleConfigs: partialConfigs49 } = await ui49.collectModuleConfigs(fixtureRoot49, ['bmm'], {
+        yes: true,
+        userName: 'CLI User',
+        communicationLanguage: 'French',
+        documentOutputLanguage: 'Spanish',
+      });
+
+      assert(partialConfigs49.core.user_name === 'CLI User', 'partial --yes preserves the explicit user name');
+      assert(partialConfigs49.core.communication_language === 'French', 'partial --yes preserves the explicit communication language');
+      assert(partialConfigs49.core.document_output_language === 'Spanish', 'partial --yes preserves the explicit document output language');
+      assert(
+        partialConfigs49.core.project_name === path.basename(fixtureRoot49),
+        'partial --yes defaults the omitted project name from the target directory',
+      );
+      assert(partialConfigs49.core.output_folder === '_bmad-output', 'partial --yes defaults the omitted output folder');
+      assert(
+        partialConfigs49.bmm.planning_artifacts === '{project-root}/_bmad-output/planning-artifacts',
+        'partial --yes resolves BMM planning artifacts beneath the default output folder',
+      );
+      assert(
+        partialConfigs49.bmm.implementation_artifacts === '{project-root}/_bmad-output/implementation-artifacts',
+        'partial --yes resolves BMM implementation artifacts beneath the default output folder',
+      );
+      assert(
+        !JSON.stringify(partialConfigs49).includes('{output_folder}'),
+        'partial --yes leaves no unresolved output_folder placeholders',
+      );
+
+      const customOutputRoot49 = path.join(fixtureRoot49, 'custom-output');
+      await fs.ensureDir(customOutputRoot49);
+      const { moduleConfigs: customConfigs49 } = await new UI().collectModuleConfigs(customOutputRoot49, ['bmm'], {
+        yes: true,
+        userName: 'CLI User',
+        outputFolder: 'generated',
+      });
+
+      assert(customConfigs49.core.output_folder === 'generated', 'partial --yes preserves an explicit output folder');
+      assert(
+        customConfigs49.core.communication_language === 'English' && customConfigs49.core.document_output_language === 'English',
+        'partial --yes completes omitted language fields alongside explicit values',
+      );
+      assert(
+        customConfigs49.bmm.planning_artifacts === '{project-root}/generated/planning-artifacts',
+        'partial --yes resolves BMM paths beneath the explicit output folder',
+      );
+
+      const originalUserInfo49 = os.userInfo;
+      os.userInfo = () => ({ username: 'fixture-user' });
+      try {
+        const usernameDefaultRoot49 = path.join(fixtureRoot49, 'username-default');
+        await fs.ensureDir(usernameDefaultRoot49);
+        const { moduleConfigs: usernameDefaultConfigs49 } = await new UI().collectModuleConfigs(usernameDefaultRoot49, ['bmm'], {
+          yes: true,
+          outputFolder: 'generated',
+        });
+        assert(
+          usernameDefaultConfigs49.core.user_name === 'Fixture-user',
+          'partial --yes defaults an omitted user name from the system account',
+        );
+      } finally {
+        os.userInfo = originalUserInfo49;
+      }
+
+      const existingRoot49 = path.join(fixtureRoot49, 'existing-install');
+      const existingBmadDir49 = path.join(existingRoot49, '_bmad');
+      await fs.ensureDir(path.join(existingBmadDir49, '_config'));
+      await fs.writeFile(path.join(existingBmadDir49, '_config', 'manifest.yaml'), 'modules: []\n', 'utf8');
+      await fs.writeFile(
+        path.join(existingBmadDir49, 'config.toml'),
+        '[core]\nproject_name = "Existing Project"\ndocument_output_language = "German"\noutput_folder = "existing-output"\n',
+        'utf8',
+      );
+      await fs.writeFile(
+        path.join(existingBmadDir49, 'config.user.toml'),
+        '[core]\nuser_name = "Existing User"\ncommunication_language = "Italian"\n',
+        'utf8',
+      );
+
+      const { moduleConfigs: existingConfigs49 } = await new UI().collectModuleConfigs(existingRoot49, ['bmm'], {
+        yes: true,
+        userName: 'CLI Override',
+      });
+
+      assert(existingConfigs49.core.user_name === 'CLI Override', 'explicit CLI values override existing core configuration');
+      assert(
+        existingConfigs49.core.communication_language === 'Italian' && existingConfigs49.core.output_folder === 'existing-output',
+        'existing core values override headless defaults for omitted CLI fields',
+      );
+      assert(
+        existingConfigs49.bmm.planning_artifacts === '{project-root}/existing-output/planning-artifacts',
+        'BMM paths resolve from preserved existing core configuration',
+      );
+
+      const partialExistingRoot49 = path.join(fixtureRoot49, 'partial-existing-install');
+      const partialExistingBmadDir49 = path.join(partialExistingRoot49, '_bmad');
+      await fs.ensureDir(path.join(partialExistingBmadDir49, '_config'));
+      await fs.writeFile(path.join(partialExistingBmadDir49, '_config', 'manifest.yaml'), 'modules: []\n', 'utf8');
+      await fs.writeFile(path.join(partialExistingBmadDir49, 'config.toml'), '[core]\nproject_name = "Partial Existing Project"\n', 'utf8');
+
+      const { moduleConfigs: partialExistingConfigs49 } = await new UI().collectModuleConfigs(partialExistingRoot49, ['bmm'], {
+        yes: true,
+      });
+
+      assert(
+        partialExistingConfigs49.core.project_name === 'Partial Existing Project',
+        'headless --yes preserves a partial existing core configuration without CLI overrides',
+      );
+      assert(
+        partialExistingConfigs49.core.output_folder === '_bmad-output',
+        'headless --yes completes omitted fields in a partial existing core configuration',
+      );
+      assert(
+        partialExistingConfigs49.bmm.planning_artifacts === '{project-root}/_bmad-output/planning-artifacts',
+        'headless --yes resolves BMM paths after completing a partial existing core configuration',
+      );
+    } finally {
+      await fs.remove(fixtureRoot49).catch(() => {});
+    }
+  }
+
+  console.log('');
+
+  // ============================================================
   // Summary
   // ============================================================
   console.log(`${colors.cyan}========================================`);

--- a/tools/installer/ui.js
+++ b/tools/installer/ui.js
@@ -807,6 +807,26 @@ class UI {
     }
 
     const configCollector = new OfficialModules({ channelOptions: options.channelOptions });
+    let headlessCoreDefaults = {};
+
+    if (options.yes) {
+      let safeUsername;
+      try {
+        safeUsername = os.userInfo().username;
+      } catch {
+        safeUsername = process.env.USER || process.env.USERNAME || 'User';
+      }
+      const defaultUsername = safeUsername.charAt(0).toUpperCase() + safeUsername.slice(1);
+      headlessCoreDefaults = {
+        user_name: defaultUsername,
+        // {directory_name} default per src/core-skills/module.yaml — matches what the
+        // interactive flow resolves via buildQuestion()'s {directory_name} placeholder.
+        project_name: path.basename(directory),
+        communication_language: 'English',
+        document_output_language: 'English',
+        output_folder: '_bmad-output',
+      };
+    }
 
     // Seed core config from CLI options if provided
     if (options.userName || options.communicationLanguage || options.documentOutputLanguage || options.outputFolder) {
@@ -830,8 +850,8 @@ class UI {
 
       // Load existing config to merge with provided options
       await configCollector.loadExistingConfig(directory);
-      const existingConfig = configCollector.collectedConfig.core || {};
-      configCollector.collectedConfig.core = { ...existingConfig, ...coreConfig };
+      const existingConfig = configCollector.existingConfig?.core || {};
+      configCollector.collectedConfig.core = { ...headlessCoreDefaults, ...existingConfig, ...coreConfig };
 
       // If not all options are provided, collect the missing ones interactively (unless --yes flag)
       if (
@@ -843,27 +863,12 @@ class UI {
     } else if (options.yes) {
       // Use all defaults when --yes flag is set
       await configCollector.loadExistingConfig(directory);
-      const existingConfig = configCollector.collectedConfig.core || {};
+      const existingConfig = configCollector.existingConfig?.core || {};
 
       if (Object.keys(existingConfig).length === 0) {
-        let safeUsername;
-        try {
-          safeUsername = os.userInfo().username;
-        } catch {
-          safeUsername = process.env.USER || process.env.USERNAME || 'User';
-        }
-        const defaultUsername = safeUsername.charAt(0).toUpperCase() + safeUsername.slice(1);
-        configCollector.collectedConfig.core = {
-          user_name: defaultUsername,
-          // {directory_name} default per src/core-skills/module.yaml — matches what the
-          // interactive flow resolves via buildQuestion()'s {directory_name} placeholder.
-          project_name: path.basename(directory),
-          communication_language: 'English',
-          document_output_language: 'English',
-          output_folder: '_bmad-output',
-        };
         await prompts.log.info('Using default configuration (--yes flag)');
       }
+      configCollector.collectedConfig.core = { ...headlessCoreDefaults, ...existingConfig };
     }
 
     // Collect all module configs — core is skipped if already seeded above


### PR DESCRIPTION
## What

Complete omitted core configuration defaults when `--yes` is combined with partial CLI options. This prevents BMM artifact paths from retaining `{output_folder}` and creating a literal directory with that name.

## Why

The partial CLI-options branch bypassed the complete headless-default branch. A command such as `bmad install --yes --user-name Alex` therefore omitted `core.output_folder`. This is a regression of #1962.

## How

- Build the full headless core default layer whenever prompts are disabled.
- Merge defaults, persisted configuration, and explicit CLI values in precedence order.
- Cover fresh partial options, custom output paths, username defaults, and existing partial configurations.

## Testing

- Reproduced the literal `{output_folder}` directory on `main`.
- Re-ran the same installer command and confirmed `_bmad-output/planning-artifacts` and `_bmad-output/implementation-artifacts` are created instead.
- Ran `npm ci && npm run quality` successfully on the committed HEAD.
