### PR TITLE
Allow configuring the Build spec editor handoff

### DIFF
--- a/docs/explanation/checkpoint-preview.md
+++ b/docs/explanation/checkpoint-preview.md
@@ -11,7 +11,7 @@ sidebar:
 
 ## The Typical Flow
 
-You run `bmad-build`. It clarifies your intent, builds a spec, implements the change, and when it's done it appends a review trail to the spec file and opens it in VS Code by default, or in the application configured through Build's customization layer. You look at the spec and see the change touched 20 files across several modules.
+You run `bmad-build`. It clarifies your intent, builds a spec, implements the change, and when it's done it appends a review trail to the spec file and opens it in VS Code by default, or in the application configured through Build's customization layer. Automatic opening can also be disabled by setting `workflow.open_spec` to an empty string. You look at the spec and see the change touched 20 files across several modules.
 
 You could eyeball the diff. But 20 files is where eyeballing starts to fail — you lose the thread, miss a connection between two distant changes, or approve something you didn't fully understand. So instead, you say "checkpoint" and the LLM walks you through it.
 

--- a/docs/explanation/checkpoint-preview.md
+++ b/docs/explanation/checkpoint-preview.md
@@ -11,7 +11,7 @@ sidebar:
 
 ## The Typical Flow
 
-You run `bmad-build`. It clarifies your intent, builds a spec, implements the change, and when it's done it appends a review trail to the spec file and opens it in your editor. You look at the spec and see the change touched 20 files across several modules.
+You run `bmad-build`. It clarifies your intent, builds a spec, implements the change, and when it's done it appends a review trail to the spec file and sends it to your configured application or the operating system's registered handler. You look at the spec and see the change touched 20 files across several modules.
 
 You could eyeball the diff. But 20 files is where eyeballing starts to fail — you lose the thread, miss a connection between two distant changes, or approve something you didn't fully understand. So instead, you say "checkpoint" and the LLM walks you through it.
 

--- a/docs/explanation/checkpoint-preview.md
+++ b/docs/explanation/checkpoint-preview.md
@@ -11,7 +11,7 @@ sidebar:
 
 ## The Typical Flow
 
-You run `bmad-build`. It clarifies your intent, builds a spec, implements the change, and when it's done it appends a review trail to the spec file and opens it in VS Code by default, or in the application configured through Build's customization layer. Automatic opening can also be disabled by setting `workflow.open_spec` to an empty string. You look at the spec and see the change touched 20 files across several modules.
+You run `bmad-build`. It clarifies your intent, builds a spec, implements the change, and when it's done it appends a review trail to the spec file and opens it in VS Code; the editor is customizable. You look at the spec and see the change touched 20 files across several modules.
 
 You could eyeball the diff. But 20 files is where eyeballing starts to fail — you lose the thread, miss a connection between two distant changes, or approve something you didn't fully understand. So instead, you say "checkpoint" and the LLM walks you through it.
 

--- a/docs/explanation/checkpoint-preview.md
+++ b/docs/explanation/checkpoint-preview.md
@@ -11,7 +11,7 @@ sidebar:
 
 ## The Typical Flow
 
-You run `bmad-build`. It clarifies your intent, builds a spec, implements the change, and when it's done it appends a review trail to the spec file and sends it to your configured application or the operating system's registered handler. You look at the spec and see the change touched 20 files across several modules.
+You run `bmad-build`. It clarifies your intent, builds a spec, implements the change, and when it's done it appends a review trail to the spec file and opens it in VS Code by default, or in the application configured through Build's customization layer. You look at the spec and see the change touched 20 files across several modules.
 
 You could eyeball the diff. But 20 files is where eyeballing starts to fail — you lose the thread, miss a connection between two distant changes, or approve something you didn't fully understand. So instead, you say "checkpoint" and the LLM walks you through it.
 

--- a/docs/explanation/checkpoint-preview.md
+++ b/docs/explanation/checkpoint-preview.md
@@ -11,7 +11,7 @@ sidebar:
 
 ## The Typical Flow
 
-You run `bmad-build`. It clarifies your intent, builds a spec, implements the change, and when it's done it appends a review trail to the spec file and opens it in VS Code; the editor is customizable. You look at the spec and see the change touched 20 files across several modules.
+You run `bmad-build`. It clarifies your intent, builds a spec, implements the change, and when it's done it appends a review trail to the spec file and shows it to you. You look at the spec and see the change touched 20 files across several modules.
 
 You could eyeball the diff. But 20 files is where eyeballing starts to fail — you lose the thread, miss a connection between two distant changes, or approve something you didn't fully understand. So instead, you say "checkpoint" and the LLM walks you through it.
 

--- a/docs/how-to/quick-fixes.md
+++ b/docs/how-to/quick-fixes.md
@@ -62,7 +62,7 @@ Build may ask clarifying questions or present a short spec for your approval bef
 
 ### 4. Review and Push
 
-Build implements the change, reviews its own work, patches issues, and commits locally. When it's done, it sends the review spec to your configured application or the operating system's registered handler.
+Build implements the change, reviews its own work, patches issues, and commits locally. When it's done, it opens the review spec in VS Code by default, or in the application configured through Build's customization layer.
 
 - Skim the diff to confirm the change matches your intent
 - If something looks off, tell the agent what to fix — it can iterate in the same session

--- a/docs/how-to/quick-fixes.md
+++ b/docs/how-to/quick-fixes.md
@@ -62,7 +62,7 @@ Build may ask clarifying questions or present a short spec for your approval bef
 
 ### 4. Review and Push
 
