### PR TITLE
fix(skills): HALT renderers on missing config keys and bad overrides

### DIFF
--- a/src/bmm-skills/4-implementation/bmad-dev-auto/render.py
+++ b/src/bmm-skills/4-implementation/bmad-dev-auto/render.py
@@ -12,7 +12,10 @@ files to {project-root}/_bmad/render/bmad-dev-auto/.
 Config: four-layer merge of _bmad/config.toml + config.user.toml +
 custom/config.toml + custom/config.user.toml (post-#2285 installs).
 Keys surface from [core] and [modules.bmm]. Missing or unparseable
-config.toml → HALT.
+config.toml → HALT. A {{.var}} referenced by this skill's .md sources but
+absent from the merged config → HALT (never a silent empty substitution).
+Optional layers may be missing, but one that exists and cannot be parsed
+or read → HALT.
 
 Customization: three-layer merge of {skill}/customize.toml +
 _bmad/custom/bmad-dev-auto.toml + .user.toml (same structural rules as
@@ -50,10 +53,12 @@ def find_project_root():
 
 
 def load_toml(path, required=False):
-    """Load a TOML file. For required files, HALT (stdout) on missing/parse
-    error so the LLM-driven workflow stops — stdout is how this script signals
-    workflow halts to its LLM caller. For optional files, write a stderr
-    warning and return {}."""
+    """Load a TOML file. Only absence is negotiable: a missing optional file
+    returns {} (customization layers are optional), a missing required file
+    HALTs. A file that exists but cannot be parsed or read always HALTs —
+    stdout is how this script signals workflow halts to its LLM caller — the
+    user wrote it to be honored, and silently continuing with {} would discard
+    their customizations with no failure signal."""
     if not os.path.isfile(path):
         if required:
             print(
@@ -66,17 +71,11 @@ def load_toml(path, required=False):
         with open(path, "rb") as fh:
             parsed = tomllib.load(fh)
     except tomllib.TOMLDecodeError as error:
-        if required:
-            print(f"HALT and report to the user: failed to parse {path}: {error}")
-            sys.exit(1)
-        print(f"render.py: warning: failed to parse {path}: {error}", file=sys.stderr)
-        return {}
+        print(f"HALT and report to the user: failed to parse {path}: {error}")
+        sys.exit(1)
     except OSError as error:
-        if required:
-            print(f"HALT and report to the user: failed to read {path}: {error}")
-            sys.exit(1)
-        print(f"render.py: warning: failed to read {path}: {error}", file=sys.stderr)
-        return {}
+        print(f"HALT and report to the user: failed to read {path}: {error}")
+        sys.exit(1)
     if not isinstance(parsed, dict):
         return {}
     return parsed
@@ -160,7 +159,7 @@ def resolve_workflow(root, skill_dir, skill_name):
     """Resolve the [workflow] customization block via the three-layer merge
     (skill defaults -> team -> user), highest priority last. Same structural
     rules as resolve_customization.py. All three layers are optional: a missing
-    or unparseable file warns (via load_toml) and is skipped."""
+    file is skipped, but an unparseable one HALTs (via load_toml)."""
     defaults = load_toml(posixpath.join(skill_dir, "customize.toml"))
     custom_dir = posixpath.join(root, "_bmad", "custom")
     team = load_toml(posixpath.join(custom_dir, f"{skill_name}.toml"))
@@ -205,9 +204,25 @@ def flatten_central_config(merged):
 
 
 def render_template(content, vars_):
-    """Resolve {{.var}} substitutions. Unresolved references emit an empty string
-    (Go's missingkey=zero semantics)."""
+    """Resolve {{.var}} substitutions. Unresolved references emit an empty string,
+    but main() HALTs on any missing reference before rendering starts, so this
+    fallback never fires in practice."""
     return re.sub(r"\{\{\.(\w+)\}\}", lambda m: vars_.get(m.group(1), ""), content)
+
+
+def collect_missing_vars(sources, vars_):
+    """Map each {{.var}} name referenced by the source .md files but absent from
+    the merged config to the files that reference it. A missing key must HALT:
+    missingkey=zero rendering would bake a corrupted workflow (empty paths,
+    blank language lines) with no failure signal."""
+    missing = {}
+    for fname, content in sources:
+        for name in re.findall(r"\{\{\.(\w+)\}\}", content):
+            if name not in vars_:
+                files = missing.setdefault(name, [])
+                if fname not in files:
+                    files.append(fname)
+    return missing
 
 
 def _scalar_str(value):
@@ -305,6 +320,9 @@ def main():
 
     vars_["project_root"] = root
 
+    # Guarded ahead of the general missing-vars scan: sprint_status and
+    # deferred_work_file derive from it below, and unlike the scan (absent
+    # keys only) this also HALTs on a present-but-empty value.
     implementation_artifacts = vars_.get("implementation_artifacts", "").strip()
     if not implementation_artifacts:
         print(
@@ -320,6 +338,27 @@ def main():
         implementation_artifacts, "deferred-work.md"
     )
 
+    sources = []
+    for fname in sorted(os.listdir(script_dir)):
+        if not fname.endswith(".md") or fname == "SKILL.md":
+            continue
+        with open(
+            posixpath.join(script_dir, fname), "r", encoding="utf-8", newline=""
+        ) as fh:
+            sources.append((fname, fh.read()))
+
+    missing = collect_missing_vars(sources, vars_)
+    if missing:
+        details = "; ".join(
+            f"`{name}` (referenced by {', '.join(files)})"
+            for name, files in sorted(missing.items())
+        )
+        print(
+            f"HALT and report to the user: config is missing {details} "
+            "(expected under [core] or [modules.bmm] in _bmad/config.toml)"
+        )
+        sys.exit(1)
+
     workflow = resolve_workflow(root, script_dir.replace(os.sep, "/"), skill_name)
 
     out_dir = posixpath.join(root, "_bmad", "render", skill_name)
@@ -329,13 +368,8 @@ def main():
         if fname.endswith(".md"):
             os.remove(posixpath.join(out_dir, fname))
 
-    for fname in sorted(os.listdir(script_dir)):
-        if not fname.endswith(".md") or fname == "SKILL.md":
-            continue
-        src = posixpath.join(script_dir, fname)
+    for fname, content in sources:
         dst = posixpath.join(out_dir, fname)
-        with open(src, "r", encoding="utf-8", newline="") as fh:
-            content = fh.read()
         with open(dst, "w", encoding="utf-8", newline="") as fh:
             fh.write(render_workflow(render_template(content, vars_), workflow))
 

--- a/src/bmm-skills/4-implementation/bmad-quick-dev/render.py
+++ b/src/bmm-skills/4-implementation/bmad-quick-dev/render.py
@@ -12,7 +12,10 @@ files to {project-root}/_bmad/render/bmad-quick-dev/.
 Config: four-layer merge of _bmad/config.toml + config.user.toml +
 custom/config.toml + custom/config.user.toml (post-#2285 installs).
 Keys surface from [core] and [modules.bmm]. Missing or unparseable
-config.toml → HALT.
+config.toml → HALT. A {{.var}} referenced by this skill's .md sources but
+absent from the merged config → HALT (never a silent empty substitution).
+Optional layers may be missing, but one that exists and cannot be parsed
+or read → HALT.
 
 Customization: three-layer merge of {skill}/customize.toml +
 _bmad/custom/bmad-quick-dev.toml + .user.toml (same structural rules as
@@ -50,10 +53,12 @@ def find_project_root():
 
 
 def load_toml(path, required=False):
-    """Load a TOML file. For required files, HALT (stdout) on missing/parse
-    error so the LLM-driven workflow stops — stdout is how this script signals
-    workflow halts to its LLM caller. For optional files, write a stderr
-    warning and return {}."""
+    """Load a TOML file. Only absence is negotiable: a missing optional file
+    returns {} (customization layers are optional), a missing required file
+    HALTs. A file that exists but cannot be parsed or read always HALTs —
+    stdout is how this script signals workflow halts to its LLM caller — the
+    user wrote it to be honored, and silently continuing with {} would discard
+    their customizations with no failure signal."""
     if not os.path.isfile(path):
         if required:
             print(
@@ -66,17 +71,11 @@ def load_toml(path, required=False):
         with open(path, "rb") as fh:
             parsed = tomllib.load(fh)
     except tomllib.TOMLDecodeError as error:
-        if required:
-            print(f"HALT and report to the user: failed to parse {path}: {error}")
-            sys.exit(1)
-        print(f"render.py: warning: failed to parse {path}: {error}", file=sys.stderr)
-        return {}
+        print(f"HALT and report to the user: failed to parse {path}: {error}")
+        sys.exit(1)
     except OSError as error:
-        if required:
-            print(f"HALT and report to the user: failed to read {path}: {error}")
-            sys.exit(1)
-        print(f"render.py: warning: failed to read {path}: {error}", file=sys.stderr)
-        return {}
+        print(f"HALT and report to the user: failed to read {path}: {error}")
+        sys.exit(1)
     if not isinstance(parsed, dict):
         return {}
     return parsed
@@ -160,7 +159,7 @@ def resolve_workflow(root, skill_dir, skill_name):
     """Resolve the [workflow] customization block via the three-layer merge
     (skill defaults -> team -> user), highest priority last. Same structural
     rules as resolve_customization.py. All three layers are optional: a missing
-    or unparseable file warns (via load_toml) and is skipped."""
+    file is skipped, but an unparseable one HALTs (via load_toml)."""
     defaults = load_toml(posixpath.join(skill_dir, "customize.toml"))
     custom_dir = posixpath.join(root, "_bmad", "custom")
     team = load_toml(posixpath.join(custom_dir, f"{skill_name}.toml"))
@@ -205,9 +204,25 @@ def flatten_central_config(merged):
 
 
 def render_template(content, vars_):
-    """Resolve {{.var}} substitutions. Unresolved references emit an empty string
-    (Go's missingkey=zero semantics)."""
+    """Resolve {{.var}} substitutions. Unresolved references emit an empty string,
+    but main() HALTs on any missing reference before rendering starts, so this
+    fallback never fires in practice."""
     return re.sub(r"\{\{\.(\w+)\}\}", lambda m: vars_.get(m.group(1), ""), content)
+
+
+def collect_missing_vars(sources, vars_):
+    """Map each {{.var}} name referenced by the source .md files but absent from
+    the merged config to the files that reference it. A missing key must HALT:
+    missingkey=zero rendering would bake a corrupted workflow (empty paths,
+    blank language lines) with no failure signal."""
+    missing = {}
+    for fname, content in sources:
+        for name in re.findall(r"\{\{\.(\w+)\}\}", content):
+            if name not in vars_:
+                files = missing.setdefault(name, [])
+                if fname not in files:
+                    files.append(fname)
+    return missing
 
 
 def _scalar_str(value):
@@ -305,6 +320,9 @@ def main():
 
     vars_["project_root"] = root
 
+    # Guarded ahead of the general missing-vars scan: sprint_status and
+    # deferred_work_file derive from it below, and unlike the scan (absent
+    # keys only) this also HALTs on a present-but-empty value.
     implementation_artifacts = vars_.get("implementation_artifacts", "").strip()
     if not implementation_artifacts:
         print(
@@ -320,6 +338,27 @@ def main():
         implementation_artifacts, "deferred-work.md"
     )
 
+    sources = []
+    for fname in sorted(os.listdir(script_dir)):
+        if not fname.endswith(".md") or fname == "SKILL.md":
+            continue
+        with open(
+            posixpath.join(script_dir, fname), "r", encoding="utf-8", newline=""
+        ) as fh:
+            sources.append((fname, fh.read()))
+
+    missing = collect_missing_vars(sources, vars_)
+    if missing:
+        details = "; ".join(
+            f"`{name}` (referenced by {', '.join(files)})"
+            for name, files in sorted(missing.items())
+        )
+        print(
+            f"HALT and report to the user: config is missing {details} "
+            "(expected under [core] or [modules.bmm] in _bmad/config.toml)"
+        )
+        sys.exit(1)
+
     workflow = resolve_workflow(root, script_dir.replace(os.sep, "/"), skill_name)
 
     out_dir = posixpath.join(root, "_bmad", "render", skill_name)
@@ -329,13 +368,8 @@ def main():
         if fname.endswith(".md"):
             os.remove(posixpath.join(out_dir, fname))
 
-    for fname in sorted(os.listdir(script_dir)):
-        if not fname.endswith(".md") or fname == "SKILL.md":
-            continue
-        src = posixpath.join(script_dir, fname)
+    for fname, content in sources:
         dst = posixpath.join(out_dir, fname)
-        with open(src, "r", encoding="utf-8", newline="") as fh:
-            content = fh.read()
         with open(dst, "w", encoding="utf-8", newline="") as fh:
             fh.write(render_workflow(render_template(content, vars_), workflow))
 

--- a/test/test-dev-auto-renderer.js
+++ b/test/test-dev-auto-renderer.js
@@ -82,6 +82,24 @@ function copyDirSync(src, dst) {
   }
 }
 
+// Extra one-off temp projects created by makeProject(); cleaned up in finally.
+const extraTmpDirs = [];
+
+/**
+ * Spin up an isolated temp project with the given _bmad/config.toml body and a
+ * copy of the skill dir, so a single bad-config scenario can be rendered in
+ * isolation. Returns { dir, skillDst }; the caller runs render.py against it.
+ */
+function makeProject(configText) {
+  const dir = fs.mkdtempSync(path.join(os.tmpdir(), 'bmad-dev-auto-renderer-halt-'));
+  extraTmpDirs.push(dir);
+  fs.mkdirSync(path.join(dir, '_bmad'), { recursive: true });
+  fs.writeFileSync(path.join(dir, '_bmad', 'config.toml'), configText, 'utf-8');
+  const skillDst = path.join(dir, 'bmad-dev-auto');
+  copyDirSync(SKILL_SRC, skillDst);
+  return { dir, skillDst };
+}
+
 // ---------------------------------------------------------------------------
 // Test fixture setup
 // ---------------------------------------------------------------------------
@@ -315,8 +333,60 @@ try {
     const leaks = renderedMdFiles().filter((f) => readRendered(f).includes('resolve_customization.py'));
     assert(leaks.length === 0, `resolve_customization.py still referenced in: ${leaks.join(', ')}`);
   });
+
+  // ---------------------------------------------------------------------------
+  // Bad-config HALTs cleanly (never a raw Python traceback)
+  // ---------------------------------------------------------------------------
+
+  test('missing planning_artifacts HALTs cleanly (no traceback)', () => {
+    // implementation_artifacts is present, so this exercises the general
+    // missing-vars scan rather than the dedicated guard.
+    const { skillDst: dst } = makeProject(
+      [
+        '[core]',
+        'communication_language = "French"',
+        'document_output_language = "Klingon"',
+        'implementation_artifacts = "{project-root}/impl"',
+      ].join('\n'),
+    );
+    const res = spawnSync('python3', [path.join(dst, 'render.py')], { cwd: dst, encoding: 'utf-8' });
+    assert(res.status === 1, `expected exit 1, got ${res.status}\nstdout: ${res.stdout}\nstderr: ${res.stderr}`);
+    assert(
+      res.stdout.includes('HALT and report to the user: config is missing') && res.stdout.includes('`planning_artifacts`'),
+      `stdout missing the planning_artifacts HALT directive.\nstdout: ${res.stdout}`,
+    );
+    assert(
+      res.stdout.includes('step-01-clarify-and-route.md'),
+      `HALT directive does not name the referencing file.\nstdout: ${res.stdout}`,
+    );
+    assert(!res.stderr.includes('Traceback'), `renderer crashed with a traceback instead of HALTing:\n${res.stderr}`);
+  });
+
+  test('unparseable customization override HALTs cleanly (no traceback)', () => {
+    const { dir, skillDst: dst } = makeProject(
+      [
+        '[core]',
+        'communication_language = "French"',
+        'document_output_language = "Klingon"',
+        'planning_artifacts = "{project-root}/plan"',
+        'implementation_artifacts = "{project-root}/impl"',
+      ].join('\n'),
+    );
+    fs.mkdirSync(path.join(dir, '_bmad', 'custom'), { recursive: true });
+    fs.writeFileSync(path.join(dir, '_bmad', 'custom', 'bmad-dev-auto.user.toml'), '[workflow\non_complete = broken', 'utf-8');
+    const res = spawnSync('python3', [path.join(dst, 'render.py')], { cwd: dst, encoding: 'utf-8' });
+    assert(res.status === 1, `expected exit 1, got ${res.status}\nstdout: ${res.stdout}\nstderr: ${res.stderr}`);
+    assert(
+      res.stdout.includes('HALT and report to the user: failed to parse') && res.stdout.includes('bmad-dev-auto.user.toml'),
+      `stdout missing the failed-to-parse HALT directive naming the override file.\nstdout: ${res.stdout}`,
+    );
+    assert(!res.stderr.includes('Traceback'), `renderer crashed with a traceback instead of HALTing:\n${res.stderr}`);
+  });
 } finally {
   fs.rmSync(tmpDir, { recursive: true, force: true });
+  for (const dir of extraTmpDirs) {
+    fs.rmSync(dir, { recursive: true, force: true });
+  }
 }
 
 // ---------------------------------------------------------------------------

--- a/test/test-quick-dev-renderer.js
+++ b/test/test-quick-dev-renderer.js
@@ -328,9 +328,62 @@ try {
     assert(!res.stderr.includes('Traceback'), `renderer crashed with a traceback instead of HALTing:\n${res.stderr}`);
   });
 
+  test('missing planning_artifacts HALTs cleanly (no traceback)', () => {
+    // implementation_artifacts is present, so this exercises the general
+    // missing-vars scan rather than the dedicated guard.
+    const { skillDst: dst } = makeProject(
+      [
+        '[core]',
+        'communication_language = "French"',
+        'document_output_language = "Klingon"',
+        'implementation_artifacts = "{project-root}/impl"',
+      ].join('\n'),
+    );
+    const res = spawnSync('python3', [path.join(dst, 'render.py')], { cwd: dst, encoding: 'utf-8' });
+    assert(res.status === 1, `expected exit 1, got ${res.status}\nstdout: ${res.stdout}\nstderr: ${res.stderr}`);
+    assert(
+      res.stdout.includes('HALT and report to the user: config is missing') && res.stdout.includes('`planning_artifacts`'),
+      `stdout missing the planning_artifacts HALT directive.\nstdout: ${res.stdout}`,
+    );
+    assert(
+      res.stdout.includes('step-01-clarify-and-route.md'),
+      `HALT directive does not name the referencing file.\nstdout: ${res.stdout}`,
+    );
+    assert(!res.stderr.includes('Traceback'), `renderer crashed with a traceback instead of HALTing:\n${res.stderr}`);
+  });
+
+  test('unparseable customization override HALTs cleanly (no traceback)', () => {
+    const { dir, skillDst: dst } = makeProject(
+      [
+        '[core]',
+        'communication_language = "French"',
+        'document_output_language = "Klingon"',
+        'planning_artifacts = "{project-root}/plan"',
+        'implementation_artifacts = "{project-root}/impl"',
+      ].join('\n'),
+    );
+    fs.mkdirSync(path.join(dir, '_bmad', 'custom'), { recursive: true });
+    fs.writeFileSync(path.join(dir, '_bmad', 'custom', 'bmad-quick-dev.user.toml'), '[workflow\non_complete = broken', 'utf-8');
+    const res = spawnSync('python3', [path.join(dst, 'render.py')], { cwd: dst, encoding: 'utf-8' });
+    assert(res.status === 1, `expected exit 1, got ${res.status}\nstdout: ${res.stdout}\nstderr: ${res.stderr}`);
+    assert(
+      res.stdout.includes('HALT and report to the user: failed to parse') && res.stdout.includes('bmad-quick-dev.user.toml'),
+      `stdout missing the failed-to-parse HALT directive naming the override file.\nstdout: ${res.stdout}`,
+    );
+    assert(!res.stderr.includes('Traceback'), `renderer crashed with a traceback instead of HALTing:\n${res.stderr}`);
+  });
+
   test('non-table [modules] does not crash the renderer', () => {
     const { dir, skillDst: dst } = makeProject(
-      ['modules = "oops-not-a-table"', '', '[core]', 'implementation_artifacts = "{project-root}/impl"'].join('\n'),
+      [
+        'modules = "oops-not-a-table"',
+        '',
+        '[core]',
+        'communication_language = "French"',
+        'document_output_language = "Klingon"',
+        'planning_artifacts = "{project-root}/plan"',
+        'implementation_artifacts = "{project-root}/impl"',
+      ].join('\n'),
     );
     const res = spawnSync('python3', [path.join(dst, 'render.py')], { cwd: dst, encoding: 'utf-8' });
     assert(res.status === 0, `expected exit 0, got ${res.status}\nstdout: ${res.stdout}\nstderr: ${res.stderr}`);


### PR DESCRIPTION
## What

Two silent-corruption paths in the `bmad-quick-dev` / `bmad-dev-auto` template renderers now HALT instead of exiting 0 with a corrupted or default-substituted render. Both `render.py` copies change in lockstep (the parity test in `test/test-dev-auto-renderer.js` enforces sync), with regression tests added to both renderer suites.

Note: this intentionally changes already-merged quick-dev behavior (from #2281) as well as dev-auto's — both fixes are findings deferred from the #2587 review.

## Why

- **Missing compile-time config keys rendered as empty strings.** `render_template()` used missingkey=zero semantics: a `{{.var}}` referenced by the skill's .md sources but absent from the merged central config rendered as `""` with exit 0 — e.g. a config without `planning_artifacts` bakes "List files in \`\`" into the workflow with no failure signal. Only `implementation_artifacts` had an explicit guard.
- **Unparseable customization layers were silently discarded.** A parse/read failure of an optional layer (`_bmad/custom/<skill>.toml`, its `.user.toml`, or the optional central-config layers) warned on stderr — which the SKILL.md shim tells the caller to ignore — and continued with `{}`, so a typo in a user's override file silently dropped their on_complete/handoff/review-layer customizations. For unattended `bmad-dev-auto` runs nobody sees stderr; HALT is the correct failure mode for an autonomous loop.

## How

- Before rendering, collect the set of `{{.var}}` names referenced across the skill's source .md files; if any is absent from the merged flat config (after the derived `project_root` / `sprint_status` / `deferred_work_file` keys are added), HALT naming the missing key(s) and the referencing file(s). This closes the whole class instead of guarding keys one by one. The dedicated `implementation_artifacts` guard stays: it runs before the derive step and also catches present-but-empty values, which the scan (absent keys only) doesn't.
- `load_toml()` now distinguishes *missing* (fine — customization layers are optional, returns `{}`) from *unparseable or unreadable* (always HALT — the file exists, the user meant something, and it cannot be honored).
- Tests: missing-`planning_artifacts` and unparseable-`.user.toml` HALT cases added to both renderer suites (exit 1, HALT directive on stdout, no traceback); the non-table `[modules]` fixture config gained the keys the new check correctly requires.

**Extraction considered and declined:** at two copies the parity test is simpler than an abstraction — propagating this change was a single `sed`. A shared module in `src/scripts/` would also hit a bootstrap wrinkle (render.py must find the project root *before* it can import from there, so root-finding and HALT plumbing stay duplicated regardless) and weaken skill self-containment at install time. Revisit when a third skill adopts the renderer.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
