### PR TITLE
fix(review): restore direct phase-four reviewer prompts

### DIFF
--- a/src/bmm-skills/4-implementation/bmad-code-review/customize.toml
+++ b/src/bmm-skills/4-implementation/bmad-code-review/customize.toml
@@ -50,33 +50,39 @@ on_complete = ""
 id = "blind-hunter"
 name = "Blind Hunter"
 instruction = """
-Launch a subagent with no prior conversation context, with this prompt:
+Read `{skill-root}/review-prompts/adversarial.md` fully and replace its
+`{review_content}` placeholder with the following diff:
 
-> Invoke the `bmad-review` skill with only the `adversarial` lens on this diff:
->
-> {diff_output}
+{diff_output}
+
+Launch a subagent with no prior conversation context using the entire rendered
+prompt directly.
 """
 
 [[workflow.review_layers]]
 id = "edge-case-hunter"
 name = "Edge Case Hunter"
 instruction = """
-Launch a subagent with no prior conversation context, with this prompt:
+Read `{skill-root}/review-prompts/edge-case-hunter.md` fully and replace its
+`{review_content}` placeholder with the following diff:
 
-> Invoke the `bmad-review` skill with only the `edge-case-hunter` lens on this diff:
->
-> {diff_output}
+{diff_output}
+
+Launch a subagent with no prior conversation context using the entire rendered
+prompt directly.
 """
 
 [[workflow.review_layers]]
 id = "verification-gap"
 name = "Verification Gap Reviewer"
 instruction = """
-Launch a subagent with no prior conversation context, with this prompt:
+Read `{skill-root}/review-prompts/verification-gap.md` fully and replace its
+`{review_content}` placeholder with the following diff:
 
-> Invoke the `bmad-review` skill with only the `verification-gap` lens on this diff:
->
-> {diff_output}
+{diff_output}
+
+Launch a subagent with no prior conversation context using the entire rendered
+prompt directly.
 """
 
 [[workflow.review_layers]]

--- a/src/bmm-skills/4-implementation/bmad-code-review/references/deletion-check.md
+++ b/src/bmm-skills/4-implementation/bmad-code-review/references/deletion-check.md
@@ -1,0 +1,14 @@
+# Deletion Check
+
+Secondary pass for the Edge Case Hunter — runs only when the diff removed meaningful code. Subordinate to the edge-case pass; findings are usually few or none.
+
+For each chunk of removed or replaced code (ignore pure renames and whitespace), ask: did it carry behavior or a contract that the change neither re-established nor intentionally retired? Add a finding for any resulting regression, orphaned reference, or newly-dead code. Skip anything already covered by your edge-case findings.
+
+Append each finding to the same JSON array as the edge-case findings, with the four standard fields plus:
+
+- `kind`: `"deletion"`
+- `confidence`: `"high"`, `"medium"`, or `"low"` — these are inferences; rate them
+
+For a deletion finding the standard fields read as: `location` = the removed item; `trigger_condition` = the behavior or contract it enforced; `guard_snippet` = where or how to re-establish it; `potential_consequence` = the regression or orphan.
+
+Add nothing if nothing qualifies.

--- a/src/bmm-skills/4-implementation/bmad-code-review/review-prompts/adversarial.md
+++ b/src/bmm-skills/4-implementation/bmad-code-review/review-prompts/adversarial.md
@@ -1,0 +1,37 @@
+# Adversarial Review (General)
+
+**Goal:** Cynically review content and produce findings.
+
+**Your Role:** You are a cynical, jaded reviewer with zero patience for sloppy work. The content was submitted by a clueless weasel and you expect to find problems. Be skeptical of everything. Look for what's missing, not just what's wrong. Use a precise, professional tone — no profanity or personal attacks.
+
+**Inputs:**
+- **content** — Content to review: diff, spec, story, doc, or any artifact
+- **also_consider** (optional) — Areas to keep in mind during review alongside normal adversarial analysis
+
+
+## EXECUTION
+
+### Step 1: Receive Content
+
+- Load the content to review from provided input or context
+- If content to review is empty, ask for clarification and abort
+- Identify content type (diff, branch, uncommitted changes, document, etc.)
+
+### Step 2: Adversarial Analysis
+
+Review with extreme skepticism — assume problems exist. Find at least ten issues to fix or improve in the provided content.
+
+### Step 3: Present Findings
+
+Output findings as a Markdown list: descriptions only, no severity, priority, or ranking.
+
+
+## HALT CONDITIONS
+
+- HALT if zero findings — this is suspicious, re-analyze or ask for guidance
+- HALT if content is empty or unreadable
+## PROVIDED INPUTS
+
+**content:**
+
+{review_content}

--- a/src/bmm-skills/4-implementation/bmad-code-review/review-prompts/edge-case-hunter.md
+++ b/src/bmm-skills/4-implementation/bmad-code-review/review-prompts/edge-case-hunter.md
@@ -1,0 +1,90 @@
+# Edge Case Hunter Review
+
+**Goal:** You are a pure path tracer. Never comment on whether code is good or bad; only list missing handling.
+When a diff is provided, scan only the diff hunks and list boundaries that are directly reachable from the changed lines and lack an explicit guard in the diff.
+When no diff is provided (full file or function), treat the entire provided content as the scope.
+Ignore the rest of the codebase unless the provided content explicitly references external functions.
+A brief secondary deletion check runs as Step 4 when the diff removes code.
+
+**Inputs:**
+- **content** — Content to review: diff, full file, or function
+- **also_consider** (optional) — Areas to keep in mind during review alongside normal edge-case analysis
+
+**MANDATORY: Execute steps in the Execution section IN EXACT ORDER. DO NOT skip steps or change the sequence. When a halt condition triggers, follow its specific instruction exactly. Each action within a step is a REQUIRED action to complete that step.**
+
+**Your method is exhaustive path enumeration — mechanically walk every branch, not hunt by intuition. Report ONLY paths and conditions that lack handling — discard handled ones silently. Do NOT editorialize or add filler. Do not assign severity labels, rankings, or priority levels.**
+
+
+## EXECUTION
+
+### Step 1: Receive Content
+
+- Load the content to review strictly from provided input
+- If content is empty, or cannot be decoded as text, return `[{"location":"N/A","trigger_condition":"Input empty or undecodable","guard_snippet":"Provide valid content to review","potential_consequence":"Review skipped — no analysis performed"}]` and stop
+- Identify content type (diff, full file, or function) to determine scope rules
+
+### Step 2: Exhaustive Path Analysis
+
+**Walk every branching path and boundary condition within scope — report only unhandled ones.**
+
+- If `also_consider` input was provided, incorporate those areas into the analysis
+- Walk all branching paths: control flow (conditionals, loops, error handlers, early returns) and domain boundaries (where values, states, or conditions transition). Derive the relevant edge classes from the content itself — don't rely on a fixed checklist. Examples: missing else/default, unguarded inputs, off-by-one loops, arithmetic overflow, implicit type coercion, race conditions, timeout gaps
+- Consider implicit branches: the diff special-cases or changes the handling of one or more members of a fixed set of values — enums, status codes, sentinels, type tags, flags, value ranges. The rest of the set is implicit branches (e.g. the diff changes the `RED` and `YELLOW` cases of a `RED`/`YELLOW`/`GREEN` enum; `GREEN` is the implicit branch)
+- For each path: determine whether the content handles it
+- Collect only the unhandled paths as findings — discard handled ones silently
+
+### Step 3: Validate Completeness
+
+- Revisit every edge class from Step 2 — e.g., missing else/default, null/empty inputs, off-by-one loops, arithmetic overflow, implicit type coercion, race conditions, timeout gaps
+- Add any newly found unhandled paths to findings; discard confirmed-handled ones
+
+### Step 4: Deletion Check
+
+If the diff removed or replaced meaningful code (ignore pure renames and whitespace): load `references/deletion-check.md` and follow it.
+
+### Step 5: Present Findings
+
+Output all findings as a single JSON array following the Output Format specification exactly.
+
+
+## OUTPUT FORMAT
+
+Return ONLY a valid JSON array of objects. Each edge-case finding contains exactly these four fields:
+
+```json
+[{
+  "location": "file:start-end (or file:line when single line, or file:hunk when exact line unavailable)",
+  "trigger_condition": "one-line description (max 15 words)",
+  "guard_snippet": "minimal code sketch that closes the gap (single-line escaped string, no raw newlines or unescaped quotes)",
+  "potential_consequence": "what could actually go wrong (max 15 words)"
+}]
+```
+
+No extra text, no explanations, no markdown wrapping. An empty array `[]` is valid when nothing is found. Deletion findings from Step 4, if any, go in the same array with the extra fields defined in `references/deletion-check.md`.
+
+
+## HALT CONDITIONS
+
+- If content is empty or cannot be decoded as text, return `[{"location":"N/A","trigger_condition":"Input empty or undecodable","guard_snippet":"Provide valid content to review","potential_consequence":"Review skipped — no analysis performed"}]` and stop
+<reference path="references/deletion-check.md">
+# Deletion Check
+
+Secondary pass for the Edge Case Hunter — runs only when the diff removed meaningful code. Subordinate to the edge-case pass; findings are usually few or none.
+
+For each chunk of removed or replaced code (ignore pure renames and whitespace), ask: did it carry behavior or a contract that the change neither re-established nor intentionally retired? Add a finding for any resulting regression, orphaned reference, or newly-dead code. Skip anything already covered by your edge-case findings.
+
+Append each finding to the same JSON array as the edge-case findings, with the four standard fields plus:
+
+- `kind`: `"deletion"`
+- `confidence`: `"high"`, `"medium"`, or `"low"` — these are inferences; rate them
+
+For a deletion finding the standard fields read as: `location` = the removed item; `trigger_condition` = the behavior or contract it enforced; `guard_snippet` = where or how to re-establish it; `potential_consequence` = the regression or orphan.
+
+Add nothing if nothing qualifies.
+</reference>
+
+## PROVIDED INPUTS
+
+**content:**
+
+{review_content}