-Build implements the change, reviews its own work, patches issues, and commits locally. When it's done, it opens the review spec in VS Code; the editor is customizable.
+Build implements the change, reviews its own work, patches issues, and commits locally. When it's done, it shows you the review spec.
 
 - Skim the diff to confirm the change matches your intent
 - If something looks off, tell the agent what to fix — it can iterate in the same session

--- a/docs/how-to/quick-fixes.md
+++ b/docs/how-to/quick-fixes.md
@@ -62,7 +62,7 @@ Build may ask clarifying questions or present a short spec for your approval bef
 
 ### 4. Review and Push
 
-Build implements the change, reviews its own work, patches issues, and commits locally. When it's done, it opens the review spec in VS Code by default, or in the application configured through Build's customization layer.
+Build implements the change, reviews its own work, patches issues, and commits locally. When it's done, it opens the review spec in VS Code by default, or in the application configured through Build's customization layer. Set `workflow.open_spec` to an empty string to disable automatic opening.
 
 - Skim the diff to confirm the change matches your intent
 - If something looks off, tell the agent what to fix — it can iterate in the same session

--- a/docs/how-to/quick-fixes.md
+++ b/docs/how-to/quick-fixes.md
@@ -62,7 +62,7 @@ Build may ask clarifying questions or present a short spec for your approval bef
 
 ### 4. Review and Push
 
-Build implements the change, reviews its own work, patches issues, and commits locally. When it's done, it opens the review spec in VS Code by default, or in the application configured through Build's customization layer. Set `workflow.open_spec` to an empty string to disable automatic opening.
+Build implements the change, reviews its own work, patches issues, and commits locally. When it's done, it opens the review spec in VS Code; the editor is customizable.
 
 - Skim the diff to confirm the change matches your intent
 - If something looks off, tell the agent what to fix — it can iterate in the same session

--- a/docs/how-to/quick-fixes.md
+++ b/docs/how-to/quick-fixes.md
@@ -62,7 +62,7 @@ Build may ask clarifying questions or present a short spec for your approval bef
 
 ### 4. Review and Push
 
-Build implements the change, reviews its own work, patches issues, and commits locally. When it's done, it opens the affected files in your editor.
+Build implements the change, reviews its own work, patches issues, and commits locally. When it's done, it sends the review spec to your configured application or the operating system's registered handler.
 
 - Skim the diff to confirm the change matches your intent
 - If something looks off, tell the agent what to fix — it can iterate in the same session

--- a/src/bmm-skills/4-implementation/bmad-build/customize.toml
+++ b/src/bmm-skills/4-implementation/bmad-build/customize.toml
@@ -62,6 +62,10 @@ on_complete = ""
 #
 # Emacs — reuse an Emacs server without waiting for the buffer to close:
 #   Run `cd "{project-root}" && emacsclient -n "{spec_file}"`.
+#
+# For every non-empty override, also tell Build to note in the completion summary
+# that the spec was sent to the chosen editor and contains a Suggested Review
+# Order, then include the default navigation tip shown below.
 
 open_spec = """
 Run `code -r "{project-root}" "{spec_file}"` — the repository root first so VS Code opens in the right context, then the spec file. Always double-quote both paths to handle spaces and special characters. If `code` is unavailable or the command fails, skip gracefully and tell the user the spec file path instead. In the completion summary, note that the spec was sent to VS Code and that it contains a Suggested Review Order, then add this navigation tip: "Ctrl+click (Cmd+click on macOS) the links in the Suggested Review Order to jump to each stop."

--- a/src/bmm-skills/4-implementation/bmad-build/customize.toml
+++ b/src/bmm-skills/4-implementation/bmad-build/customize.toml
@@ -33,13 +33,16 @@ persistent_facts = [
 
 on_complete = ""
 
-# How Build opens a completed spec for human review. Override this with the
-# application and behavior you prefer, or instruct Build not to open it.
+# How Build opens a completed spec for human review. The default deliberately
+# opens the repository root first and the spec second in a reused VS Code
+# window so relative review links resolve in the correct workspace. Override
+# this with the application and equivalent behavior you prefer, or instruct
+# Build not to open it.
 # Example requests for bmad-customize: "Open completed specs in Cursor and
 # reuse the project window" or "Do not open completed specs automatically."
 
 open_spec = """
