### PR TITLE
fix(review): focus verification gaps on behavior

### DIFF
--- a/src/core-skills/bmad-review/references/lens-verification-gap.md
+++ b/src/core-skills/bmad-review/references/lens-verification-gap.md
@@ -30,6 +30,8 @@ Identify what behavior changed compared to the previous version: output, side ef
 
 Treat broad-impact changes as behavioral even when no single changed line looks important: dependency, toolchain, build/config, data-file, etc.
 
+For LLM prompts, verify deterministic construction and transformation, including the generated output's exact content or structure. Do not seek assertions that phrases exist directly in hand-authored prompts, skills, documents, or source files. Do not require crossing the inference boundary by invoking a model or judging its semantic response. Deterministic request construction and response handling remain eligible without live inference; existing inference tests are not precedent for more.
+
 ### Step 3: Trace where that behavior is used
 
 Trace the changed behavior to the places that observe it. Start with direct callers and registered entry points (routes, commands, DI), contract consumers (schemas, events, APIs, database readers), and reverse-dependency info if already available.

--- a/src/core-skills/bmad-review/references/lens-verification-gap.md
+++ b/src/core-skills/bmad-review/references/lens-verification-gap.md
@@ -30,7 +30,9 @@ Identify what behavior changed compared to the previous version: output, side ef
 
 Treat broad-impact changes as behavioral even when no single changed line looks important: dependency, toolchain, build/config, data-file, etc.
 
-For LLM prompts, verify deterministic construction and transformation, including the generated output's exact content or structure. Do not seek assertions that phrases exist directly in hand-authored prompts, skills, documents, or source files. Do not require crossing the inference boundary by invoking a model or judging its semantic response. Deterministic request construction and response handling remain eligible without live inference; existing inference tests are not precedent for more.
+Seek verification of behavior, not the literal text of implementation or documentation artifacts. Exact content or structure remains eligible when it is output produced by deterministic construction or transformation, including generated prompts and request payloads. Do not seek phrase-existence assertions over hand-authored prompts, skills, documents, or source files.
+
+For LLM-backed behavior, stop at the inference boundary: do not require invoking a model or judging its semantic response. Deterministic request construction and response handling remain eligible without live inference; existing inference tests are not precedent for more.
 
 ### Step 3: Trace where that behavior is used
 


### PR DESCRIPTION
## What

Focus verification-gap reviews on observable behavior rather than literal text in hand-authored implementation or documentation artifacts, and stop LLM checks at the inference boundary.

## Why

Verification reviews were creating obligations for phrase-existence assertions over prompts, skills, documents, and source files, as well as live model inference. Those tests are brittle or nondeterministic without protecting computed behavior.

## How

- Exclude direct phrase assertions over hand-authored artifacts.
- Keep exact generated content eligible when deterministic code constructs or transforms it.
- Exclude live inference and semantic response judgment while retaining deterministic request construction and response handling.

## Testing

- `HUSKY=0 npm ci && npm run quality`
- Old/new isolated review of `85be6e0b`: the old lens requested source-text assertions; the revised lens requested only deterministic generated-handoff checks.