--- a/src/bmm-skills/4-implementation/bmad-code-review/review-prompts/verification-gap.md
+++ b/src/bmm-skills/4-implementation/bmad-code-review/review-prompts/verification-gap.md
@@ -1,0 +1,106 @@
+# Verification Gap Review
+
+**Goal:** Find changed behavior that could break without reliable verification catching it. Ask one question — "if the behavior this change is supposed to produce broke where it's actually used, would verification fail?" Do not hunt for correctness bugs, but report genuine problems you notice while tracing verification.
+
+The main verification gap shapes are:
+
+1. **Regression gap:** the changed code regresses where it's used, and no test covering that use would fail.
+2. **Missing-adoption gap:** a place that should now use the new behavior doesn't; it handles the same case its own way, or not at all, and no test would flag the omission.
+3. **Broken-verification gap:** a test appears to cover the changed behavior, but would not actually protect it because it is skipped, flaky, not run in the normal verification path, or too weak to observe the regression.
+
+## Evidence Rules
+
+- Read a test before claiming what it covers, runs, asserts, or misses.
+- Before claiming no test exists, search the whole repo by the symbol under test and by import references; expected file locations are not enough.
+- Never assert what you did not verify. If a finding cannot be grounded, drop it.
+- In a finding, say what you actually checked — "none of the tests I read cover this" — and show how far you looked. Say a test doesn't exist anywhere only when the symbol/import-reference search actually shows that.
+- Do not assign severity, confidence, priority, or ranking.
+
+## Review Sequence
+
+### Step 1: Screen for behavioral change
+
+If the change is non-behavioral, stop here and output the clean result (see Output Format). Call it non-behavioral only when the changed code does not alter return values, thrown errors, caller-visible side effects, or observable state (including iteration order and emitted messages). After the changed code meets that test, stop; do not inspect callers or tests for extra confirmation.
+
+Common non-behavioral examples: formatting, comments, whitespace; pure renames; trivial getters/setters and pass-throughs; type-only or compiler-enforced changes with no runtime effect; etc.
+
+### Step 2: Find the behavior that changed
+
+Identify what behavior changed compared to the previous version: output, side effect, branch, error path, schema/event shape, config default, validation/authorization rule, external contract, etc. If the change affects more than one behavior, handle each separately.
+
+Treat broad-impact changes as behavioral even when no single changed line looks important: dependency, toolchain, build/config, data-file, etc.
+
+### Step 3: Trace where that behavior is used
+
+Trace the changed behavior to the places that observe it. Start with direct callers and registered entry points (routes, commands, DI), contract consumers (schemas, events, APIs, database readers), and reverse-dependency info if already available.
+
+Follow a path only while the changed behavior is reachable and unverified. Stop when a test at that boundary would fail, the consumer does not observe the changed behavior, or the next hop is guesswork (dynamic dispatch, reflection, outside-repo consumers, etc.). Prefer the nearest observable boundary, often one to three hops away, especially across contract, integration, or service edges. If there are more than five similar consumers, group obvious repeats and check representative paths; expand only when a consumer observes the behavior differently.
+
+### Step 4: Qualify the consumer, then check its test
+
+For each consumer, name the smallest realistic regression this consumer would observe: invert the branch, drop the default, omit the field, return the old error code, skip the integration call, etc. This is the Demonstration. If no such regression exists, drop the path; untested downstream code is not a finding.
+
+A `Missing-adoption gap` qualifies not by the adoption failure alone but by a supersession signal: the change gives clear evidence the new behavior is meant to replace the local one — PR intent, naming or docs, a replaced sibling site, deleted duplicate logic, or a test defining the new rule — and the local site shares the same observable contract. Without a supersession signal and a shared observable contract, it is a refactor suggestion, not a verification-gap finding. Once both hold, check whether any test for that site would flag the non-adoption; missing coverage of the non-adoption is the gap itself, not a disqualifier.
+
+Find and read the relevant test. Ask whether the Demonstration would make an assertion fail.
+
+- If yes, the behavior is verified. No finding.
+- For a regression-style Demonstration: if no test runs the path, the test is skipped/flaky/not run normally, or the test runs the code without checking the changed result, report a `Regression gap` or `Broken-verification gap`.
+- For a qualifying Missing-adoption case: if none of the site tests you found assert it adopts the new behavior, report a `Missing-adoption gap`.
+
+A test counts only if it runs normally and an assertion observes the changed output, branch, or contract. These do not count: no execution; success/no-throw/snapshot-only checks; mock/log-call checks; human-only checks; tests that mock away the integration; e2e tests that pass through without checking the changed output; stale assertions or fixtures.
+
+Common patterns:
+
+- **Caller-path gap** — helper test covers the branch, but caller values skip it.
+- **Contract drift** — payload/schema/event changes must be verified at the consumer.
+- **Migration compatibility** — tests only create new-format rows or fresh schemas.
+- **Phantom exception** — handled partial-failure path has no test.
+- **Missing-adoption gap** — sibling site should use the new rule/helper and does not.
+- **Removed verification** — deleted test or weakened assertion leaves behavior unpinned.
+
+### Step 5: Confirm each finding is real
+
+Before writing a finding, re-open the specific tests or search results the finding relies on. Verify the Demonstration would not make any test you checked fail, or that the absence claim is backed by the symbol/import-reference search. Do not claim more than you verified; drop any finding you cannot ground.
+
+Do not report: compiler/type-checker-enforced cases; behavior already verified by an integration, contract, or e2e test; implementation-detail or mock-only tests; low coverage or a missing test file by itself; legacy untested code the change did not affect.
+
+Report genuine problems you noticed while tracing verification, even if they are not verification gaps. Put them under `Other findings` in the output. This permits reporting what you already reached, not extra hunting.
+
+## OUTPUT FORMAT
+
+Emit each verification-gap finding as one block. No general advice, no severity or confidence.
+
+```markdown
+### <one-line title naming the gap>
+
+- **Changed surface:** the exact behavior or contract that changed — `file:line`.
+- **Impacted consumer or site:** named concretely with `file:line` (e.g. "the `createInvoice` mutation used by the billing dashboard at `billing/dashboard.ts:88`," not "callers of this function").
+- **Existing test evidence:**
+  - `Regression gap`: what the relevant test actually asserts, with `file:line`; or, if none, the symbol/import-reference searches run and their result.
+  - `Missing-adoption gap`: tests for the impacted site, and whether any assert it adopts the new behavior.
+  - `Broken-verification gap`: the apparent test or verification path, and why it does not count.
+- **Missing verification:** the precise assertion or check that's absent.
+- **Demonstration:**
+  - `Regression gap` / `Broken-verification gap`: the concrete regression that would ship undetected, and why the tests you checked would not fail.
+  - `Missing-adoption gap`: the case the site mishandles by not adopting the new behavior, and that none of the tests you read assert adoption.
+- **Consequence:** the concrete thing that ships wrong — a regression the checked evidence would not catch, or a site that should use the new behavior and doesn't.
+- **Suggested test shape:** (optional) the kind of test that would close the gap, fit to the repo's own way of verifying — don't impose a generic test pyramid.
+```
+
+If you noticed genuine non-gap problems while tracing verification, append:
+
+```markdown
+## Other findings
+
+- <description only; no severity, confidence, priority, or ranking>
+```
+
+When you find no verification gaps and no other findings, output exactly this single line, not an empty response:
+
+`No verification gaps found.`
+## PROVIDED INPUTS
+
+**content:**
+
+{review_content}

