### PR TITLE
fix(installer): seed schema-declared core keys on --yes installs and propagate core --set overrides to module config spreads

### DIFF
--- a/test/test-installation-components.js
+++ b/test/test-installation-components.js
@@ -3699,6 +3699,35 @@ test_future_pref:
         bothResult.moduleConfigs.core.test_future_pref === 'keep',
         'a prior [core] answer takes precedence over a prior module-section answer',
       );
+
+      // ---- --yes + CLI flags: backfill must not overwrite CLI values -------
+      const cliDir49 = path.join(root49, 'cli-flags-project');
+      await fs.ensureDir(cliDir49);
+      const cliResult = await new UI().collectModuleConfigs(cliDir49, [], {
+        yes: true,
+        userName: 'CliName',
+        outputFolder: 'cli-output',
+      });
+      assert(cliResult.moduleConfigs.core.user_name === 'CliName', 'backfill preserves a --user-name CLI value under --yes');
+      assert(cliResult.moduleConfigs.core.output_folder === 'cli-output', 'backfill preserves an --output-folder CLI value under --yes');
+      assert(
+        cliResult.moduleConfigs.core.test_future_pref === 'true',
+        'backfill still seeds schema-declared keys alongside CLI-provided values',
+      );
+
+      // ---- unreadable schema: install proceeds with the seeded config ------
+      projectRoot49.getSourcePath = (...segments) => path.join(root49, 'no-such-src', ...segments);
+      const noSchemaDir49 = path.join(root49, 'no-schema-project');
+      await fs.ensureDir(noSchemaDir49);
+      const noSchemaResult = await new UI().collectModuleConfigs(noSchemaDir49, [], { yes: true });
+      assert(
+        typeof noSchemaResult.moduleConfigs.core.user_name === 'string' && noSchemaResult.moduleConfigs.core.user_name.length > 0,
+        'unreadable core module.yaml: --yes install still proceeds with the seeded config',
+      );
+      assert(
+        !('test_future_pref' in noSchemaResult.moduleConfigs.core),
+        'unreadable core module.yaml: backfill is skipped rather than crashing the install',
+      );
     } finally {
       projectRoot49.getSourcePath = originalGetSourcePath49;
     }