-Open the completed spec with the standard file-opening facility available in the current environment, delegating application choice to the operating system's registered handler. Do not probe for or prefer editor-specific commands. If no graphical system opener is available, skip gracefully.
+Run `code -r "{absolute-root}" "{absolute-spec-file}"` — the repository root first so VS Code opens in the right context, then the spec file. Always double-quote both absolute paths to handle spaces and special characters. If `code` is unavailable or the command fails, skip gracefully.
 """
 
 # Handoff for the implementation subagent in step 03. The whole execution

--- a/src/bmm-skills/4-implementation/bmad-build/customize.toml
+++ b/src/bmm-skills/4-implementation/bmad-build/customize.toml
@@ -33,6 +33,15 @@ persistent_facts = [
 
 on_complete = ""
 
+# How Build opens a completed spec for human review. Override this with the
+# application and behavior you prefer, or instruct Build not to open it.
+# Example requests for bmad-customize: "Open completed specs in Cursor and
+# reuse the project window" or "Do not open completed specs automatically."
+
+open_spec = """
+Open the completed spec with the standard file-opening facility available in the current environment, delegating application choice to the operating system's registered handler. Do not probe for or prefer editor-specific commands. If no graphical system opener is available, skip gracefully.
+"""
+
 # Handoff for the implementation subagent in step 03. The whole execution
 # recipe — a subagent by default, but an override may run it any other way
 # (a different model, an external coding tool via bash). {spec_file} is

--- a/src/bmm-skills/4-implementation/bmad-build/customize.toml
+++ b/src/bmm-skills/4-implementation/bmad-build/customize.toml
@@ -42,28 +42,29 @@ on_complete = ""
 # reuse the project window" or "Do not open completed specs automatically."
 #
 # Example `open_spec` override instructions for bmad-build.user.toml:
+# {project-root} and {spec_file} are substituted at run time.
 #
 # VS Code and compatible GUI editors — shipped default uses `code`; Cursor,
 # Windsurf, Antigravity, Zed, and similar editors can substitute their launcher.
 # Preserve reuse-window behavior when the launcher supports it, and always pass
 # the repository root first and the spec second:
-#   Run `code -r "{absolute-root}" "{absolute-spec-file}"`, root first.
-#   Run `cursor -r "{absolute-root}" "{absolute-spec-file}"`, root first.
-#   Run `windsurf -r "{absolute-root}" "{absolute-spec-file}"`, root first.
-#   Run `zed "{absolute-root}" "{absolute-spec-file}"`, root first.
+#   Run `code -r "{project-root}" "{spec_file}"`, root first.
+#   Run `cursor -r "{project-root}" "{spec_file}"`, root first.
+#   Run `windsurf -r "{project-root}" "{spec_file}"`, root first.
+#   Run `zed "{project-root}" "{spec_file}"`, root first.
 #
 # IntelliJ IDEA — its CLI accepts one path per invocation:
-#   Run `idea "{absolute-root}"` to open the project, then
-#   `idea "{absolute-spec-file}"` to open the spec in that project.
+#   Run `idea "{project-root}"` to open the project, then
+#   `idea "{spec_file}"` to open the spec in that project.
 #
 # Vim — keep repository context as the working directory:
-#   Run `cd "{absolute-root}" && vim "{absolute-spec-file}"`.
+#   Run `cd "{project-root}" && vim "{spec_file}"`.
 #
 # Emacs — reuse an Emacs server without waiting for the buffer to close:
-#   Run `cd "{absolute-root}" && emacsclient -n "{absolute-spec-file}"`.
+#   Run `cd "{project-root}" && emacsclient -n "{spec_file}"`.
 
 open_spec = """
-Resolve two absolute paths: (1) the repository root (`git rev-parse --show-toplevel` — returns the worktree root when in a worktree, project root otherwise; if this fails, fall back to the current working directory), (2) `{spec_file}`. Run `code -r "{absolute-root}" "{absolute-spec-file}"` — the repository root first so VS Code opens in the right context, then the spec file. Always double-quote both absolute paths to handle spaces and special characters. If `code` is unavailable or the command fails, skip gracefully and tell the user the spec file path instead. In the completion summary, note that the spec was sent to VS Code and that it contains a Suggested Review Order, then add this navigation tip: "Ctrl+click (Cmd+click on macOS) the links in the Suggested Review Order to jump to each stop."
+Run `code -r "{project-root}" "{spec_file}"` — the repository root first so VS Code opens in the right context, then the spec file. Always double-quote both paths to handle spaces and special characters. If `code` is unavailable or the command fails, skip gracefully and tell the user the spec file path instead. In the completion summary, note that the spec was sent to VS Code and that it contains a Suggested Review Order, then add this navigation tip: "Ctrl+click (Cmd+click on macOS) the links in the Suggested Review Order to jump to each stop."
 """
 
 # Handoff for the implementation subagent in step 03. The whole execution

--- a/src/bmm-skills/4-implementation/bmad-build/customize.toml
+++ b/src/bmm-skills/4-implementation/bmad-build/customize.toml
@@ -36,13 +36,13 @@ on_complete = ""
 # How Build opens a completed spec for human review. The default deliberately
 # opens the repository root first and the spec second in a reused VS Code
 # window so relative review links resolve in the correct workspace. Override
-# this with the application and equivalent behavior you prefer, or instruct
-# Build not to open it.
+# this with the application and equivalent behavior you prefer. Set it to an
+# empty string to disable automatic opening and all related completion output.
 # Example requests for bmad-customize: "Open completed specs in Cursor and
 # reuse the project window" or "Do not open completed specs automatically."
 
 open_spec = """