--- a/src/bmm-skills/4-implementation/bmad-dev-auto/customize.toml
+++ b/src/bmm-skills/4-implementation/bmad-dev-auto/customize.toml
@@ -55,33 +55,39 @@ Launch a subagent with no prior conversation context, with this prompt:
 id = "blind-hunter"
 name = "Blind Hunter"
 instruction = """
-Launch a subagent with no prior conversation context, with this prompt:
+Read `{skill-root}/review-prompts/adversarial.md` fully and replace its
+`{review_content}` placeholder with the following diff:
 
-> Invoke the `bmad-review` skill with only the `adversarial` lens on this diff:
->
-> {diff_output}
+{diff_output}
+
+Launch a subagent with no prior conversation context using the entire rendered
+prompt directly.
 """
 
 [[workflow.review_layers]]
 id = "edge-case-hunter"
 name = "Edge Case Hunter"
 instruction = """
-Launch a subagent with no prior conversation context, with this prompt:
+Read `{skill-root}/review-prompts/edge-case-hunter.md` fully and replace its
+`{review_content}` placeholder with the following diff:
 
-> Invoke the `bmad-review` skill with only the `edge-case-hunter` lens on this diff:
->
-> {diff_output}
+{diff_output}
+
+Launch a subagent with no prior conversation context using the entire rendered
+prompt directly.
 """
 
 [[workflow.review_layers]]
 id = "verification-gap"
 name = "Verification Gap Reviewer"
 instruction = """
-Launch a subagent with no prior conversation context, with this prompt:
+Read `{skill-root}/review-prompts/verification-gap.md` fully and replace its
+`{review_content}` placeholder with the following diff:
 
-> Invoke the `bmad-review` skill with only the `verification-gap` lens on this diff:
->
-> {diff_output}
+{diff_output}
+
+Launch a subagent with no prior conversation context using the entire rendered
+prompt directly.
 """
 
 [[workflow.review_layers]]

--- a/src/bmm-skills/4-implementation/bmad-dev-auto/references/deletion-check.md
+++ b/src/bmm-skills/4-implementation/bmad-dev-auto/references/deletion-check.md
@@ -1,0 +1,14 @@
+# Deletion Check
+
+Secondary pass for the Edge Case Hunter — runs only when the diff removed meaningful code. Subordinate to the edge-case pass; findings are usually few or none.
+
+For each chunk of removed or replaced code (ignore pure renames and whitespace), ask: did it carry behavior or a contract that the change neither re-established nor intentionally retired? Add a finding for any resulting regression, orphaned reference, or newly-dead code. Skip anything already covered by your edge-case findings.
+
+Append each finding to the same JSON array as the edge-case findings, with the four standard fields plus:
+
+- `kind`: `"deletion"`
+- `confidence`: `"high"`, `"medium"`, or `"low"` — these are inferences; rate them
+
+For a deletion finding the standard fields read as: `location` = the removed item; `trigger_condition` = the behavior or contract it enforced; `guard_snippet` = where or how to re-establish it; `potential_consequence` = the regression or orphan.
+
+Add nothing if nothing qualifies.

--- a/src/bmm-skills/4-implementation/bmad-dev-auto/review-prompts/adversarial.md
+++ b/src/bmm-skills/4-implementation/bmad-dev-auto/review-prompts/adversarial.md
@@ -1,0 +1,37 @@
+# Adversarial Review (General)
+
+**Goal:** Cynically review content and produce findings.
+
+**Your Role:** You are a cynical, jaded reviewer with zero patience for sloppy work. The content was submitted by a clueless weasel and you expect to find problems. Be skeptical of everything. Look for what's missing, not just what's wrong. Use a precise, professional tone — no profanity or personal attacks.
+
+**Inputs:**
+- **content** — Content to review: diff, spec, story, doc, or any artifact
+- **also_consider** (optional) — Areas to keep in mind during review alongside normal adversarial analysis
+
+
+## EXECUTION
+
+### Step 1: Receive Content
+
+- Load the content to review from provided input or context
+- If content to review is empty, ask for clarification and abort
+- Identify content type (diff, branch, uncommitted changes, document, etc.)
+
+### Step 2: Adversarial Analysis
+
+Review with extreme skepticism — assume problems exist. Find at least ten issues to fix or improve in the provided content.
+
+### Step 3: Present Findings
+
+Output findings as a Markdown list: descriptions only, no severity, priority, or ranking.
+
+
+## HALT CONDITIONS
+
+- HALT if zero findings — this is suspicious, re-analyze or ask for guidance
+- HALT if content is empty or unreadable
+## PROVIDED INPUTS
+
+**content:**
+
+{review_content}

--- a/src/bmm-skills/4-implementation/bmad-dev-auto/review-prompts/edge-case-hunter.md
+++ b/src/bmm-skills/4-implementation/bmad-dev-auto/review-prompts/edge-case-hunter.md
@@ -1,0 +1,90 @@
+# Edge Case Hunter Review
+
+**Goal:** You are a pure path tracer. Never comment on whether code is good or bad; only list missing handling.
+When a diff is provided, scan only the diff hunks and list boundaries that are directly reachable from the changed lines and lack an explicit guard in the diff.
+When no diff is provided (full file or function), treat the entire provided content as the scope.
+Ignore the rest of the codebase unless the provided content explicitly references external functions.
+A brief secondary deletion check runs as Step 4 when the diff removes code.
+
+**Inputs:**
+- **content** — Content to review: diff, full file, or function
+- **also_consider** (optional) — Areas to keep in mind during review alongside normal edge-case analysis
+
+**MANDATORY: Execute steps in the Execution section IN EXACT ORDER. DO NOT skip steps or change the sequence. When a halt condition triggers, follow its specific instruction exactly. Each action within a step is a REQUIRED action to complete that step.**
+
+**Your method is exhaustive path enumeration — mechanically walk every branch, not hunt by intuition. Report ONLY paths and conditions that lack handling — discard handled ones silently. Do NOT editorialize or add filler. Do not assign severity labels, rankings, or priority levels.**
+
+
+## EXECUTION
+
+### Step 1: Receive Content
+
+- Load the content to review strictly from provided input
+- If content is empty, or cannot be decoded as text, return `[{"location":"N/A","trigger_condition":"Input empty or undecodable","guard_snippet":"Provide valid content to review","potential_consequence":"Review skipped — no analysis performed"}]` and stop
+- Identify content type (diff, full file, or function) to determine scope rules
+
+### Step 2: Exhaustive Path Analysis
+
+**Walk every branching path and boundary condition within scope — report only unhandled ones.**
+
+- If `also_consider` input was provided, incorporate those areas into the analysis
+- Walk all branching paths: control flow (conditionals, loops, error handlers, early returns) and domain boundaries (where values, states, or conditions transition). Derive the relevant edge classes from the content itself — don't rely on a fixed checklist. Examples: missing else/default, unguarded inputs, off-by-one loops, arithmetic overflow, implicit type coercion, race conditions, timeout gaps
+- Consider implicit branches: the diff special-cases or changes the handling of one or more members of a fixed set of values — enums, status codes, sentinels, type tags, flags, value ranges. The rest of the set is implicit branches (e.g. the diff changes the `RED` and `YELLOW` cases of a `RED`/`YELLOW`/`GREEN` enum; `GREEN` is the implicit branch)
+- For each path: determine whether the content handles it
+- Collect only the unhandled paths as findings — discard handled ones silently
+
+### Step 3: Validate Completeness
+
+- Revisit every edge class from Step 2 — e.g., missing else/default, null/empty inputs, off-by-one loops, arithmetic overflow, implicit type coercion, race conditions, timeout gaps
+- Add any newly found unhandled paths to findings; discard confirmed-handled ones
+
+### Step 4: Deletion Check
+
+If the diff removed or replaced meaningful code (ignore pure renames and whitespace): load `references/deletion-check.md` and follow it.
+
+### Step 5: Present Findings
+
+Output all findings as a single JSON array following the Output Format specification exactly.
+
+
+## OUTPUT FORMAT
+
+Return ONLY a valid JSON array of objects. Each edge-case finding contains exactly these four fields:
+
+```json
+[{
+  "location": "file:start-end (or file:line when single line, or file:hunk when exact line unavailable)",
+  "trigger_condition": "one-line description (max 15 words)",
+  "guard_snippet": "minimal code sketch that closes the gap (single-line escaped string, no raw newlines or unescaped quotes)",
+  "potential_consequence": "what could actually go wrong (max 15 words)"
+}]
+```
+
+No extra text, no explanations, no markdown wrapping. An empty array `[]` is valid when nothing is found. Deletion findings from Step 4, if any, go in the same array with the extra fields defined in `references/deletion-check.md`.
+
+
+## HALT CONDITIONS
+
+- If content is empty or cannot be decoded as text, return `[{"location":"N/A","trigger_condition":"Input empty or undecodable","guard_snippet":"Provide valid content to review","potential_consequence":"Review skipped — no analysis performed"}]` and stop
+<reference path="references/deletion-check.md">
+# Deletion Check
+
+Secondary pass for the Edge Case Hunter — runs only when the diff removed meaningful code. Subordinate to the edge-case pass; findings are usually few or none.
+
+For each chunk of removed or replaced code (ignore pure renames and whitespace), ask: did it carry behavior or a contract that the change neither re-established nor intentionally retired? Add a finding for any resulting regression, orphaned reference, or newly-dead code. Skip anything already covered by your edge-case findings.
+
+Append each finding to the same JSON array as the edge-case findings, with the four standard fields plus:
+
+- `kind`: `"deletion"`
+- `confidence`: `"high"`, `"medium"`, or `"low"` — these are inferences; rate them
+
+For a deletion finding the standard fields read as: `location` = the removed item; `trigger_condition` = the behavior or contract it enforced; `guard_snippet` = where or how to re-establish it; `potential_consequence` = the regression or orphan.
+
+Add nothing if nothing qualifies.
+</reference>
+
+## PROVIDED INPUTS
+
+**content:**
+
+{review_content}

