### PR TITLE
Fix Copilot BMAD loading and add Herdr setup guide

### DIFF
--- a/SKILL.md
+++ b/SKILL.md
@@ -1,0 +1,53 @@
+---
+name: bmad-method
+description: 'BMAD Method (Breakthrough Method for Agile AI-Driven Development). Use when the user asks to follow BMAD methodology, adopt a BMAD persona (analyst, architect, PM, dev, DevOps, QA), run a BMAD workflow, or produce BMAD-structured artifacts. Do not use for generic coding tasks unless the user explicitly requests BMAD.'
+---
+
+# BMAD Method
+
+BMAD is a structured, agent-driven software delivery methodology. It assigns AI agents to named personas — Analyst, PM, Architect, Dev Lead, DevOps Lead, QA — and routes each project phase through the right persona in sequence.
+
+## Core personas
+
+| Skill name             | Persona     | Primary responsibility                        |
+| ---------------------- | ----------- | --------------------------------------------- |
+| `bmad-agent-analyst`   | Analyst     | Research, requirements, and idea shaping      |
+| `bmad-agent-pm`        | PM          | PRDs, epics, sprint planning                  |
+| `bmad-agent-architect` | Architect   | System design, ADRs, technical architecture   |
+| `bmad-agent-dev`       | Dev Lead    | Story implementation, code review, correction |
+| `bmad-agent-devops`    | DevOps Lead | IaC, CI/CD pipelines, deployment strategies   |
+| `bmad-agent-ux`        | UX Designer | User flows, design specs, accessibility       |
+
+## Standard delivery sequence
+
+1. **Analysis** — Analyst forges the idea and produces a brief.
+2. **Planning** — PM converts the brief into a PRD and epic breakdown.
+3. **Architecture** — Architect designs the system and produces the architecture doc.
+4. **Implementation** — Dev Lead works story-by-story through the epic backlog.
+5. **DevOps** — DevOps Lead owns pipeline and infrastructure for the whole lifecycle.
+
+## Using BMAD skills
+
+If this skill was installed via `npx skills add`, individual persona skills are available as separate skill files. Invoke a persona by name:
+
+```
+/skill bmad-agent-dev
+```
+
+or reference the skill file directly if your agent uses file-based skills:
+
+```
+Load .agents/skills/bmad-agent-dev/SKILL.md and follow its instructions.
+```
+
+## Using the full BMAD installer
+
+For a complete project setup — skill files, custom agent pointers for GitHub Copilot, and team configuration — run:
+
+```bash
+npx bmad-method install
+```
+
+This installs all selected modules into your project and configures the agent integration for your chosen tools (Claude Code, Cursor, GitHub Copilot, OpenCode, and others).
+
+Full documentation: <https://bmad.run>

