### PR TITLE
fix(code-review): make no-spec mode an explicit supported path

### DIFF
--- a/src/bmm-skills/4-implementation/bmad-code-review/steps/step-01-gather-context.md
+++ b/src/bmm-skills/4-implementation/bmad-code-review/steps/step-01-gather-context.md
@@ -64,7 +64,7 @@ story_key: '' # set at runtime when discovered from sprint status
    - After constructing `{diff_output}`, verify it is non-empty regardless of source type. If empty, HALT and tell the user there is nothing to review.
 
 4. **Set the spec context.**
-   - If the triggering request or recent conversation **explicitly** states there is no spec (e.g. "no spec", "without a spec", "no-spec"): set `{review_mode}` = `"no-spec"`. Do **not** ask for a spec. Do **not** infer no-spec mode merely because the invocation omitted a spec path.
+   - If the triggering request or recent conversation **explicitly** states there is no spec (e.g. "no spec", "without a spec", "no-spec"): set `{review_mode}` = `"no-spec"` and clear `{spec_file}` (set it to `''`). Do **not** ask for a spec. Do **not** infer no-spec mode merely because the invocation omitted a spec path.
    - Else if `{spec_file}` is already set (from Tier 1 or Tier 2): verify the file exists and is readable, then set `{review_mode}` = `"full"`.
    - Else (neither a spec path nor an explicit no-spec declaration is present): ask the user to choose:
      1. Provide a spec or story file path for context; or

--- a/src/bmm-skills/4-implementation/bmad-code-review/steps/step-01-gather-context.md
+++ b/src/bmm-skills/4-implementation/bmad-code-review/steps/step-01-gather-context.md
@@ -64,10 +64,13 @@ story_key: '' # set at runtime when discovered from sprint status
    - After constructing `{diff_output}`, verify it is non-empty regardless of source type. If empty, HALT and tell the user there is nothing to review.
 
 4. **Set the spec context.**
-   - If `{spec_file}` is already set (from Tier 1 or Tier 2): verify the file exists and is readable, then set `{review_mode}` = `"full"`.
-   - Otherwise, ask the user: **Is there a spec or story file that provides context for these changes?**
-     - If yes: set `{spec_file}` to the path provided, verify the file exists and is readable, then set `{review_mode}` = `"full"`.
-     - If no: set `{review_mode}` = `"no-spec"`.
+   - If the triggering request or recent conversation **explicitly** states there is no spec (e.g. "no spec", "without a spec", "no-spec"): set `{review_mode}` = `"no-spec"`. Do **not** ask for a spec. Do **not** infer no-spec mode merely because the invocation omitted a spec path.
+   - Else if `{spec_file}` is already set (from Tier 1 or Tier 2): verify the file exists and is readable, then set `{review_mode}` = `"full"`.
+   - Else (neither a spec path nor an explicit no-spec declaration is present): ask the user to choose:
+     1. Provide a spec or story file path for context; or
+     2. Continue without a spec.
+     - If the user provides a path: set `{spec_file}` to that path, verify the file exists and is readable, then set `{review_mode}` = `"full"`.
+     - If the user explicitly chooses to continue without a spec: set `{review_mode}` = `"no-spec"`.
 
 5. If `{review_mode}` = `"full"` and the file at `{spec_file}` has a `context` field in its frontmatter listing additional docs, load each referenced document. Warn the user about any docs that cannot be found.
 


### PR DESCRIPTION
## Summary

- Clarifies `bmad-code-review` Step 1 spec-context selection so no-spec review is an explicit supported path.
- Honors an explicit no-spec declaration in the trigger/conversation without asking for a spec.
- Does not infer no-spec merely because a spec path was omitted.
- When neither a known `{spec_file}` nor an explicit no-spec declaration is present, asks the user to choose between providing a path or continuing without a spec.
- Replaces bare "If yes / If no" conditions with conditions that name the relevant user response.

Checkpoint and all downstream workflow behavior (reviewer selection, triage, presentation, existing no-spec handling) are unchanged.

## Test plan

- [x] `HUSKY=0 npm run quality` on the feature worktree
- [ ] Spot-check Step 1: trigger with explicit "no spec" → `{review_mode}` = `"no-spec"` without a prompt
- [ ] Spot-check Step 1: provide a spec path → `{review_mode}` = `"full"` after verification
- [ ] Spot-check Step 1: omit both → agent offers path vs continue-without choices
- [ ] Confirm checkpoint and later steps still behave as before in both modes