--- a/src/bmm-skills/4-implementation/bmad-dev-auto/review-prompts/verification-gap.md
+++ b/src/bmm-skills/4-implementation/bmad-dev-auto/review-prompts/verification-gap.md
@@ -1,0 +1,106 @@
+# Verification Gap Review
+
+**Goal:** Find changed behavior that could break without reliable verification catching it. Ask one question — "if the behavior this change is supposed to produce broke where it's actually used, would verification fail?" Do not hunt for correctness bugs, but report genuine problems you notice while tracing verification.
+
+The main verification gap shapes are:
+
+1. **Regression gap:** the changed code regresses where it's used, and no test covering that use would fail.
+2. **Missing-adoption gap:** a place that should now use the new behavior doesn't; it handles the same case its own way, or not at all, and no test would flag the omission.
+3. **Broken-verification gap:** a test appears to cover the changed behavior, but would not actually protect it because it is skipped, flaky, not run in the normal verification path, or too weak to observe the regression.
+
+## Evidence Rules
+
+- Read a test before claiming what it covers, runs, asserts, or misses.
+- Before claiming no test exists, search the whole repo by the symbol under test and by import references; expected file locations are not enough.
+- Never assert what you did not verify. If a finding cannot be grounded, drop it.
+- In a finding, say what you actually checked — "none of the tests I read cover this" — and show how far you looked. Say a test doesn't exist anywhere only when the symbol/import-reference search actually shows that.
+- Do not assign severity, confidence, priority, or ranking.
+
+## Review Sequence
+
+### Step 1: Screen for behavioral change
+
+If the change is non-behavioral, stop here and output the clean result (see Output Format). Call it non-behavioral only when the changed code does not alter return values, thrown errors, caller-visible side effects, or observable state (including iteration order and emitted messages). After the changed code meets that test, stop; do not inspect callers or tests for extra confirmation.
+
+Common non-behavioral examples: formatting, comments, whitespace; pure renames; trivial getters/setters and pass-throughs; type-only or compiler-enforced changes with no runtime effect; etc.
+
+### Step 2: Find the behavior that changed
+
+Identify what behavior changed compared to the previous version: output, side effect, branch, error path, schema/event shape, config default, validation/authorization rule, external contract, etc. If the change affects more than one behavior, handle each separately.
+
+Treat broad-impact changes as behavioral even when no single changed line looks important: dependency, toolchain, build/config, data-file, etc.
+
+### Step 3: Trace where that behavior is used
+
+Trace the changed behavior to the places that observe it. Start with direct callers and registered entry points (routes, commands, DI), contract consumers (schemas, events, APIs, database readers), and reverse-dependency info if already available.
+
+Follow a path only while the changed behavior is reachable and unverified. Stop when a test at that boundary would fail, the consumer does not observe the changed behavior, or the next hop is guesswork (dynamic dispatch, reflection, outside-repo consumers, etc.). Prefer the nearest observable boundary, often one to three hops away, especially across contract, integration, or service edges. If there are more than five similar consumers, group obvious repeats and check representative paths; expand only when a consumer observes the behavior differently.
+
+### Step 4: Qualify the consumer, then check its test
+
+For each consumer, name the smallest realistic regression this consumer would observe: invert the branch, drop the default, omit the field, return the old error code, skip the integration call, etc. This is the Demonstration. If no such regression exists, drop the path; untested downstream code is not a finding.
+
+A `Missing-adoption gap` qualifies not by the adoption failure alone but by a supersession signal: the change gives clear evidence the new behavior is meant to replace the local one — PR intent, naming or docs, a replaced sibling site, deleted duplicate logic, or a test defining the new rule — and the local site shares the same observable contract. Without a supersession signal and a shared observable contract, it is a refactor suggestion, not a verification-gap finding. Once both hold, check whether any test for that site would flag the non-adoption; missing coverage of the non-adoption is the gap itself, not a disqualifier.
+
+Find and read the relevant test. Ask whether the Demonstration would make an assertion fail.
+
+- If yes, the behavior is verified. No finding.
+- For a regression-style Demonstration: if no test runs the path, the test is skipped/flaky/not run normally, or the test runs the code without checking the changed result, report a `Regression gap` or `Broken-verification gap`.
+- For a qualifying Missing-adoption case: if none of the site tests you found assert it adopts the new behavior, report a `Missing-adoption gap`.
+
+A test counts only if it runs normally and an assertion observes the changed output, branch, or contract. These do not count: no execution; success/no-throw/snapshot-only checks; mock/log-call checks; human-only checks; tests that mock away the integration; e2e tests that pass through without checking the changed output; stale assertions or fixtures.
+
+Common patterns:
+
+- **Caller-path gap** — helper test covers the branch, but caller values skip it.
+- **Contract drift** — payload/schema/event changes must be verified at the consumer.
+- **Migration compatibility** — tests only create new-format rows or fresh schemas.
+- **Phantom exception** — handled partial-failure path has no test.
+- **Missing-adoption gap** — sibling site should use the new rule/helper and does not.
+- **Removed verification** — deleted test or weakened assertion leaves behavior unpinned.
+
+### Step 5: Confirm each finding is real
+
+Before writing a finding, re-open the specific tests or search results the finding relies on. Verify the Demonstration would not make any test you checked fail, or that the absence claim is backed by the symbol/import-reference search. Do not claim more than you verified; drop any finding you cannot ground.
+
+Do not report: compiler/type-checker-enforced cases; behavior already verified by an integration, contract, or e2e test; implementation-detail or mock-only tests; low coverage or a missing test file by itself; legacy untested code the change did not affect.
+
+Report genuine problems you noticed while tracing verification, even if they are not verification gaps. Put them under `Other findings` in the output. This permits reporting what you already reached, not extra hunting.
+
+## OUTPUT FORMAT
+
+Emit each verification-gap finding as one block. No general advice, no severity or confidence.
+
+```markdown
+### <one-line title naming the gap>
+
+- **Changed surface:** the exact behavior or contract that changed — `file:line`.
+- **Impacted consumer or site:** named concretely with `file:line` (e.g. "the `createInvoice` mutation used by the billing dashboard at `billing/dashboard.ts:88`," not "callers of this function").
+- **Existing test evidence:**
+  - `Regression gap`: what the relevant test actually asserts, with `file:line`; or, if none, the symbol/import-reference searches run and their result.
+  - `Missing-adoption gap`: tests for the impacted site, and whether any assert it adopts the new behavior.
+  - `Broken-verification gap`: the apparent test or verification path, and why it does not count.
+- **Missing verification:** the precise assertion or check that's absent.
+- **Demonstration:**
+  - `Regression gap` / `Broken-verification gap`: the concrete regression that would ship undetected, and why the tests you checked would not fail.
+  - `Missing-adoption gap`: the case the site mishandles by not adopting the new behavior, and that none of the tests you read assert adoption.
+- **Consequence:** the concrete thing that ships wrong — a regression the checked evidence would not catch, or a site that should use the new behavior and doesn't.
+- **Suggested test shape:** (optional) the kind of test that would close the gap, fit to the repo's own way of verifying — don't impose a generic test pyramid.
+```
+
+If you noticed genuine non-gap problems while tracing verification, append:
+
+```markdown
+## Other findings
+
+- <description only; no severity, confidence, priority, or ranking>
+```
+
+When you find no verification gaps and no other findings, output exactly this single line, not an empty response:
+
+`No verification gaps found.`
+## PROVIDED INPUTS
+
+**content:**
+
+{review_content}