--- a/docs/how-to/use-bmad-with-herdr.md
+++ b/docs/how-to/use-bmad-with-herdr.md
@@ -1,0 +1,92 @@
+---
+title: 'Use BMAD with Herdr'
+description: Run BMAD agents inside Herdr terminal panes, install BMAD skills via the open skills CLI, and orchestrate multi-agent workflows with the Herdr sidebar.
+sidebar:
+  order: 14
+---
+
+Herdr is a terminal multiplexer built for AI coding agents. It detects GitHub Copilot CLI, Claude Code, Codex, and other agents running inside panes, surfaces their state in a sidebar, and lets you drive them through its CLI. BMAD skills install directly into whichever agent you are running — Herdr sees the agent; BMAD shapes how that agent thinks.
+
+## Install Herdr
+
+```bash
+curl -fsSL https://herdr.dev/install.sh | sh
+herdr
+```
+
+Install the GitHub Copilot CLI integration so Herdr can report native session identity and restore your session after a restart:
+
+```bash
+herdr integration install copilot
+```
+
+## Install BMAD skills via the open skills CLI
+
+BMAD publishes all its skills in the open skills format. Install them into your current agent with one command:
+
+```bash
+npx skills add bmad-code-org/BMAD-METHOD
+```
+
+The CLI discovers all 35+ BMAD skills — analysis, planning, architecture, implementation, and persona agents — and presents a picker. Use `--global` (`-g`) to install at the user level so every project inherits them:
+
+```bash
+npx skills add bmad-code-org/BMAD-METHOD -g
+```
+
+To install without an interactive prompt:
+
+```bash
+npx skills add bmad-code-org/BMAD-METHOD --yes -g
+```
+
+:::note[Skill locations]
+The skills CLI places BMAD skills where your agent reads them. For GitHub Copilot CLI that is `~/.agents/skills/` (global) or `.agents/skills/` (project). For Claude Code it is `~/.claude/skills/` or `.claude/skills/`. The path matches the agent you are running inside Herdr.
+:::
+
+## Start a BMAD agent inside Herdr
+
+Open a Herdr pane, start Copilot CLI (or any supported agent), then invoke a BMAD persona:
+
+```bash
+# In a Herdr pane
+copilot-cli chat
+
+# In the chat, invoke a persona
+/skill bmad-agent-dev
+```
+
+Herdr detects the agent state automatically. The sidebar shows the persona as `working`, `blocked`, or `done`.
+
+## Orchestrate multiple BMAD agents with Herdr
+
+Herdr's CLI lets one agent drive others. If you are running inside a Herdr pane (`HERDR_ENV=1`), install the Herdr skill into the running agent so it knows how to control panes:
+
+```bash
+npx skills add ogulcancelik/herdr --skill herdr -g
+```
+
+Then prompt your agent to coordinate:
+
+```
+Start a reviewer agent in a sibling pane, give it the bmad-code-review skill,
+and have it review the current diff while I continue in this pane.
+```
+
+The agent uses the Herdr CLI (`herdr pane split`, `herdr agent start`, `herdr agent prompt`) to open a second pane, start another Copilot CLI instance as `reviewer`, load the `bmad-code-review` skill, and submit the review task — all without interrupting your flow.
+
+## Assign BMAD persona agents to GitHub PRs inside Herdr
+
+If you have run `npx bmad-method install` for the `github-copilot` platform, the installer created `.github/agents/*.agent.md` files for each persona. Open a PR in GitHub and select one of those agents from the Custom Agents picker. The agent reads its SKILL.md and follows BMAD methodology for the full PR lifecycle.
+
+You can trigger the same agent from a Herdr pane by starting Copilot CLI and passing the PR URL:
+
+```bash
+copilot-cli chat --pr https://github.com/org/repo/pull/123
+```
+
+Herdr tracks the agent state while it reviews, waits for `blocked` (when the agent needs your input), and scrolls back to show the results when `done`.
+
+:::tip[Recommended workflow]
+Use `npx bmad-method install` for the full per-project skill installation (creates `.agents/skills/`, custom agent pointers, etc.). Use `npx skills add bmad-code-org/BMAD-METHOD -g` for a lightweight global install that travels with you across all Herdr sessions on the machine.
+:::

