### PR TITLE
docs(core): include deep-recon in core skill count references

### DIFF
--- a/docs/reference/commands.md
+++ b/docs/reference/commands.md
@@ -122,7 +122,7 @@ bmad-help What are my options for UX design?
 
 **Other Core Tasks and Tools**
 
-The core module includes 8 built-in tools — help, reviews, refinement, customization, and the thinking skills (brainstorming, forge idea, party mode). See [Core Tools](./core-tools.md) for the complete reference.
+The core module includes 8 built-in tools — help, reviews, refinement, customization, and the thinking skills (brainstorming, deep-recon, forge idea, party mode). See [Core Tools](./core-tools.md) for the complete reference.
 
 ## Naming Convention
 

--- a/docs/reference/core-tools.md
+++ b/docs/reference/core-tools.md
@@ -5,7 +5,7 @@ sidebar:
   order: 3
 ---
 
-Every BMad installation includes the **core module** — a small set of skills that work across all projects, all modules, and all phases. This page covers those seven core skills: the four kernel tools plus the three **thinking skills** (brainstorming, forge idea, party mode).
+Every BMad installation includes the **core module** — a small set of skills that work across all projects, all modules, and all phases. This page covers those eight core skills: the four kernel tools plus the four **thinking skills** (brainstorming, deep-recon, forge idea, party mode).
 
 :::tip[Quick Path]
 Run any tool by typing its skill name (e.g., `bmad-help`) in your IDE. No agent session required.


### PR DESCRIPTION
## What
Sync the English core-tools and commands reference pages with the shipped core skill set so `bmad-deep-recon` is counted and listed.

## Why
`src/core-skills/bmad-deep-recon` exists, but `docs/reference/core-tools.md` says the module has "seven core skills" with three thinking skills, and `docs/reference/commands.md` says "8 built-in tools" while only naming seven. Both summaries omit `deep-recon`.

## How
- `core-tools.md`: update the intro to "eight core skills" / "four thinking skills" and add `deep-recon` to the thinking-skills list.
- `commands.md`: add `deep-recon` to the parenthetical list of thinking skills.

## Testing
- `git show upstream/main:<file>` confirmed the bug marker is still present.
- `python3 ../scripts/preflight_ship.py` passed (no open duplicates, fix marker absent).
- `node tools/validate-file-refs.js --strict` → 0 broken refs.
- `node tools/validate-doc-links.js`, `node tools/validate-sidebar-order.js`, `node tools/build-docs.mjs`, and `node tools/validate-skills.js --strict` all passed.