--- a/test/test-installation-components.js
+++ b/test/test-installation-components.js
@@ -3615,6 +3615,146 @@ async function runTests() {
   console.log('');
 
   // ============================================================
+  // Test Suite 49: --yes seeding of schema-declared core keys +
+  // core --set propagation to module config spreads
+  // ============================================================
+  console.log(`${colors.yellow}Test Suite 49: core-key seeding and core --set spread propagation${colors.reset}\n`);
+
+  let root49;
+  const projectRoot49 = require('../tools/installer/project-root');
+  const originalGetSourcePath49 = projectRoot49.getSourcePath;
+  try {
+    const { UI } = require('../tools/installer/ui');
+    const { applySetOverrides } = require('../tools/installer/set-overrides');
+
+    root49 = await fs.mkdtemp(path.join(os.tmpdir(), 'bmad-core-seed-test-'));
+
+    // Fixture "src" tree: the real core schema plus one key the hardcoded
+    // --yes literal in ui.js knows nothing about. Redirecting getSourcePath
+    // here is what makes the backfill read this schema instead of src/.
+    const fixtureSrc49 = path.join(root49, 'src');
+    await fs.ensureDir(path.join(fixtureSrc49, 'core-skills'));
+    const realCoreSchema49 = await fs.readFile(path.join(originalGetSourcePath49('core-skills'), 'module.yaml'), 'utf8');
+    await fs.writeFile(
+      path.join(fixtureSrc49, 'core-skills', 'module.yaml'),
+      realCoreSchema49 +
+        `
+test_future_pref:
+  prompt: "A core preference declared after the --yes literal was written?"
+  scope: user
+  default: "true"
+  result: "{value}"
+`,
+      'utf8',
+    );
+
+    // Minimal v6 install fixture: _config/manifest.yaml is the marker
+    // findBmadDir keys on; the central tomls are what loadExistingConfig reads.
+    const makeV6Install = async (name, userTomlBody) => {
+      const projectDir = path.join(root49, name);
+      const bmadDir = path.join(projectDir, '_bmad');
+      await fs.ensureDir(path.join(bmadDir, '_config'));
+      await fs.writeFile(path.join(bmadDir, '_config', 'manifest.yaml'), 'version: 6.0.0\n', 'utf8');
+      await fs.writeFile(path.join(bmadDir, 'config.toml'), '[core]\nproject_name = "fixture"\n', 'utf8');
+      await fs.writeFile(path.join(bmadDir, 'config.user.toml'), userTomlBody, 'utf8');
+      return projectDir;
+    };
+
+    projectRoot49.getSourcePath = (...segments) => path.join(fixtureSrc49, ...segments);
+    try {
+      // ---- fresh --yes install: schema-declared key seeded from default ----
+      const freshDir49 = path.join(root49, 'fresh-project');
+      await fs.ensureDir(freshDir49);
+      const freshResult = await new UI().collectModuleConfigs(freshDir49, [], { yes: true });
+      assert(
+        freshResult.moduleConfigs.core.test_future_pref === 'true',
+        'fresh --yes install seeds a schema-declared core key with its schema default',
+      );
+
+      // ---- --yes update: prior [core] answer wins over the default --------
+      const coreValueDir49 = await makeV6Install('core-value-project', '[core]\ntest_future_pref = "keep"\n');
+      const coreValueResult = await new UI().collectModuleConfigs(coreValueDir49, [], { yes: true });
+      assert(
+        coreValueResult.moduleConfigs.core.test_future_pref === 'keep',
+        '--yes update preserves a prior [core] answer instead of resetting to the schema default',
+      );
+
+      // ---- --yes update: key promoted module → core keeps the prior value --
+      // The legacy _hoistCoreKeysFromLegacyModuleConfigs never runs on the v6
+      // central-toml load path, so this migration must come from the backfill.
+      const promotedDir49 = await makeV6Install('promoted-project', '[modules.bmm]\ntest_future_pref = "false"\n');
+      const promotedResult = await new UI().collectModuleConfigs(promotedDir49, [], { yes: true });
+      assert(
+        promotedResult.moduleConfigs.core.test_future_pref === 'false',
+        '--yes update migrates a prior module-section value for a key promoted to core',
+      );
+
+      // ---- precedence: prior [core] answer beats a prior module answer -----
+      const bothDir49 = await makeV6Install(
+        'both-values-project',
+        '[core]\ntest_future_pref = "keep"\n\n[modules.bmm]\ntest_future_pref = "false"\n',
+      );
+      const bothResult = await new UI().collectModuleConfigs(bothDir49, [], { yes: true });
+      assert(
+        bothResult.moduleConfigs.core.test_future_pref === 'keep',
+        'a prior [core] answer takes precedence over a prior module-section answer',
+      );
+    } finally {
+      projectRoot49.getSourcePath = originalGetSourcePath49;
+    }
+
+    // ---- core --set propagates to every module's config.yaml spread copy ----
+    {
+      const bmadDir = path.join(root49, 'set-spread', '_bmad');
+      await fs.ensureDir(path.join(bmadDir, '_config'));
+      await fs.writeFile(path.join(bmadDir, 'config.toml'), '[core]\nproject_name = "fixture"\n', 'utf8');
+      await fs.writeFile(path.join(bmadDir, 'config.user.toml'), '[core]\nuser_name = "Brian"\n', 'utf8');
+      for (const moduleName of ['core', 'bmm', 'cis']) {
+        await fs.ensureDir(path.join(bmadDir, moduleName));
+        await fs.writeFile(
+          path.join(bmadDir, moduleName, 'config.yaml'),
+          '# Generated by installer — do not edit.\nuser_name: Brian\n',
+          'utf8',
+        );
+      }
+      // Non-module dirs must not be touched by the core spread refresh.
+      await fs.ensureDir(path.join(bmadDir, 'docs'));
+      await fs.writeFile(path.join(bmadDir, 'docs', 'config.yaml'), 'user_name: Brian\n', 'utf8');
+
+      await applySetOverrides({ core: { user_name: 'Updated' } }, bmadDir);
+
+      const userToml = await fs.readFile(path.join(bmadDir, 'config.user.toml'), 'utf8');
+      assert(userToml.includes('user_name = "Updated"'), 'core --set still routes the value to config.user.toml');
+      for (const moduleName of ['core', 'bmm', 'cis']) {
+        const spread = await fs.readFile(path.join(bmadDir, moduleName, 'config.yaml'), 'utf8');
+        assert(spread.includes('user_name: Updated'), `core --set refreshes the spread copy in ${moduleName}/config.yaml immediately`);
+      }
+      const coreYaml = await fs.readFile(path.join(bmadDir, 'core', 'config.yaml'), 'utf8');
+      assert(coreYaml.startsWith('# Generated by installer'), 'spread refresh preserves the generated-file banner header');
+
+      // docs/ has a config.yaml but is not a module dir — must stay untouched.
+      const docsYaml = await fs.readFile(path.join(bmadDir, 'docs', 'config.yaml'), 'utf8');
+      assert(docsYaml.includes('user_name: Brian'), 'core --set does not touch config.yaml files in non-module dirs');
+
+      // A module-scoped --set must stay scoped to that module's spread copy.
+      await applySetOverrides({ bmm: { project_knowledge: 'research' } }, bmadDir);
+      const cisYaml = await fs.readFile(path.join(bmadDir, 'cis', 'config.yaml'), 'utf8');
+      assert(!cisYaml.includes('project_knowledge'), 'a module-scoped --set does not propagate to other modules');
+      const bmmYaml = await fs.readFile(path.join(bmadDir, 'bmm', 'config.yaml'), 'utf8');
+      assert(bmmYaml.includes('project_knowledge: research'), 'a module-scoped --set still patches its own module yaml');
+    }
+  } catch (error) {
+    console.log(`${colors.red}Test Suite 49 setup failed: ${error.message}${colors.reset}`);
+    console.log(error.stack);
+    failed++;
+  } finally {
+    projectRoot49.getSourcePath = originalGetSourcePath49;
+    if (root49) await fs.remove(root49).catch(() => {});
+  }
+
+  console.log('');
+
+  // ============================================================
   // Summary
   // ============================================================
   console.log(`${colors.cyan}========================================`);

--- a/tools/installer/core/installer.js
+++ b/tools/installer/core/installer.js
@@ -16,6 +16,7 @@ const { MODULE_HELP_CSV_HEADER } = require('../modules/module-help-schema');
 
 const { ExistingInstall } = require('./existing-install');
 const { warnPreNativeSkillsLegacy } = require('./legacy-warnings');
+const { NON_MODULE_DIRS } = require('../non-module-dirs');
 
 class Installer {
   constructor() {
@@ -959,8 +960,7 @@ class Installer {
 
     // Get all installed module directories
     const entries = await fs.readdir(bmadDir, { withFileTypes: true });
-    const nonModuleDirs = new Set(['_config', '_memory', 'memory', 'docs', 'scripts', 'custom']);
-    const installedModules = entries.filter((entry) => entry.isDirectory() && !nonModuleDirs.has(entry.name)).map((entry) => entry.name);
+    const installedModules = entries.filter((entry) => entry.isDirectory() && !NON_MODULE_DIRS.has(entry.name)).map((entry) => entry.name);
 
     // Generate config.yaml for each installed module
     for (const moduleName of installedModules) {
@@ -1056,8 +1056,7 @@ class Installer {
 
     // Get all installed module directories
     const entries = await fs.readdir(bmadDir, { withFileTypes: true });
-    const nonModuleDirs = new Set(['_config', '_memory', 'memory', 'docs', 'scripts', 'custom']);
-    const installedModules = entries.filter((entry) => entry.isDirectory() && !nonModuleDirs.has(entry.name)).map((entry) => entry.name);
+    const installedModules = entries.filter((entry) => entry.isDirectory() && !NON_MODULE_DIRS.has(entry.name)).map((entry) => entry.name);
 
     // Add core module to scan (it's installed at root level as _config, but we check src/core-skills)
     const coreModulePath = getSourcePath('core-skills');

--- a/tools/installer/modules/official-modules.js
+++ b/tools/installer/modules/official-modules.js
@@ -5,6 +5,7 @@ const prompts = require('../prompts');
 const { getProjectRoot, getSourcePath, getModulePath } = require('../project-root');
 const { CLIUtils } = require('../cli-utils');
 const { ExternalModuleManager } = require('./external-manager');
+const { NON_MODULE_DIRS } = require('../non-module-dirs');
 
 class OfficialModules {
   constructor(options = {}) {
@@ -922,10 +923,9 @@ class OfficialModules {
 
     // Fallback: legacy per-module config.yaml files (pre-v6 installations).
     const entries = await fs.readdir(bmadDir, { withFileTypes: true });
-    const nonModuleDirs = new Set(['_config', '_memory', 'memory', 'docs', 'scripts', 'custom']);
     for (const entry of entries) {
       if (entry.isDirectory()) {
-        if (nonModuleDirs.has(entry.name)) {
+        if (NON_MODULE_DIRS.has(entry.name)) {
           continue;
         }
 

--- a/tools/installer/non-module-dirs.js
+++ b/tools/installer/non-module-dirs.js
@@ -1,0 +1,10 @@
+// Reserved directories that live under `_bmad/` but are not module installs.
+// Anything that iterates `_bmad/`'s children to find installed modules must
+// exclude these. Single-sourced here because a drifted copy is silent breakage:
+// a future reserved dir that happens to contain a `config.yaml` would start
+// receiving core `--set` patches (set-overrides.js) or being treated as a
+// module by config generation/cleanup (core/installer.js) and the legacy
+// config loader (modules/official-modules.js).
+const NON_MODULE_DIRS = new Set(['_config', '_memory', 'memory', 'docs', 'scripts', 'custom']);
+
+module.exports = { NON_MODULE_DIRS };

--- a/tools/installer/set-overrides.js
+++ b/tools/installer/set-overrides.js
@@ -25,6 +25,7 @@ const PROTOTYPE_POLLUTING_NAMES = new Set(['__proto__', 'prototype', 'constructo
 const path = require('node:path');
 const fs = require('./fs-native');
 const yaml = require('yaml');
+const { NON_MODULE_DIRS } = require('./non-module-dirs');
 
 /**
  * Parse a single `--set <module>.<key>=<value>` entry.
@@ -297,10 +298,12 @@ async function applySetOverrides(overrides, bmadDir) {
     // until the next install regenerates the spread.
     const yamlTargets = [path.join(bmadDir, moduleCode, 'config.yaml')];
     if (moduleCode === 'core') {
-      const nonModuleDirs = new Set(['_config', '_memory', 'memory', 'docs', 'scripts', 'custom', 'core']);
+      // 'core' joins the exclusions only because its own yaml is already the
+      // first target above — don't patch it twice.
+      const excluded = new Set([...NON_MODULE_DIRS, 'core']);
       const entries = await fs.readdir(bmadDir, { withFileTypes: true });
       for (const entry of entries) {
-        if (entry.isDirectory() && !nonModuleDirs.has(entry.name)) {
+        if (entry.isDirectory() && !excluded.has(entry.name)) {
           yamlTargets.push(path.join(bmadDir, entry.name, 'config.yaml'));
         }
       }

--- a/tools/installer/set-overrides.js
+++ b/tools/installer/set-overrides.js
@@ -291,8 +291,22 @@ async function applySetOverrides(overrides, bmadDir) {
     // value lives in the per-module yaml but won't be re-emitted into
     // config.toml on the next install (the schema-strict partition drops
     // it); re-pass `--set` if you need it sticky.
-    const moduleYamlPath = path.join(bmadDir, moduleCode, 'config.yaml');
-    if (await fs.pathExists(moduleYamlPath)) {
+    // Core overrides also refresh the spread copies: core values are spread
+    // into every module's config.yaml at generate time and skills read their
+    // own module's copy — without this, a core --set would not take effect
+    // until the next install regenerates the spread.
+    const yamlTargets = [path.join(bmadDir, moduleCode, 'config.yaml')];
+    if (moduleCode === 'core') {
+      const nonModuleDirs = new Set(['_config', '_memory', 'memory', 'docs', 'scripts', 'custom', 'core']);
+      const entries = await fs.readdir(bmadDir, { withFileTypes: true });
+      for (const entry of entries) {
+        if (entry.isDirectory() && !nonModuleDirs.has(entry.name)) {
+          yamlTargets.push(path.join(bmadDir, entry.name, 'config.yaml'));
+        }
+      }
+    }
+    for (const moduleYamlPath of yamlTargets) {
+      if (!(await fs.pathExists(moduleYamlPath))) continue;
       try {
         const text = await fs.readFile(moduleYamlPath, 'utf8');
         const parsed = yaml.parse(text);

--- a/tools/installer/ui.js
+++ b/tools/installer/ui.js
@@ -876,14 +876,22 @@ class UI {
     // schema default. This mirrors _hoistCoreKeysFromLegacyModuleConfigs, which
     // only runs on the legacy (pre-central-toml) load path.
     if (options.yes) {
+      const yaml = require('yaml');
+      const { getSourcePath } = require('./project-root');
+      let coreSchema = null;
       try {
-        const yaml = require('yaml');
-        const { getSourcePath } = require('./project-root');
-        const coreSchema = yaml.parse(await fs.readFile(path.join(getSourcePath('core-skills'), 'module.yaml'), 'utf8'));
+        coreSchema = yaml.parse(await fs.readFile(path.join(getSourcePath('core-skills'), 'module.yaml'), 'utf8'));
+      } catch (error) {
+        // Schema unreadable — keep the seeded config as-is rather than fail
+        // the install, but say so: silently skipping means newly declared
+        // core keys quietly stop seeding.
+        await prompts.log.warn(`Could not read core module.yaml (${error.message}); skipping core config backfill.`);
+      }
+      if (coreSchema && typeof coreSchema === 'object' && !Array.isArray(coreSchema)) {
         const core = (configCollector.collectedConfig.core ||= {});
-        const existing = configCollector._existingConfig || {};
+        const existing = configCollector.existingConfig || {};
         const existingCore = existing.core && typeof existing.core === 'object' && !Array.isArray(existing.core) ? existing.core : {};
-        for (const [key, item] of Object.entries(coreSchema || {})) {
+        for (const [key, item] of Object.entries(coreSchema)) {
           if (!item || typeof item !== 'object' || Array.isArray(item) || !item.prompt || key in core) continue;
           let value = existingCore[key];
           if (value === undefined) {
@@ -897,13 +905,11 @@ class UI {
           }
           if (value === undefined) {
             let def = item.default;
-            if (typeof def === 'string') def = def.replace('{directory_name}', path.basename(directory));
+            if (typeof def === 'string') def = def.replaceAll('{directory_name}', path.basename(directory));
             value = def;
           }
           if (value !== undefined && value !== null && value !== '') core[key] = value;
         }
-      } catch {
-        // Schema unreadable — keep the seeded config as-is rather than fail the install.
       }
     }
 

--- a/tools/installer/ui.js
+++ b/tools/installer/ui.js
@@ -866,6 +866,47 @@ class UI {
       }
     }
 
+    // --yes backfill: seed any core keys declared in the schema but absent from
+    // the config assembled above (the fresh-install defaults, CLI-flag seed, or
+    // carried-forward existing config). Without this, a newly declared core key
+    // is silently dropped on every --yes install — core is skipped by
+    // collectAllConfigurations once seeded, so schema defaults never apply.
+    // Value precedence per key: prior [core] answer, then a prior answer under
+    // a module section (key promoted module → core, e.g. bmm → core), then the
+    // schema default. This mirrors _hoistCoreKeysFromLegacyModuleConfigs, which
+    // only runs on the legacy (pre-central-toml) load path.
+    if (options.yes) {
+      try {
+        const yaml = require('yaml');
+        const { getSourcePath } = require('./project-root');
+        const coreSchema = yaml.parse(await fs.readFile(path.join(getSourcePath('core-skills'), 'module.yaml'), 'utf8'));
+        const core = (configCollector.collectedConfig.core ||= {});
+        const existing = configCollector._existingConfig || {};
+        const existingCore = existing.core && typeof existing.core === 'object' && !Array.isArray(existing.core) ? existing.core : {};
+        for (const [key, item] of Object.entries(coreSchema || {})) {
+          if (!item || typeof item !== 'object' || Array.isArray(item) || !item.prompt || key in core) continue;
+          let value = existingCore[key];
+          if (value === undefined) {
+            for (const [moduleName, cfg] of Object.entries(existing)) {
+              if (moduleName === 'core' || !cfg || typeof cfg !== 'object' || Array.isArray(cfg)) continue;
+              if (cfg[key] !== undefined) {
+                value = cfg[key];
+                break;
+              }
+            }
+          }
+          if (value === undefined) {
+            let def = item.default;
+            if (typeof def === 'string') def = def.replace('{directory_name}', path.basename(directory));
+            value = def;
+          }
+          if (value !== undefined && value !== null && value !== '') core[key] = value;
+        }
+      } catch {
+        // Schema unreadable — keep the seeded config as-is rather than fail the install.
+      }
+    }
+
     // Collect all module configs — core is skipped if already seeded above
     await configCollector.collectAllConfigurations(modules, directory, {
       skipPrompts: options.yes || false,


### PR DESCRIPTION
## What
Two related installer fixes around core config keys, prototyped and requested by @jheyworth in the [review of #2609](https://github.com/bmad-code-org/BMAD-METHOD/pull/2609#issuecomment-5058913536). This PR gates #2609, which will declare the first core key that the `--yes` literal doesn't know about.

1. **`--yes` installs now seed schema-declared core keys.** Fresh `--yes` installs seed core from a hardcoded five-key literal in `ui.js` without reading core's schema, and `--yes` updates skip core once seeded — so any newly declared core key was silently dropped on every `--yes` install, and a later `--set core.<key>` mis-filed to team scope because `config.user.toml` never learned the key.
2. **`--set core.<key>` now refreshes the spread copies.** Core values are spread into every module's `config.yaml` at generate time and skills read their own module's copy — but `--set core.<key> --action update` only patched the central tomls, leaving every spread copy stale until a later install regenerated it. This half is live on main today with existing core keys (e.g. `--set core.user_name`).

## How
- `tools/installer/ui.js` — after the `--yes` core seed, backfill any core keys declared in `src/core-skills/module.yaml` but absent from the assembled config. Value precedence per key: prior `[core]` answer → prior answer under a module section (key promoted module → core) → schema default. The legacy `_hoistCoreKeysFromLegacyModuleConfigs()` cannot cover the promotion case: it only runs on the pre-central-toml load path, never for v6 installs.
- `tools/installer/set-overrides.js` — a core `--set` now patches the spread copy in every installed module's `config.yaml`, not just core's own. Non-module dirs (`_config`, `docs`, etc.) are excluded; module-scoped `--set` behavior is unchanged.

## Testing
New Test Suite 49 in `test/test-installation-components.js` with the three regression cases requested in the #2609 review, plus edge guards:
- fresh `--yes` install seeds a schema-declared core key with its schema default
- `--yes` update preserves a prior `[core]` answer instead of resetting to the default
- `--yes` update migrates a prior module-section value for a key promoted to core (and a prior `[core]` answer wins over a module-section one)
- core `--set` routes to `config.user.toml` and immediately refreshes the spread copies in `core/`, `bmm/`, and an external module's `config.yaml`, preserving the generated-file banner header
- non-module dirs are untouched, and a module-scoped `--set` does not propagate to other modules

`npm test` run locally: refs, install (403/403), urls, channels, skills, eslint, markdownlint, and prettier all pass. The `test:renderer` step fails on this machine on pristine main as well (local Python is 3.9; `render.py` imports `tomllib`, stdlib only in 3.11+) — environmental, unrelated to this change; CI should confirm.

🤖 Generated with [Claude Code](https://claude.com/claude-code)