-Run `code -r "{absolute-root}" "{absolute-spec-file}"` — the repository root first so VS Code opens in the right context, then the spec file. Always double-quote both absolute paths to handle spaces and special characters. If `code` is unavailable or the command fails, skip gracefully.
+Resolve two absolute paths: (1) the repository root (`git rev-parse --show-toplevel` — returns the worktree root when in a worktree, project root otherwise; if this fails, fall back to the current working directory), (2) `{spec_file}`. Run `code -r "{absolute-root}" "{absolute-spec-file}"` — the repository root first so VS Code opens in the right context, then the spec file. Always double-quote both absolute paths to handle spaces and special characters. If `code` is unavailable or the command fails, skip gracefully and tell the user the spec file path instead. In the completion summary, note that the spec was sent to VS Code and that it contains a Suggested Review Order, then add this navigation tip: "Ctrl+click (Cmd+click on macOS) the links in the Suggested Review Order to jump to each stop."
 """
 
 # Handoff for the implementation subagent in step 03. The whole execution

--- a/src/bmm-skills/4-implementation/bmad-build/customize.toml
+++ b/src/bmm-skills/4-implementation/bmad-build/customize.toml
@@ -40,6 +40,27 @@ on_complete = ""
 # empty string to disable automatic opening and all related completion output.
 # Example requests for bmad-customize: "Open completed specs in Cursor and
 # reuse the project window" or "Do not open completed specs automatically."
+#
+# Example `open_spec` override instructions for bmad-build.user.toml:
+#
+# VS Code and compatible GUI editors — shipped default uses `code`; Cursor,
+# Windsurf, Antigravity, Zed, and similar editors can substitute their launcher.
+# Preserve reuse-window behavior when the launcher supports it, and always pass
+# the repository root first and the spec second:
+#   Run `code -r "{absolute-root}" "{absolute-spec-file}"`, root first.
+#   Run `cursor -r "{absolute-root}" "{absolute-spec-file}"`, root first.
+#   Run `windsurf -r "{absolute-root}" "{absolute-spec-file}"`, root first.
+#   Run `zed "{absolute-root}" "{absolute-spec-file}"`, root first.
+#
+# IntelliJ IDEA — its CLI accepts one path per invocation:
+#   Run `idea "{absolute-root}"` to open the project, then
+#   `idea "{absolute-spec-file}"` to open the spec in that project.
+#
+# Vim — keep repository context as the working directory:
+#   Run `cd "{absolute-root}" && vim "{absolute-spec-file}"`.
+#
+# Emacs — reuse an Emacs server without waiting for the buffer to close:
+#   Run `cd "{absolute-root}" && emacsclient -n "{absolute-spec-file}"`.
 
 open_spec = """
 Resolve two absolute paths: (1) the repository root (`git rev-parse --show-toplevel` — returns the worktree root when in a worktree, project root otherwise; if this fails, fall back to the current working directory), (2) `{spec_file}`. Run `code -r "{absolute-root}" "{absolute-spec-file}"` — the repository root first so VS Code opens in the right context, then the spec file. Always double-quote both absolute paths to handle spaces and special characters. If `code` is unavailable or the command fails, skip gracefully and tell the user the spec file path instead. In the completion summary, note that the spec was sent to VS Code and that it contains a Suggested Review Order, then add this navigation tip: "Ctrl+click (Cmd+click on macOS) the links in the Suggested Review Order to jump to each stop."

--- a/src/bmm-skills/4-implementation/bmad-build/render.py
+++ b/src/bmm-skills/4-implementation/bmad-build/render.py
@@ -392,10 +392,10 @@ def main():
     skill_dir = script_dir.replace(os.sep, "/")
     workflow = resolve_workflow(root, skill_dir, skill_name)
     open_spec = workflow.get("open_spec")
-    if not isinstance(open_spec, str) or not open_spec.strip():
+    if not isinstance(open_spec, str):
         print(
             "HALT and report to the user: customization `workflow.open_spec` "
-            "must be a non-empty string"
+            "must be a string"
         )
         sys.exit(1)
     workflow = expand_review_layer_skill_roots(workflow, skill_dir)

--- a/src/bmm-skills/4-implementation/bmad-build/render.py
+++ b/src/bmm-skills/4-implementation/bmad-build/render.py
@@ -391,6 +391,13 @@ def main():
 
     skill_dir = script_dir.replace(os.sep, "/")
     workflow = resolve_workflow(root, skill_dir, skill_name)
+    open_spec = workflow.get("open_spec")
+    if not isinstance(open_spec, str) or not open_spec.strip():
+        print(
+            "HALT and report to the user: customization `workflow.open_spec` "
+            "must be a non-empty string"
+        )
+        sys.exit(1)
     workflow = expand_review_layer_skill_roots(workflow, skill_dir)
 
     out_dir = posixpath.join(root, "_bmad", "render", skill_name)

--- a/src/bmm-skills/4-implementation/bmad-build/step-05-present.md
+++ b/src/bmm-skills/4-implementation/bmad-build/step-05-present.md
@@ -54,22 +54,16 @@ Change `{spec_file}` status to `done` in the frontmatter.
 
 Follow `./sync-sprint-status.md` with `target_status` = `review`.
 
-### Commit and Open
+### Commit and Complete
 
 If version control is available and the tree is dirty, create a local commit with a conventional message derived from the spec title.
 
-Resolve two absolute paths: (1) the repository root (`git rev-parse --show-toplevel` — returns the worktree root when in a worktree, project root otherwise; if this fails, fall back to the current working directory), (2) `{spec_file}`. Then follow this configured opening instruction using `{absolute-root}` and `{absolute-spec-file}`:
-
 {workflow.open_spec}
-
-If opening was skipped or failed, tell the user the spec file path instead.
 
 ### Display Summary
 
 Display summary of your work to the user, including the commit hash if one was created. Any file paths shown in conversation/terminal output must use CWD-relative format (no leading `/`) with `:line` notation (e.g., `src/path/file.ts:42`) for terminal clickability — the goal is to make paths clickable in terminal emulators. Include:
 