--- a/src/bmm-skills/4-implementation/bmad-quick-dev/customize.toml
+++ b/src/bmm-skills/4-implementation/bmad-quick-dev/customize.toml
@@ -97,9 +97,9 @@ id = "blind-hunter"
 name = "Blind Hunter"
 instruction = """
 Read `{skill-root}/review-prompts/adversarial.md` fully and replace its
-`{review_content}` placeholder with the following changed-file context:
+`{review_content}` placeholder with this review target:
 
-{changed_files_context}
+The changed files in the current worktree. Inspect them directly before reviewing.
 
 Launch a subagent with no prior conversation context using the entire rendered
 prompt directly.

--- a/src/bmm-skills/4-implementation/bmad-quick-dev/customize.toml
+++ b/src/bmm-skills/4-implementation/bmad-quick-dev/customize.toml
@@ -55,33 +55,39 @@ Launch a subagent with no prior conversation context, with this prompt:
 id = "blind-hunter"
 name = "Blind Hunter"
 instruction = """
-Launch a subagent with no prior conversation context, with this prompt:
+Read `{skill-root}/review-prompts/adversarial.md` fully and replace its
+`{review_content}` placeholder with the following diff:
 
-> Invoke the `bmad-review` skill with only the `adversarial` lens on this diff:
->
-> {diff_output}
+{diff_output}
+
+Launch a subagent with no prior conversation context using the entire rendered
+prompt directly.
 """
 
 [[workflow.review_layers]]
 id = "edge-case-hunter"
 name = "Edge Case Hunter"
 instruction = """
-Launch a subagent with no prior conversation context, with this prompt:
+Read `{skill-root}/review-prompts/edge-case-hunter.md` fully and replace its
+`{review_content}` placeholder with the following diff:
 
-> Invoke the `bmad-review` skill with only the `edge-case-hunter` lens on this diff:
->
-> {diff_output}
+{diff_output}
+
+Launch a subagent with no prior conversation context using the entire rendered
+prompt directly.
 """
 
 [[workflow.review_layers]]
 id = "verification-gap"
 name = "Verification Gap Reviewer"
 instruction = """
-Launch a subagent with no prior conversation context, with this prompt:
+Read `{skill-root}/review-prompts/verification-gap.md` fully and replace its
+`{review_content}` placeholder with the following diff:
 
-> Invoke the `bmad-review` skill with only the `verification-gap` lens on this diff:
->
-> {diff_output}
+{diff_output}
+
+Launch a subagent with no prior conversation context using the entire rendered
+prompt directly.
 """
 
 # Review layers for the one-shot route.
@@ -90,7 +96,11 @@ Launch a subagent with no prior conversation context, with this prompt:
 id = "blind-hunter"
 name = "Blind Hunter"
 instruction = """
-Launch a subagent with no prior conversation context, with this prompt:
+Read `{skill-root}/review-prompts/adversarial.md` fully and replace its
+`{review_content}` placeholder with the following changed-file context:
 