--- a/test/test-installation-components.js
+++ b/test/test-installation-components.js
@@ -786,8 +786,12 @@ async function runTests() {
       'Copilot agent pointer body references the skill via a repo-relative path (<target_dir>/<id>/SKILL.md)',
     );
     assert(
-      personaAgentContent17.includes('BMAD Method') && !personaAgentContent17.includes('{project-root}'),
-      'Copilot agent pointer includes BMAD methodology context and uses a repo-relative path (no {project-root} literal)',
+      personaAgentContent17.includes('BMAD Method'),
+      'Copilot agent pointer includes BMAD methodology context',
+    );
+    assert(
+      !personaAgentContent17.includes('{project-root}'),
+      'Copilot agent pointer uses a repo-relative path (no {project-root} literal)',
     );
     assert(
       personaAgentContent17.includes('MANDATORY FIRST ACTION') &&
@@ -805,6 +809,34 @@ async function runTests() {
     assert(result17b.success === true, 'Second GitHub Copilot install succeeds (idempotent)');
     assert(await fs.pathExists(agentFileForPersona17), 'Persona agent pointer survives a second install pass');
     assert(!(await fs.pathExists(agentFileForWorkflow17)), 'Workflow skill remains filtered out of agents picker on second install');
+
+    // Migration behavior: an older generated Copilot pointer that still uses
+    // the legacy {project-root} LOAD template should be recognized as
+    // generator-owned and refreshed to the current template on reinstall.
+    const oldGeneratedBody17 = [
+      '---',
+      'description: Persona agent — customize.toml has [agent], SHOULD appear',
+      '---',
+      '',
+      'LOAD the FULL {project-root}/.agents/skills/bmad-agent-fixture/SKILL.md, READ its entire contents and follow its directions exactly!',
+      '',
+    ].join('\n');
+    await fs.writeFile(agentFileForPersona17, oldGeneratedBody17, 'utf8');
+
+    const result17c = await ideManager17.setup('github-copilot', tempProjectDir17, installedBmadDir17, {
+      silent: true,
+      selectedModules: ['bmm'],
+    });
+    assert(result17c.success === true, 'Third GitHub Copilot install succeeds (legacy pointer migration)');
+    const migratedPersonaAgentContent17 = await fs.readFile(agentFileForPersona17, 'utf8');
+    assert(
+      migratedPersonaAgentContent17.includes('MANDATORY FIRST ACTION'),
+      'Legacy Copilot pointer is refreshed to current template on reinstall',
+    );
+    assert(
+      !migratedPersonaAgentContent17.includes('{project-root}/.agents/skills/bmad-agent-fixture/SKILL.md'),
+      'Migrated Copilot pointer no longer uses legacy {project-root} path',
+    );
 
     await fs.remove(tempProjectDir17);
     await fs.remove(path.dirname(installedBmadDir17));

--- a/test/test-installation-components.js
+++ b/test/test-installation-components.js
@@ -789,6 +789,11 @@ async function runTests() {
       personaAgentContent17.includes('BMAD Method') && !personaAgentContent17.includes('{project-root}'),
       'Copilot agent pointer includes BMAD methodology context and uses a repo-relative path (no {project-root} literal)',
     );
+    assert(
+      personaAgentContent17.includes('MANDATORY FIRST ACTION') &&
+        personaAgentContent17.includes('Do not skip or defer this step.'),
+      'Copilot agent pointer enforces first-read behavior so PR-assigned agents must load SKILL.md before acting',
+    );
 
     // Idempotency: re-running setup must not duplicate or rewrite the agent
     // pointer when the source manifest is unchanged, AND must not start

--- a/test/test-installation-components.js
+++ b/test/test-installation-components.js
@@ -775,15 +775,19 @@ async function runTests() {
     );
 
     // Body content of the persona agent file: frontmatter description +
-    // LOAD pattern referencing the skill's SKILL.md path under target_dir.
+    // BMAD methodology preamble + repo-relative path to the skill's SKILL.md.
     const personaAgentContent17 = await fs.readFile(agentFileForPersona17, 'utf8');
     assert(
       personaAgentContent17.includes('description:'),
       'Copilot agent pointer carries a description in YAML frontmatter (drives the agents picker label)',
     );
     assert(
-      personaAgentContent17.includes('{project-root}/.agents/skills/bmad-agent-fixture/SKILL.md'),
-      'Copilot agent pointer body resolves to the skill via LOAD {project-root}/<target_dir>/<id>/SKILL.md',
+      personaAgentContent17.includes('.agents/skills/bmad-agent-fixture/SKILL.md'),
+      'Copilot agent pointer body references the skill via a repo-relative path (<target_dir>/<id>/SKILL.md)',
+    );
+    assert(
+      personaAgentContent17.includes('BMAD Method') && !personaAgentContent17.includes('{project-root}'),
+      'Copilot agent pointer includes BMAD methodology context and uses a repo-relative path (no {project-root} literal)',
     );
 
     // Idempotency: re-running setup must not duplicate or rewrite the agent

--- a/tools/installer/ide/_config-driven.js
+++ b/tools/installer/ide/_config-driven.js
@@ -56,6 +56,8 @@ function isSafeCanonicalId(value) {
 // installer config doesn't override `commands_body_template`. Matches
 // OpenCode's native `@skills/<id>` skill-reference syntax.
 const DEFAULT_COMMANDS_BODY_TEMPLATE = '@skills/{canonicalId}';
+const LEGACY_GITHUB_COPILOT_COMMANDS_BODY_TEMPLATE =
+  'LOAD the FULL {project-root}/{target_dir}/{canonicalId}/SKILL.md, READ its entire contents and follow its directions exactly!';
 
 // Is this skill a persona agent (vs. a workflow/tool/standalone skill)?
 // Used by platforms that surface only persona agents (e.g. Copilot's Custom
@@ -114,8 +116,16 @@ function looksLikeGeneratorOutput(content, canonicalId, { template, targetDir })
   if (typeof content !== 'string') return false;
   const trimmed = content.trim();
   const expectedTail = expandBodyTemplate(template, { canonicalId, targetDir }).trim();
-  // Must end with the exact body our generator writes (post-expansion).
-  if (!trimmed.endsWith(expectedTail)) return false;
+  const legacyCopilotTail = expandBodyTemplate(LEGACY_GITHUB_COPILOT_COMMANDS_BODY_TEMPLATE, {
+    canonicalId,
+    targetDir,
+  }).trim();
+  // Must end with either:
+  // - the exact body our current generator writes (post-expansion), or
+  // - the prior GitHub Copilot generator tail (migration path from {project-root}).
+  //   This lets re-installs refresh old generated files instead of treating them
+  //   as hand-modified forever.
+  if (!trimmed.endsWith(expectedTail) && !trimmed.endsWith(legacyCopilotTail)) return false;
   // Must start with frontmatter containing exactly one description: line.
   const fmMatch = trimmed.match(/^---\n([\S\s]*?)\n---\n/);
   if (!fmMatch) return false;

--- a/tools/installer/ide/platform-codes.yaml
+++ b/tools/installer/ide/platform-codes.yaml
@@ -148,7 +148,12 @@ platforms:
       global_target_dir: ~/.agents/skills
       commands_target_dir: .github/agents
       commands_extension: .agent.md
-      commands_body_template: "LOAD the FULL {project-root}/{target_dir}/{canonicalId}/SKILL.md, READ its entire contents and follow its directions exactly!"
+      commands_body_template: |
+        You are a BMAD Method (Breakthrough Method for Agile AI-Driven Development) persona agent.
+
+        **MANDATORY FIRST ACTION — before responding to anything:** Read the complete file `{target_dir}/{canonicalId}/SKILL.md` from the repository root. This file defines your persona, capabilities, BMAD workflow protocols, and operating instructions. You must follow it exactly.
+
+        Do not skip or defer this step. If the file cannot be read, say so explicitly rather than proceeding with generic behavior.
       # The Custom Agents picker should only show persona agents (not
       # workflows/tools). Detected by reading each skill's source
       # `customize.toml` and checking for an `[agent]` section — that's


### PR DESCRIPTION
## What
This updates GitHub Copilot custom-agent pointer generation so BMAD persona agents reliably load their SKILL.md instructions, and adds Herdr setup documentation plus a root BMAD skill entry-point for open-skills installs.

## Why
Copilot PR-assigned agents could skip BMAD methodology when the pointer relied on a `{project-root}` placeholder at runtime. We also needed clear guidance for teams using Herdr and `npx skills add` to bootstrap BMAD consistently.

## How
- Updated `tools/installer/ide/platform-codes.yaml` for `github-copilot` command pointers to use a repo-relative SKILL path, explicit BMAD context, and mandatory-first-action wording.
- Updated `test/test-installation-components.js` assertions for the new pointer invariants.
- Added `docs/how-to/use-bmad-with-herdr.md` and root `SKILL.md` as an open-skills entry-point.
- Added an explicit test assertion that generated Copilot agent pointers include mandatory-first-action enforcement text (`MANDATORY FIRST ACTION` and `Do not skip or defer this step.`).

## Testing
Targeted installation component tests pass for the updated pointer behavior, and markdown/prettier checks are clean for the new docs files.