-- A note that the spec was sent to their configured application (or the file path if it couldn't be opened). Mention that `{spec_file}` now contains a Suggested Review Order.
-- **Navigation tip:** "Ctrl+click (Cmd+click on macOS) the links in the Suggested Review Order to jump to each stop."
 - Offer to push and/or create a pull request.
 
 Workflow complete.

--- a/src/bmm-skills/4-implementation/bmad-build/step-05-present.md
+++ b/src/bmm-skills/4-implementation/bmad-build/step-05-present.md
@@ -58,7 +58,7 @@ Follow `./sync-sprint-status.md` with `target_status` = `review`.
 
 If version control is available and the tree is dirty, create a local commit with a conventional message derived from the spec title.
 
-Resolve two absolute paths: (1) the BMad project root `{{.project_root}}`, (2) `{spec_file}`. Then follow this configured opening instruction using those paths:
+Resolve two absolute paths: (1) the repository root (`git rev-parse --show-toplevel` — returns the worktree root when in a worktree, project root otherwise; if this fails, fall back to the current working directory), (2) `{spec_file}`. Then follow this configured opening instruction using `{absolute-root}` and `{absolute-spec-file}`:
 
 {workflow.open_spec}
 
@@ -68,8 +68,8 @@ If opening was skipped or failed, tell the user the spec file path instead.
 
 Display summary of your work to the user, including the commit hash if one was created. Any file paths shown in conversation/terminal output must use CWD-relative format (no leading `/`) with `:line` notation (e.g., `src/path/file.ts:42`) for terminal clickability — the goal is to make paths clickable in terminal emulators. Include:
 
-- A note that the spec was sent to their configured application or system handler (or the file path if it couldn't be opened). Mention that `{spec_file}` now contains a Suggested Review Order.
-- **Navigation tip:** "Follow the links in the Suggested Review Order to jump to each stop; in source-mode editors this may require Ctrl+click (Cmd+click on macOS)."
+- A note that the spec was sent to their configured application (or the file path if it couldn't be opened). Mention that `{spec_file}` now contains a Suggested Review Order.
+- **Navigation tip:** "Ctrl+click (Cmd+click on macOS) the links in the Suggested Review Order to jump to each stop."
 - Offer to push and/or create a pull request.
 
 Workflow complete.

--- a/src/bmm-skills/4-implementation/bmad-build/step-05-present.md
+++ b/src/bmm-skills/4-implementation/bmad-build/step-05-present.md
@@ -56,17 +56,20 @@ Follow `./sync-sprint-status.md` with `target_status` = `review`.
 
 ### Commit and Open
 
-1. If version control is available and the tree is dirty, create a local commit with a conventional message derived from the spec title.
-2. Open the spec in the user's editor so they can click through the Suggested Review Order:
-   - Resolve two absolute paths: (1) the repository root (`git rev-parse --show-toplevel` — returns the worktree root when in a worktree, project root otherwise; if this fails, fall back to the current working directory), (2) `{spec_file}`. Run `code -r "{absolute-root}" "{absolute-spec-file}"` — the root first so VS Code opens in the right context, then the spec file. Always double-quote paths to handle spaces and special characters.
-   - If `code` is not available (command fails), skip gracefully and tell the user the spec file path instead.
+If version control is available and the tree is dirty, create a local commit with a conventional message derived from the spec title.
+
+Resolve two absolute paths: (1) the BMad project root `{{.project_root}}`, (2) `{spec_file}`. Then follow this configured opening instruction using those paths:
+
+{workflow.open_spec}
+
+If opening was skipped or failed, tell the user the spec file path instead.
 
 ### Display Summary
 
 Display summary of your work to the user, including the commit hash if one was created. Any file paths shown in conversation/terminal output must use CWD-relative format (no leading `/`) with `:line` notation (e.g., `src/path/file.ts:42`) for terminal clickability — the goal is to make paths clickable in terminal emulators. Include:
 
-- A note that the spec is open in their editor (or the file path if it couldn't be opened). Mention that `{spec_file}` now contains a Suggested Review Order.
-- **Navigation tip:** "Ctrl+click (Cmd+click on macOS) the links in the Suggested Review Order to jump to each stop."
+- A note that the spec was sent to their configured application or system handler (or the file path if it couldn't be opened). Mention that `{spec_file}` now contains a Suggested Review Order.
+- **Navigation tip:** "Follow the links in the Suggested Review Order to jump to each stop; in source-mode editors this may require Ctrl+click (Cmd+click on macOS)."
 - Offer to push and/or create a pull request.
 
 Workflow complete.

--- a/src/bmm-skills/4-implementation/bmad-build/step-05-present.md
+++ b/src/bmm-skills/4-implementation/bmad-build/step-05-present.md
@@ -62,9 +62,9 @@ If version control is available and the tree is dirty, create a local commit wit
 
 ### Display Summary
 
-Display summary of your work to the user, including the commit hash if one was created. Any file paths shown in conversation/terminal output must use CWD-relative format (no leading `/`) with `:line` notation (e.g., `src/path/file.ts:42`) for terminal clickability — the goal is to make paths clickable in terminal emulators. Include:
+Display summary of your work to the user, including the commit hash if one was created. Any file paths shown in conversation/terminal output must use CWD-relative format (no leading `/`) with `:line` notation (e.g., `src/path/file.ts:42`) for terminal clickability — the goal is to make paths clickable in terminal emulators.
 
-- Offer to push and/or create a pull request.
+Offer to push and/or create a pull request.
 
 Workflow complete.
 

--- a/src/bmm-skills/4-implementation/bmad-build/step-oneshot.md
+++ b/src/bmm-skills/4-implementation/bmad-build/step-oneshot.md
@@ -56,19 +56,13 @@ If version control is available and the tree is dirty, create a local commit wit
 
 ### Present
 
-Resolve two absolute paths: (1) the repository root (`git rev-parse --show-toplevel` — returns the worktree root when in a worktree, project root otherwise; if this fails, fall back to the current working directory), (2) `{spec_file}`. Then follow this configured opening instruction using `{absolute-root}` and `{absolute-spec-file}`:
-
 {workflow.open_spec}
-
-If opening was skipped or failed, tell the user the spec file path instead.
 
 Display a summary in conversation output, including:
 
 - The commit hash (if one was created).
 - List of files changed with one-line descriptions. Any file paths shown in conversation/terminal output must use CWD-relative format (no leading `/`) with `:line` notation (e.g., `src/path/file.ts:42`) for terminal clickability — this differs from spec-file links which use spec-file-relative paths.
 - Review findings breakdown: patches applied, items deferred, items rejected. If all findings were rejected, say so.
-- A note that the spec was sent to their configured application (or the file path if it couldn't be opened). Mention that `{spec_file}` now contains a Suggested Review Order.
-- **Navigation tip:** "Ctrl+click (Cmd+click on macOS) the links in the Suggested Review Order to jump to each stop."
 
 Offer to push and/or create a pull request.
 

--- a/src/bmm-skills/4-implementation/bmad-build/step-oneshot.md
+++ b/src/bmm-skills/4-implementation/bmad-build/step-oneshot.md
@@ -56,7 +56,7 @@ If version control is available and the tree is dirty, create a local commit wit
 
 ### Present
 
-Resolve two absolute paths: (1) the BMad project root `{{.project_root}}`, (2) `{spec_file}`. Then follow this configured opening instruction using those paths:
+Resolve two absolute paths: (1) the repository root (`git rev-parse --show-toplevel` — returns the worktree root when in a worktree, project root otherwise; if this fails, fall back to the current working directory), (2) `{spec_file}`. Then follow this configured opening instruction using `{absolute-root}` and `{absolute-spec-file}`:
 
 {workflow.open_spec}
 
@@ -67,8 +67,8 @@ Display a summary in conversation output, including:
 - The commit hash (if one was created).
 - List of files changed with one-line descriptions. Any file paths shown in conversation/terminal output must use CWD-relative format (no leading `/`) with `:line` notation (e.g., `src/path/file.ts:42`) for terminal clickability — this differs from spec-file links which use spec-file-relative paths.
 - Review findings breakdown: patches applied, items deferred, items rejected. If all findings were rejected, say so.
-- A note that the spec was sent to their configured application or system handler (or the file path if it couldn't be opened). Mention that `{spec_file}` now contains a Suggested Review Order.
-- **Navigation tip:** "Follow the links in the Suggested Review Order to jump to each stop; in source-mode editors this may require Ctrl+click (Cmd+click on macOS)."
+- A note that the spec was sent to their configured application (or the file path if it couldn't be opened). Mention that `{spec_file}` now contains a Suggested Review Order.
+- **Navigation tip:** "Ctrl+click (Cmd+click on macOS) the links in the Suggested Review Order to jump to each stop."
 
 Offer to push and/or create a pull request.
 

--- a/src/bmm-skills/4-implementation/bmad-build/step-oneshot.md
+++ b/src/bmm-skills/4-implementation/bmad-build/step-oneshot.md
@@ -56,16 +56,21 @@ If version control is available and the tree is dirty, create a local commit wit
 
 ### Present
 
-1. Open the spec in the user's editor so they can click through the Suggested Review Order:
-   - Resolve two absolute paths: (1) the repository root (`git rev-parse --show-toplevel` — returns the worktree root when in a worktree, project root otherwise; if this fails, fall back to the current working directory), (2) `{spec_file}`. Run `code -r "{absolute-root}" "{absolute-spec-file}"` — the root first so VS Code opens in the right context, then the spec file. Always double-quote paths to handle spaces and special characters.
-   - If `code` is not available (command fails), skip gracefully and tell the user the spec file path instead.
-2. Display a summary in conversation output, including:
-   - The commit hash (if one was created).
-   - List of files changed with one-line descriptions. Any file paths shown in conversation/terminal output must use CWD-relative format (no leading `/`) with `:line` notation (e.g., `src/path/file.ts:42`) for terminal clickability — this differs from spec-file links which use spec-file-relative paths.
-   - Review findings breakdown: patches applied, items deferred, items rejected. If all findings were rejected, say so.
-   - A note that the spec is open in their editor (or the file path if it couldn't be opened). Mention that `{spec_file}` now contains a Suggested Review Order.
-   - **Navigation tip:** "Ctrl+click (Cmd+click on macOS) the links in the Suggested Review Order to jump to each stop."
-3. Offer to push and/or create a pull request.
+Resolve two absolute paths: (1) the BMad project root `{{.project_root}}`, (2) `{spec_file}`. Then follow this configured opening instruction using those paths:
+
+{workflow.open_spec}
+
+If opening was skipped or failed, tell the user the spec file path instead.
+
+Display a summary in conversation output, including:
+
+- The commit hash (if one was created).
+- List of files changed with one-line descriptions. Any file paths shown in conversation/terminal output must use CWD-relative format (no leading `/`) with `:line` notation (e.g., `src/path/file.ts:42`) for terminal clickability — this differs from spec-file links which use spec-file-relative paths.
+- Review findings breakdown: patches applied, items deferred, items rejected. If all findings were rejected, say so.
+- A note that the spec was sent to their configured application or system handler (or the file path if it couldn't be opened). Mention that `{spec_file}` now contains a Suggested Review Order.
+- **Navigation tip:** "Follow the links in the Suggested Review Order to jump to each stop; in source-mode editors this may require Ctrl+click (Cmd+click on macOS)."
+
+Offer to push and/or create a pull request.
 
 HALT and wait for human input.
 

--- a/test/test-build-renderer.js
+++ b/test/test-build-renderer.js
@@ -248,6 +248,13 @@ try {
     }
   });
 
+  test('open_spec default and examples use only established runtime path placeholders', () => {
+    const content = fs.readFileSync(path.join(skillDst, 'customize.toml'), 'utf-8');
+    assert(content.includes('code -r "{project-root}" "{spec_file}"'), 'default supported-placeholder command missing');
+    assert(!content.includes('{absolute-root}'), 'invented {absolute-root} placeholder remains in customize.toml');
+    assert(!content.includes('{absolute-spec-file}'), 'invented {absolute-spec-file} placeholder remains in customize.toml');
+  });
+
   test('review layers materialize as invocation blocks in step-04', () => {
     const content = readRendered('step-04-review.md');
     const expectedPromptPath = `${skillDst.replaceAll('\\', '/')}/review-prompts/adversarial.md`;
@@ -334,10 +341,9 @@ try {
     }
     for (const file of ['step-05-present.md', 'step-oneshot.md']) {
       const content = readRendered(file);
-      assert(
-        content.includes('code -r "{absolute-root}" "{absolute-spec-file}"'),
-        `default root-first VS Code command missing from ${file}`,
-      );
+      assert(content.includes('code -r "{project-root}" "{spec_file}"'), `default root-first VS Code command missing from ${file}`);
+      assert(!content.includes('{absolute-root}'), `invented {absolute-root} placeholder survived in ${file}`);
+      assert(!content.includes('{absolute-spec-file}'), `invented {absolute-spec-file} placeholder survived in ${file}`);
     }
   });
 

--- a/test/test-build-renderer.js
+++ b/test/test-build-renderer.js
@@ -416,6 +416,30 @@ try {
     assert(!res.stderr.includes('Traceback'), `renderer crashed with a traceback instead of HALTing:\n${res.stderr}`);
   });
 
+  test('empty open_spec customization renders as an explicit disable', () => {
+    const { dir, skillDst: dst } = makeProject(
+      [
+        '[core]',
+        'communication_language = "French"',
+        'document_output_language = "Klingon"',
+        'planning_artifacts = "{project-root}/plan"',
+        'implementation_artifacts = "{project-root}/impl"',
+      ].join('\n'),
+    );
+    fs.mkdirSync(path.join(dir, '_bmad', 'custom'), { recursive: true });
+    fs.writeFileSync(path.join(dir, '_bmad', 'custom', 'bmad-build.user.toml'), '[workflow]\nopen_spec = ""\n', 'utf-8');
+    const res = spawnSync('python3', [path.join(dst, 'render.py')], { cwd: dst, encoding: 'utf-8' });
+    assert(res.status === 0, `expected exit 0, got ${res.status}\nstdout: ${res.stdout}\nstderr: ${res.stderr}`);
+    const renderDir = path.join(dir, '_bmad', 'render', 'bmad-build');
+    for (const file of ['step-05-present.md', 'step-oneshot.md']) {
+      const content = fs.readFileSync(path.join(renderDir, file), 'utf-8');
+      assert(!content.includes('code -r'), `default open_spec survived empty override in ${file}`);
+      assert(!content.includes('Suggested Review Order to jump'), `navigation output survived empty override in ${file}`);
+      assert(!content.includes('spec was sent'), `opening summary survived empty override in ${file}`);
+      assert(content.includes('Suggested Review Order'), `spec review trail generation disappeared from ${file}`);
+    }
+  });
+
   test('non-string open_spec customization HALTs cleanly', () => {
     const { dir, skillDst: dst } = makeProject(
       [
@@ -435,7 +459,7 @@ try {
     const res = spawnSync('python3', [path.join(dst, 'render.py')], { cwd: dst, encoding: 'utf-8' });
     assert(res.status === 1, `expected exit 1, got ${res.status}\nstdout: ${res.stdout}\nstderr: ${res.stderr}`);
     assert(
-      res.stdout.includes('customization `workflow.open_spec` must be a non-empty string'),
+      res.stdout.includes('customization `workflow.open_spec` must be a string'),
       `stdout missing open_spec type error.\nstdout: ${res.stdout}`,
     );
     assert(!res.stderr.includes('Traceback'), `renderer crashed with a traceback instead of HALTing:\n${res.stderr}`);

--- a/test/test-build-renderer.js
+++ b/test/test-build-renderer.js
@@ -248,6 +248,12 @@ try {
     }
   });
 
+  test('step-05 keeps the push offer separate from summary content', () => {
+    const content = readRendered('step-05-present.md');
+    assert(!content.includes('Include:\n\n- Offer to push'), 'push offer remains under a dangling Include list');
+    assert(content.includes('\n\nOffer to push and/or create a pull request.\n'), 'standalone push offer missing');
+  });
+
   test('open_spec default and examples use only established runtime path placeholders', () => {
     const content = fs.readFileSync(path.join(skillDst, 'customize.toml'), 'utf-8');
     assert(content.includes('code -r "{project-root}" "{spec_file}"'), 'default supported-placeholder command missing');

--- a/test/test-build-renderer.js
+++ b/test/test-build-renderer.js
@@ -10,7 +10,7 @@
  *   2. sprint_status is an absolute path rooted at the temp project dir.
  *   3. [workflow] customization is self-resolved and inlined: prepend bullet,
  *      persistent_facts append (base kept), empty list -> _None._, on_complete
- *      scalar baked into step-05/step-oneshot.
+ *      and open_spec scalars baked into step-05/step-oneshot.
  *   4. Review layers materialize as direct invocation blocks: default layers
  *      become #### sections in step-04, an override replacing a layer by id
  *      wins, an empty-instruction override drops its layer, a `when` renders
@@ -140,6 +140,10 @@ try {
       'activation_steps_prepend = ["TEST_PREPEND_STEP"]',
       'persistent_facts = ["TEST_EXTRA_FACT"]',
       'on_complete = "TEST_ON_COMPLETE_INSTRUCTION"',
+      'open_spec = """',
+      'TEST_OPEN_SPEC_LINE_ONE',
+      'TEST_OPEN_SPEC_LINE_TWO',
+      '"""',
       '',
       '[[workflow.review_layers]]',
       'id = "edge-case-hunter"',
@@ -234,6 +238,16 @@ try {
     }
   });
 
+  test('open_spec scalar inlined into step-05 and step-oneshot', () => {
+    for (const file of ['step-05-present.md', 'step-oneshot.md']) {
+      const content = readRendered(file);
+      assert(
+        content.includes('\nTEST_OPEN_SPEC_LINE_ONE\nTEST_OPEN_SPEC_LINE_TWO\n'),
+        `multiline open_spec not inlined at top-level in ${file}`,
+      );
+    }
+  });
+
   test('review layers materialize as invocation blocks in step-04', () => {
     const content = readRendered('step-04-review.md');
     const expectedPromptPath = `${skillDst.replaceAll('\\', '/')}/review-prompts/adversarial.md`;
@@ -318,6 +332,11 @@ try {
     for (const file of ['step-04-review.md', 'step-oneshot.md']) {
       assert(readRendered(file).includes(halt), `HALT instruction missing from ${file}`);
     }
+    for (const file of ['step-05-present.md', 'step-oneshot.md']) {
+      const content = readRendered(file);
+      assert(content.includes("operating system's registered handler"), `default open_spec missing from ${file}`);
+      assert(!content.includes('code -r'), `hard-coded VS Code command survived in ${file}`);
+    }
   });
 
   test('no {workflow.*} placeholder survives in any rendered file', () => {
@@ -391,6 +410,31 @@ try {
     assert(
       res.stdout.includes('HALT and report to the user: failed to parse') && res.stdout.includes('bmad-build.user.toml'),
       `stdout missing the failed-to-parse HALT directive naming the override file.\nstdout: ${res.stdout}`,
+    );
+    assert(!res.stderr.includes('Traceback'), `renderer crashed with a traceback instead of HALTing:\n${res.stderr}`);
+  });
+
+  test('non-string open_spec customization HALTs cleanly', () => {
+    const { dir, skillDst: dst } = makeProject(
+      [
+        '[core]',
+        'communication_language = "French"',
+        'document_output_language = "Klingon"',
+        'planning_artifacts = "{project-root}/plan"',
+        'implementation_artifacts = "{project-root}/impl"',
+      ].join('\n'),
+    );
+    fs.mkdirSync(path.join(dir, '_bmad', 'custom'), { recursive: true });
+    fs.writeFileSync(
+      path.join(dir, '_bmad', 'custom', 'bmad-build.user.toml'),
+      '[workflow]\nopen_spec = ["not", "an", "instruction"]\n',
+      'utf-8',
+    );
+    const res = spawnSync('python3', [path.join(dst, 'render.py')], { cwd: dst, encoding: 'utf-8' });
+    assert(res.status === 1, `expected exit 1, got ${res.status}\nstdout: ${res.stdout}\nstderr: ${res.stderr}`);
+    assert(
+      res.stdout.includes('customization `workflow.open_spec` must be a non-empty string'),
+      `stdout missing open_spec type error.\nstdout: ${res.stdout}`,
     );
     assert(!res.stderr.includes('Traceback'), `renderer crashed with a traceback instead of HALTing:\n${res.stderr}`);
   });

--- a/test/test-build-renderer.js
+++ b/test/test-build-renderer.js
@@ -334,8 +334,10 @@ try {
     }
     for (const file of ['step-05-present.md', 'step-oneshot.md']) {
       const content = readRendered(file);
-      assert(content.includes("operating system's registered handler"), `default open_spec missing from ${file}`);
-      assert(!content.includes('code -r'), `hard-coded VS Code command survived in ${file}`);
+      assert(
+        content.includes('code -r "{absolute-root}" "{absolute-spec-file}"'),
+        `default root-first VS Code command missing from ${file}`,
+      );
     }
   });
 


### PR DESCRIPTION
## What
Makes the BMad Build spec handoff configurable while preserving the existing, carefully ordered VS Code command as the default. Setting `workflow.open_spec` to an empty string disables only the editor launch; the complete spec is still generated normally.

## Why
The hard-coded `code` launcher assumes VS Code is installed and preferred. The customization layer now supports another editor, or no automatic launch, without imposing a customization file on users who want the current default behavior.

## How
- Replaced the hard-coded presentation commands with a standalone `{workflow.open_spec}` customization in both Build completion paths.
- Kept the default root-first `code -r "{project-root}" "{spec_file}"` behavior using Build's established runtime path placeholders, including the existing fallback guidance.
- Added string validation, empty-string coverage, and commented examples for VS Code-compatible editors, Zed, IntelliJ IDEA, Vim, and Emacs.

## Testing
Ran `HUSKY=0 npm ci && npm run quality` successfully, including formatting, linting, documentation builds, installer tests, renderer tests, contract checks, and skill validation. The focused Build renderer suite passes all 27 tests, including regression checks for invented path placeholders and the Step 5 summary/push-offer boundary.