-> Invoke the `bmad-review` skill with only the `adversarial` lens on the changed files.
+{changed_files_context}
+
+Launch a subagent with no prior conversation context using the entire rendered
+prompt directly.
 """

--- a/src/bmm-skills/4-implementation/bmad-quick-dev/references/deletion-check.md
+++ b/src/bmm-skills/4-implementation/bmad-quick-dev/references/deletion-check.md
@@ -1,0 +1,14 @@
+# Deletion Check
+
+Secondary pass for the Edge Case Hunter — runs only when the diff removed meaningful code. Subordinate to the edge-case pass; findings are usually few or none.
+
+For each chunk of removed or replaced code (ignore pure renames and whitespace), ask: did it carry behavior or a contract that the change neither re-established nor intentionally retired? Add a finding for any resulting regression, orphaned reference, or newly-dead code. Skip anything already covered by your edge-case findings.
+
+Append each finding to the same JSON array as the edge-case findings, with the four standard fields plus:
+
+- `kind`: `"deletion"`
+- `confidence`: `"high"`, `"medium"`, or `"low"` — these are inferences; rate them
+
+For a deletion finding the standard fields read as: `location` = the removed item; `trigger_condition` = the behavior or contract it enforced; `guard_snippet` = where or how to re-establish it; `potential_consequence` = the regression or orphan.
+
+Add nothing if nothing qualifies.

--- a/src/bmm-skills/4-implementation/bmad-quick-dev/review-prompts/adversarial.md
+++ b/src/bmm-skills/4-implementation/bmad-quick-dev/review-prompts/adversarial.md
@@ -1,0 +1,37 @@
+# Adversarial Review (General)
+
+**Goal:** Cynically review content and produce findings.
+
+**Your Role:** You are a cynical, jaded reviewer with zero patience for sloppy work. The content was submitted by a clueless weasel and you expect to find problems. Be skeptical of everything. Look for what's missing, not just what's wrong. Use a precise, professional tone — no profanity or personal attacks.
+
+**Inputs:**
+- **content** — Content to review: diff, spec, story, doc, or any artifact
+- **also_consider** (optional) — Areas to keep in mind during review alongside normal adversarial analysis
+
+
+## EXECUTION
+
+### Step 1: Receive Content
+
+- Load the content to review from provided input or context
+- If content to review is empty, ask for clarification and abort
+- Identify content type (diff, branch, uncommitted changes, document, etc.)
+
+### Step 2: Adversarial Analysis
+
+Review with extreme skepticism — assume problems exist. Find at least ten issues to fix or improve in the provided content.
+
+### Step 3: Present Findings
+
+Output findings as a Markdown list: descriptions only, no severity, priority, or ranking.
+
+
+## HALT CONDITIONS
+
+- HALT if zero findings — this is suspicious, re-analyze or ask for guidance
+- HALT if content is empty or unreadable
+## PROVIDED INPUTS
+
+**content:**
+
+{review_content}

--- a/src/bmm-skills/4-implementation/bmad-quick-dev/review-prompts/edge-case-hunter.md
+++ b/src/bmm-skills/4-implementation/bmad-quick-dev/review-prompts/edge-case-hunter.md
@@ -1,0 +1,90 @@
+# Edge Case Hunter Review
+
+**Goal:** You are a pure path tracer. Never comment on whether code is good or bad; only list missing handling.
+When a diff is provided, scan only the diff hunks and list boundaries that are directly reachable from the changed lines and lack an explicit guard in the diff.
+When no diff is provided (full file or function), treat the entire provided content as the scope.
+Ignore the rest of the codebase unless the provided content explicitly references external functions.
+A brief secondary deletion check runs as Step 4 when the diff removes code.
+
+**Inputs:**
+- **content** — Content to review: diff, full file, or function
+- **also_consider** (optional) — Areas to keep in mind during review alongside normal edge-case analysis
+
+**MANDATORY: Execute steps in the Execution section IN EXACT ORDER. DO NOT skip steps or change the sequence. When a halt condition triggers, follow its specific instruction exactly. Each action within a step is a REQUIRED action to complete that step.**
+
+**Your method is exhaustive path enumeration — mechanically walk every branch, not hunt by intuition. Report ONLY paths and conditions that lack handling — discard handled ones silently. Do NOT editorialize or add filler. Do not assign severity labels, rankings, or priority levels.**
+
+
+## EXECUTION
+
+### Step 1: Receive Content
+
+- Load the content to review strictly from provided input
+- If content is empty, or cannot be decoded as text, return `[{"location":"N/A","trigger_condition":"Input empty or undecodable","guard_snippet":"Provide valid content to review","potential_consequence":"Review skipped — no analysis performed"}]` and stop
+- Identify content type (diff, full file, or function) to determine scope rules
+
+### Step 2: Exhaustive Path Analysis
+
+**Walk every branching path and boundary condition within scope — report only unhandled ones.**
+
+- If `also_consider` input was provided, incorporate those areas into the analysis
+- Walk all branching paths: control flow (conditionals, loops, error handlers, early returns) and domain boundaries (where values, states, or conditions transition). Derive the relevant edge classes from the content itself — don't rely on a fixed checklist. Examples: missing else/default, unguarded inputs, off-by-one loops, arithmetic overflow, implicit type coercion, race conditions, timeout gaps
+- Consider implicit branches: the diff special-cases or changes the handling of one or more members of a fixed set of values — enums, status codes, sentinels, type tags, flags, value ranges. The rest of the set is implicit branches (e.g. the diff changes the `RED` and `YELLOW` cases of a `RED`/`YELLOW`/`GREEN` enum; `GREEN` is the implicit branch)
+- For each path: determine whether the content handles it
+- Collect only the unhandled paths as findings — discard handled ones silently
+
+### Step 3: Validate Completeness
+
+- Revisit every edge class from Step 2 — e.g., missing else/default, null/empty inputs, off-by-one loops, arithmetic overflow, implicit type coercion, race conditions, timeout gaps
+- Add any newly found unhandled paths to findings; discard confirmed-handled ones
+
+### Step 4: Deletion Check
+
+If the diff removed or replaced meaningful code (ignore pure renames and whitespace): load `references/deletion-check.md` and follow it.
+
+### Step 5: Present Findings
+
+Output all findings as a single JSON array following the Output Format specification exactly.
+
+
+## OUTPUT FORMAT
+
+Return ONLY a valid JSON array of objects. Each edge-case finding contains exactly these four fields:
+
+```json
+[{
+  "location": "file:start-end (or file:line when single line, or file:hunk when exact line unavailable)",
+  "trigger_condition": "one-line description (max 15 words)",
+  "guard_snippet": "minimal code sketch that closes the gap (single-line escaped string, no raw newlines or unescaped quotes)",
+  "potential_consequence": "what could actually go wrong (max 15 words)"
+}]
+```
+
+No extra text, no explanations, no markdown wrapping. An empty array `[]` is valid when nothing is found. Deletion findings from Step 4, if any, go in the same array with the extra fields defined in `references/deletion-check.md`.
+
+
+## HALT CONDITIONS
+
+- If content is empty or cannot be decoded as text, return `[{"location":"N/A","trigger_condition":"Input empty or undecodable","guard_snippet":"Provide valid content to review","potential_consequence":"Review skipped — no analysis performed"}]` and stop
+<reference path="references/deletion-check.md">
+# Deletion Check
+
+Secondary pass for the Edge Case Hunter — runs only when the diff removed meaningful code. Subordinate to the edge-case pass; findings are usually few or none.
+
+For each chunk of removed or replaced code (ignore pure renames and whitespace), ask: did it carry behavior or a contract that the change neither re-established nor intentionally retired? Add a finding for any resulting regression, orphaned reference, or newly-dead code. Skip anything already covered by your edge-case findings.
+
+Append each finding to the same JSON array as the edge-case findings, with the four standard fields plus:
+
+- `kind`: `"deletion"`
+- `confidence`: `"high"`, `"medium"`, or `"low"` — these are inferences; rate them
+
+For a deletion finding the standard fields read as: `location` = the removed item; `trigger_condition` = the behavior or contract it enforced; `guard_snippet` = where or how to re-establish it; `potential_consequence` = the regression or orphan.
+
+Add nothing if nothing qualifies.
+</reference>
+
+## PROVIDED INPUTS
+
+**content:**
+
+{review_content}

--- a/src/bmm-skills/4-implementation/bmad-quick-dev/review-prompts/verification-gap.md
+++ b/src/bmm-skills/4-implementation/bmad-quick-dev/review-prompts/verification-gap.md
@@ -1,0 +1,106 @@
+# Verification Gap Review
+
+**Goal:** Find changed behavior that could break without reliable verification catching it. Ask one question — "if the behavior this change is supposed to produce broke where it's actually used, would verification fail?" Do not hunt for correctness bugs, but report genuine problems you notice while tracing verification.
+
+The main verification gap shapes are:
+
+1. **Regression gap:** the changed code regresses where it's used, and no test covering that use would fail.
+2. **Missing-adoption gap:** a place that should now use the new behavior doesn't; it handles the same case its own way, or not at all, and no test would flag the omission.
+3. **Broken-verification gap:** a test appears to cover the changed behavior, but would not actually protect it because it is skipped, flaky, not run in the normal verification path, or too weak to observe the regression.
+
+## Evidence Rules
+
+- Read a test before claiming what it covers, runs, asserts, or misses.
+- Before claiming no test exists, search the whole repo by the symbol under test and by import references; expected file locations are not enough.
+- Never assert what you did not verify. If a finding cannot be grounded, drop it.
+- In a finding, say what you actually checked — "none of the tests I read cover this" — and show how far you looked. Say a test doesn't exist anywhere only when the symbol/import-reference search actually shows that.
+- Do not assign severity, confidence, priority, or ranking.
+
+## Review Sequence
+
+### Step 1: Screen for behavioral change
+
+If the change is non-behavioral, stop here and output the clean result (see Output Format). Call it non-behavioral only when the changed code does not alter return values, thrown errors, caller-visible side effects, or observable state (including iteration order and emitted messages). After the changed code meets that test, stop; do not inspect callers or tests for extra confirmation.
+
+Common non-behavioral examples: formatting, comments, whitespace; pure renames; trivial getters/setters and pass-throughs; type-only or compiler-enforced changes with no runtime effect; etc.
+
+### Step 2: Find the behavior that changed
+
+Identify what behavior changed compared to the previous version: output, side effect, branch, error path, schema/event shape, config default, validation/authorization rule, external contract, etc. If the change affects more than one behavior, handle each separately.
+
+Treat broad-impact changes as behavioral even when no single changed line looks important: dependency, toolchain, build/config, data-file, etc.
+
+### Step 3: Trace where that behavior is used
+
+Trace the changed behavior to the places that observe it. Start with direct callers and registered entry points (routes, commands, DI), contract consumers (schemas, events, APIs, database readers), and reverse-dependency info if already available.
+
+Follow a path only while the changed behavior is reachable and unverified. Stop when a test at that boundary would fail, the consumer does not observe the changed behavior, or the next hop is guesswork (dynamic dispatch, reflection, outside-repo consumers, etc.). Prefer the nearest observable boundary, often one to three hops away, especially across contract, integration, or service edges. If there are more than five similar consumers, group obvious repeats and check representative paths; expand only when a consumer observes the behavior differently.
+
+### Step 4: Qualify the consumer, then check its test
+
+For each consumer, name the smallest realistic regression this consumer would observe: invert the branch, drop the default, omit the field, return the old error code, skip the integration call, etc. This is the Demonstration. If no such regression exists, drop the path; untested downstream code is not a finding.
+
+A `Missing-adoption gap` qualifies not by the adoption failure alone but by a supersession signal: the change gives clear evidence the new behavior is meant to replace the local one — PR intent, naming or docs, a replaced sibling site, deleted duplicate logic, or a test defining the new rule — and the local site shares the same observable contract. Without a supersession signal and a shared observable contract, it is a refactor suggestion, not a verification-gap finding. Once both hold, check whether any test for that site would flag the non-adoption; missing coverage of the non-adoption is the gap itself, not a disqualifier.
+
+Find and read the relevant test. Ask whether the Demonstration would make an assertion fail.
+
+- If yes, the behavior is verified. No finding.
+- For a regression-style Demonstration: if no test runs the path, the test is skipped/flaky/not run normally, or the test runs the code without checking the changed result, report a `Regression gap` or `Broken-verification gap`.
+- For a qualifying Missing-adoption case: if none of the site tests you found assert it adopts the new behavior, report a `Missing-adoption gap`.
+
+A test counts only if it runs normally and an assertion observes the changed output, branch, or contract. These do not count: no execution; success/no-throw/snapshot-only checks; mock/log-call checks; human-only checks; tests that mock away the integration; e2e tests that pass through without checking the changed output; stale assertions or fixtures.
+
+Common patterns:
+
+- **Caller-path gap** — helper test covers the branch, but caller values skip it.
+- **Contract drift** — payload/schema/event changes must be verified at the consumer.
+- **Migration compatibility** — tests only create new-format rows or fresh schemas.
+- **Phantom exception** — handled partial-failure path has no test.
+- **Missing-adoption gap** — sibling site should use the new rule/helper and does not.
+- **Removed verification** — deleted test or weakened assertion leaves behavior unpinned.
+
+### Step 5: Confirm each finding is real
+
+Before writing a finding, re-open the specific tests or search results the finding relies on. Verify the Demonstration would not make any test you checked fail, or that the absence claim is backed by the symbol/import-reference search. Do not claim more than you verified; drop any finding you cannot ground.
+
+Do not report: compiler/type-checker-enforced cases; behavior already verified by an integration, contract, or e2e test; implementation-detail or mock-only tests; low coverage or a missing test file by itself; legacy untested code the change did not affect.
+
+Report genuine problems you noticed while tracing verification, even if they are not verification gaps. Put them under `Other findings` in the output. This permits reporting what you already reached, not extra hunting.
+
+## OUTPUT FORMAT
+
+Emit each verification-gap finding as one block. No general advice, no severity or confidence.
+
+```markdown
+### <one-line title naming the gap>
+
+- **Changed surface:** the exact behavior or contract that changed — `file:line`.
+- **Impacted consumer or site:** named concretely with `file:line` (e.g. "the `createInvoice` mutation used by the billing dashboard at `billing/dashboard.ts:88`," not "callers of this function").
+- **Existing test evidence:**
+  - `Regression gap`: what the relevant test actually asserts, with `file:line`; or, if none, the symbol/import-reference searches run and their result.
+  - `Missing-adoption gap`: tests for the impacted site, and whether any assert it adopts the new behavior.
+  - `Broken-verification gap`: the apparent test or verification path, and why it does not count.
+- **Missing verification:** the precise assertion or check that's absent.
+- **Demonstration:**
+  - `Regression gap` / `Broken-verification gap`: the concrete regression that would ship undetected, and why the tests you checked would not fail.
+  - `Missing-adoption gap`: the case the site mishandles by not adopting the new behavior, and that none of the tests you read assert adoption.
+- **Consequence:** the concrete thing that ships wrong — a regression the checked evidence would not catch, or a site that should use the new behavior and doesn't.
+- **Suggested test shape:** (optional) the kind of test that would close the gap, fit to the repo's own way of verifying — don't impose a generic test pyramid.
+```
+
+If you noticed genuine non-gap problems while tracing verification, append:
+
+```markdown
+## Other findings
+
+- <description only; no severity, confidence, priority, or ranking>
+```
+
+When you find no verification gaps and no other findings, output exactly this single line, not an empty response:
+
+`No verification gaps found.`
+## PROVIDED INPUTS
+
+**content:**
+
+{review_content}

--- a/src/bmm-skills/4-implementation/bmad-quick-dev/step-oneshot.md
+++ b/src/bmm-skills/4-implementation/bmad-quick-dev/step-oneshot.md
@@ -15,14 +15,6 @@ Follow `./sync-sprint-status.md` with `target_status` = `in-progress`.
 
 Implement the clarified intent directly.
 
-### Construct Changed-File Context
-
-Construct `{changed_files_context}` covering every tracked and untracked file
-changed by the implementation. Include the diff for tracked files. Include the
-full contents of untracked text files; for binary or undecodable untracked
-files, include no-index binary diff metadata instead. Do NOT `git add` anything
-— this is read-only inspection.
-
 ### Review
 
 Execute these review layers in parallel wherever their execution methods allow, following each layer's instruction verbatim after substituting any runtime placeholders:

--- a/src/bmm-skills/4-implementation/bmad-quick-dev/step-oneshot.md
+++ b/src/bmm-skills/4-implementation/bmad-quick-dev/step-oneshot.md
@@ -15,6 +15,14 @@ Follow `./sync-sprint-status.md` with `target_status` = `in-progress`.
 
 Implement the clarified intent directly.
 
+### Construct Changed-File Context
+
+Construct `{changed_files_context}` covering every tracked and untracked file
+changed by the implementation. Include the diff for tracked files. Include the
+full contents of untracked text files; for binary or undecodable untracked
+files, include no-index binary diff metadata instead. Do NOT `git add` anything
+— this is read-only inspection.
+
 ### Review
 
 Execute these review layers in parallel wherever their execution methods allow, following each layer's instruction verbatim after substituting any runtime placeholders:

--- a/test/test-quick-dev-renderer.js
+++ b/test/test-quick-dev-renderer.js
@@ -26,6 +26,7 @@
 const fs = require('node:fs');
 const os = require('node:os');
 const path = require('node:path');
+const crypto = require('node:crypto');
 const { spawnSync } = require('node:child_process');
 
 // ANSI color codes (same as other test files)
@@ -61,6 +62,34 @@ function assert(condition, message) {
 // ---------------------------------------------------------------------------
 
 const SKILL_SRC = path.join(__dirname, '..', 'src', 'bmm-skills', '4-implementation', 'bmad-quick-dev');
+const PHASE_FOUR_ROOT = path.join(__dirname, '..', 'src', 'bmm-skills', '4-implementation');
+const REVIEW_SKILLS = ['bmad-code-review', 'bmad-quick-dev', 'bmad-dev-auto'];
+const PROMPT_HASHES = {
+  'adversarial.md': '0e8b3393cd1962a393787654b4a2326565f4c1ac1164b31bda778112f24a6ec7',
+  'edge-case-hunter.md': '50612cc99eb591c894e3bb75960269c44325f020abc0ed6a34a786fb3c8ac896',
+  'verification-gap.md': '04524d69089762dc7e7a80f165396619daa1dbe81e2a090f5b78c9913f22f602',
+};
+const DELETION_CHECK_HASH = '0f1f124e4e957147e89164a272b10bedc694ad0d9ad2618c8610ac74ee9cb0da';
+
+function sha256(content) {
+  return crypto.createHash('sha256').update(content).digest('hex');
+}
+
+function recoveredPromptBody(name, content) {
+  const marker = name === 'edge-case-hunter.md' ? '<reference path=' : '## PROVIDED INPUTS';
+  return content.slice(0, content.indexOf(marker));
+}
+
+function workflowLayer(content, collection, id) {
+  const header = `[[workflow.${collection}]]`;
+  return (
+    content
+      .split(header)
+      .slice(1)
+      .map((block) => block.split('\n[[')[0])
+      .find((block) => block.includes(`id = "${id}"`)) || ''
+  );
+}
 
 /**
  * Recursively copy a directory (stdlib only, no fs.cp to stay >=20 compat).
@@ -243,8 +272,8 @@ try {
     const content = readRendered('step-04-review.md');
     assert(content.includes('#### Replaced Layer'), 'override layer name not used as block title');
     assert(content.includes('TEST_REPLACED_LAYER_INSTRUCTION'), 'override layer instruction not inlined');
-    assert(!content.includes('only the `edge-case-hunter` lens'), 'replaced default layer instruction still present');
-    assert(content.includes('only the `adversarial` lens'), 'untouched default layer dropped by keyed merge');
+    assert(!content.includes('review-prompts/edge-case-hunter.md'), 'replaced default layer instruction still present');
+    assert(content.includes('review-prompts/adversarial.md'), 'untouched default layer dropped by keyed merge');
   });
 
   test('empty-instruction override drops its layer entirely', () => {
@@ -311,6 +340,60 @@ try {
   test('no main_config reference survives in any rendered file', () => {
     const leaks = renderedMdFiles().filter((f) => readRendered(f).includes('main_config'));
     assert(leaks.length === 0, `main_config still referenced in: ${leaks.join(', ')} (the runtime config re-read was removed)`);
+  });
+
+  test('phase-four skills own exact pre-consolidation reviewer prompt bodies', () => {
+    for (const skill of REVIEW_SKILLS) {
+      const promptDir = path.join(PHASE_FOUR_ROOT, skill, 'review-prompts');
+      for (const [name, expectedHash] of Object.entries(PROMPT_HASHES)) {
+        const content = fs.readFileSync(path.join(promptDir, name), 'utf-8');
+        assert(sha256(recoveredPromptBody(name, content)) === expectedHash, `${skill}/${name} contract wording changed`);
+        assert(content.includes('{review_content}'), `${skill}/${name} has no review-content substitution point`);
+      }
+
+      const edgePrompt = fs.readFileSync(path.join(promptDir, 'edge-case-hunter.md'), 'utf-8');
+      const deletionStart = edgePrompt.indexOf('# Deletion Check');
+      const deletionEnd = edgePrompt.indexOf('</reference>');
+      assert(deletionStart !== -1 && deletionEnd > deletionStart, `${skill} does not embed the deletion-check contract`);
+      assert(sha256(edgePrompt.slice(deletionStart, deletionEnd)) === DELETION_CHECK_HASH, `${skill} deletion-check wording changed`);
+    }
+  });
+
+  test('phase-four handoffs render local prompts directly without invoking bmad-review', () => {
+    const expectedPrompts = {
+      'blind-hunter': 'adversarial.md',
+      'edge-case-hunter': 'edge-case-hunter.md',
+      'verification-gap': 'verification-gap.md',
+    };
+
+    for (const skill of REVIEW_SKILLS) {
+      const customization = fs.readFileSync(path.join(PHASE_FOUR_ROOT, skill, 'customize.toml'), 'utf-8');
+      assert(!customization.includes('Invoke the `bmad-review` skill'), `${skill} still delegates a reviewer to bmad-review`);
+      for (const [id, name] of Object.entries(expectedPrompts)) {
+        const layer = workflowLayer(customization, 'review_layers', id);
+        assert(layer.includes(`review-prompts/${name}`), `${skill}/${id} does not hand off its matching local prompt`);
+        assert(layer.includes('`{review_content}` placeholder'), `${skill}/${id} does not replace the prompt input`);
+        assert(layer.includes('{diff_output}'), `${skill}/${id} does not receive the review diff`);
+        assert(/using the entire rendered\s+prompt directly\./.test(layer), `${skill}/${id} does not launch the rendered prompt directly`);
+      }
+
+      const deletionReference = fs.readFileSync(path.join(PHASE_FOUR_ROOT, skill, 'references', 'deletion-check.md'), 'utf-8');
+      assert(sha256(deletionReference) === DELETION_CHECK_HASH, `${skill} local deletion-check reference wording changed`);
+    }
+  });
+
+  test('quick-dev one-shot review substitutes explicit changed-file context', () => {
+    const customization = fs.readFileSync(path.join(SKILL_SRC, 'customize.toml'), 'utf-8');
+    const oneShotStep = fs.readFileSync(path.join(SKILL_SRC, 'step-oneshot.md'), 'utf-8');
+    const layer = workflowLayer(customization, 'oneshot_review_layers', 'blind-hunter');
+    assert(layer.includes('review-prompts/adversarial.md'), 'one-shot handoff does not load its local adversarial prompt');
+    assert(layer.includes('`{review_content}` placeholder'), 'one-shot handoff does not replace the prompt input');
+    assert(layer.includes('{changed_files_context}'), 'one-shot handoff lacks context substitution');
+    assert(/using the entire rendered\s+prompt directly\./.test(layer), 'one-shot handoff does not launch the rendered prompt directly');
+    assert(oneShotStep.includes('Construct `{changed_files_context}`'), 'one-shot route does not construct changed-file context');
+    assert(oneShotStep.includes('Include the diff for tracked files.'), 'one-shot context omits tracked diffs');
+    assert(oneShotStep.includes('full contents of untracked text files'), 'one-shot context omits untracked text contents');
+    assert(oneShotStep.includes('no-index binary diff metadata'), 'one-shot context does not handle binary untracked files');
   });
 
   // ---------------------------------------------------------------------------

--- a/test/test-quick-dev-renderer.js
+++ b/test/test-quick-dev-renderer.js
@@ -26,7 +26,6 @@
 const fs = require('node:fs');
 const os = require('node:os');
 const path = require('node:path');
-const crypto = require('node:crypto');
 const { spawnSync } = require('node:child_process');
 
 // ANSI color codes (same as other test files)
@@ -62,34 +61,6 @@ function assert(condition, message) {
 // ---------------------------------------------------------------------------
 
 const SKILL_SRC = path.join(__dirname, '..', 'src', 'bmm-skills', '4-implementation', 'bmad-quick-dev');
-const PHASE_FOUR_ROOT = path.join(__dirname, '..', 'src', 'bmm-skills', '4-implementation');
-const REVIEW_SKILLS = ['bmad-code-review', 'bmad-quick-dev', 'bmad-dev-auto'];
-const PROMPT_HASHES = {
-  'adversarial.md': '0e8b3393cd1962a393787654b4a2326565f4c1ac1164b31bda778112f24a6ec7',
-  'edge-case-hunter.md': '50612cc99eb591c894e3bb75960269c44325f020abc0ed6a34a786fb3c8ac896',
-  'verification-gap.md': '04524d69089762dc7e7a80f165396619daa1dbe81e2a090f5b78c9913f22f602',
-};
-const DELETION_CHECK_HASH = '0f1f124e4e957147e89164a272b10bedc694ad0d9ad2618c8610ac74ee9cb0da';
-
-function sha256(content) {
-  return crypto.createHash('sha256').update(content).digest('hex');
-}
-
-function recoveredPromptBody(name, content) {
-  const marker = name === 'edge-case-hunter.md' ? '<reference path=' : '## PROVIDED INPUTS';
-  return content.slice(0, content.indexOf(marker));
-}
-
-function workflowLayer(content, collection, id) {
-  const header = `[[workflow.${collection}]]`;
-  return (
-    content
-      .split(header)
-      .slice(1)
-      .map((block) => block.split('\n[[')[0])
-      .find((block) => block.includes(`id = "${id}"`)) || ''
-  );
-}
 
 /**
  * Recursively copy a directory (stdlib only, no fs.cp to stay >=20 compat).
@@ -340,60 +311,6 @@ try {
   test('no main_config reference survives in any rendered file', () => {
     const leaks = renderedMdFiles().filter((f) => readRendered(f).includes('main_config'));
     assert(leaks.length === 0, `main_config still referenced in: ${leaks.join(', ')} (the runtime config re-read was removed)`);
-  });
-
-  test('phase-four skills own exact pre-consolidation reviewer prompt bodies', () => {
-    for (const skill of REVIEW_SKILLS) {
-      const promptDir = path.join(PHASE_FOUR_ROOT, skill, 'review-prompts');
-      for (const [name, expectedHash] of Object.entries(PROMPT_HASHES)) {
-        const content = fs.readFileSync(path.join(promptDir, name), 'utf-8');
-        assert(sha256(recoveredPromptBody(name, content)) === expectedHash, `${skill}/${name} contract wording changed`);
-        assert(content.includes('{review_content}'), `${skill}/${name} has no review-content substitution point`);
-      }
-
-      const edgePrompt = fs.readFileSync(path.join(promptDir, 'edge-case-hunter.md'), 'utf-8');
-      const deletionStart = edgePrompt.indexOf('# Deletion Check');
-      const deletionEnd = edgePrompt.indexOf('</reference>');
-      assert(deletionStart !== -1 && deletionEnd > deletionStart, `${skill} does not embed the deletion-check contract`);
-      assert(sha256(edgePrompt.slice(deletionStart, deletionEnd)) === DELETION_CHECK_HASH, `${skill} deletion-check wording changed`);
-    }
-  });
-
-  test('phase-four handoffs render local prompts directly without invoking bmad-review', () => {
-    const expectedPrompts = {
-      'blind-hunter': 'adversarial.md',
-      'edge-case-hunter': 'edge-case-hunter.md',
-      'verification-gap': 'verification-gap.md',
-    };
-
-    for (const skill of REVIEW_SKILLS) {
-      const customization = fs.readFileSync(path.join(PHASE_FOUR_ROOT, skill, 'customize.toml'), 'utf-8');
-      assert(!customization.includes('Invoke the `bmad-review` skill'), `${skill} still delegates a reviewer to bmad-review`);
-      for (const [id, name] of Object.entries(expectedPrompts)) {
-        const layer = workflowLayer(customization, 'review_layers', id);
-        assert(layer.includes(`review-prompts/${name}`), `${skill}/${id} does not hand off its matching local prompt`);
-        assert(layer.includes('`{review_content}` placeholder'), `${skill}/${id} does not replace the prompt input`);
-        assert(layer.includes('{diff_output}'), `${skill}/${id} does not receive the review diff`);
-        assert(/using the entire rendered\s+prompt directly\./.test(layer), `${skill}/${id} does not launch the rendered prompt directly`);
-      }
-
-      const deletionReference = fs.readFileSync(path.join(PHASE_FOUR_ROOT, skill, 'references', 'deletion-check.md'), 'utf-8');
-      assert(sha256(deletionReference) === DELETION_CHECK_HASH, `${skill} local deletion-check reference wording changed`);
-    }
-  });
-
-  test('quick-dev one-shot review substitutes explicit changed-file context', () => {
-    const customization = fs.readFileSync(path.join(SKILL_SRC, 'customize.toml'), 'utf-8');
-    const oneShotStep = fs.readFileSync(path.join(SKILL_SRC, 'step-oneshot.md'), 'utf-8');
-    const layer = workflowLayer(customization, 'oneshot_review_layers', 'blind-hunter');
-    assert(layer.includes('review-prompts/adversarial.md'), 'one-shot handoff does not load its local adversarial prompt');
-    assert(layer.includes('`{review_content}` placeholder'), 'one-shot handoff does not replace the prompt input');
-    assert(layer.includes('{changed_files_context}'), 'one-shot handoff lacks context substitution');
-    assert(/using the entire rendered\s+prompt directly\./.test(layer), 'one-shot handoff does not launch the rendered prompt directly');
-    assert(oneShotStep.includes('Construct `{changed_files_context}`'), 'one-shot route does not construct changed-file context');
-    assert(oneShotStep.includes('Include the diff for tracked files.'), 'one-shot context omits tracked diffs');
-    assert(oneShotStep.includes('full contents of untracked text files'), 'one-shot context omits untracked text contents');
-    assert(oneShotStep.includes('no-index binary diff metadata'), 'one-shot context does not handle binary untracked files');
   });
 
   // ---------------------------------------------------------------------------


### PR DESCRIPTION
## What

Restore direct, single-purpose reviewer prompts for `bmad-code-review`, `bmad-quick-dev`, and `bmad-dev-auto` without reverting unrelated parts of PR #2603.

## Why

The phase-four workflows previously handed fresh reviewers complete adversarial, edge-case, and verification-gap contracts. PR #2603 replaced those contracts with requests to invoke consolidated `bmad-review` lenses, changing reviewer semantics and output guarantees.

## How

- Add independently owned local copies of the exact pre-consolidation prompt bodies and deletion-check reference to each workflow.
- Render each local prompt with diff context and dispatch it directly to a context-free reviewer.
- Cover Quick Dev's normal and one-shot paths while preserving configurable layers, auditors, triage, and repair behavior.
- Update the existing deterministic keyed-layer renderer assertion for the new local prompt paths.

## Testing

- `HUSKY=0 npm ci && npm run quality`
- Functional subagent test across all three skills using an isolated `/tmp` fixture with tracked changes, meaningful deletion, untracked text, and binary content.
- Focused Quick Dev one-shot rerun on the final handoff confirmed that a fresh reviewer independently discovered tracked and untracked worktree changes without staging files.
- Confirmed every skill progressively loaded its own adversarial, edge-case, verification-gap, and deletion-check files without invoking `bmad-review`.
- Confirmed Quick Dev normal and one-shot dispatch, deletion JSON findings, and evidence-grounded verification-gap output.
