### PR TITLE
docs: refocus getting started tutorials on activation

### DIFF
--- a/docs/index.md
+++ b/docs/index.md
@@ -1,60 +1,68 @@
 ---
-title: Welcome to the BMad Method
-description: AI-driven development framework with specialized agents, guided workflows, and intelligent planning
+title: Build Software with BMad
+description: See how BMad turns short requests and shared specifications into reviewed software changes while you keep control of important decisions.
+hero:
+  title: Turn intent into working software
+  tagline: BMad clarifies what matters, gives you a plan to approve, implements the change, reviews its work, and shows you the result.
+  actions:
+    - text: Start with a small build
+      link: ./tutorials/getting-started/
+      variant: primary
+    - text: Try it in Django
+      link: ./tutorials/getting-deeper/
+      variant: secondary
 ---
 
-The BMad Method (**B**uild **M**ore **A**rchitect **D**reams) is an AI-driven development framework module within the BMad Method Ecosystem that helps you build software through the whole process from ideation and planning all the way through agentic implementation. It provides specialized AI agents, guided workflows, and intelligent planning that adapts to your project's complexity, whether you're fixing a bug or building an enterprise platform.
+BMad works with supported AI coding tools to carry a software request through
+clarification, an approved plan, implementation, and review. You keep control
+of the decisions that shape the result, and Build returns working code you can
+run and inspect.
 
-If you're comfortable working with AI coding assistants like Claude, Cursor, or GitHub Copilot, you're ready to get started.
+## Start with Working Software
 
-:::note[🚀 V6 is Here and We're Just Getting Started!]
-Skills Architecture, BMad Builder v1, Dev Loop Automation, and so much more in the works. **[Check out the Roadmap →](/roadmap/)**
-:::
+[Getting Started](./tutorials/getting-started.md) begins in an empty directory
+with one short request:
 
-## New Here? Start with a Tutorial
+```text
+/bmad-build write an implementation of mars rover kata
+```
 
-The fastest way to understand BMad is to try it.
+Build asks for the choices it needs, then gives you a plan to approve or change.
+It writes and reviews the program before you run the finished Mars Rover in your
+terminal. The request stays small; you decide what the program should become.
 
-- **[Get Started with BMad](./tutorials/getting-started.md)** — Install and understand how BMad works
-- **[Workflow Map](./reference/workflow-map.md)** — Visual overview of BMM phases, workflows, and context management
+**[Build Mars Rover with BMad](./tutorials/getting-started.md)**
 
-:::tip[Just Want to Dive In?]
-Install BMad and use the `bmad-help` skill — it will guide you through everything based on your project and installed modules.
-:::
+## Continue in a Mature Codebase
 
-## How to Use These Docs
+[Getting Deeper](./tutorials/getting-deeper.md) moves the same direct workflow
+into Django 5.2.4. You ask Build to add JSON output to `django-admin
+diffsettings`, make the decisions that define that output, run the focused
+tests, and inspect the JSON produced by the command.
 
-These docs are organized into four sections based on what you're trying to do:
+The second Django exercise shows what changes when the work spans several
+stories. BMad Spec records one shared contract for filtering, redaction, and CI
+status. Three Build runs implement it in order, and one final command shows the
+features working together: filtering selects the setting, redaction hides its
+value, and the exit status still reports the remaining difference.
 
-| Section           | Purpose                                                                                                    |
-| ----------------- | ---------------------------------------------------------------------------------------------------------- |
-| **Tutorials**     | Learning-oriented. Step-by-step guides that walk you through building something. Start here if you're new. |
-| **How-To Guides** | Task-oriented. Practical guides for solving specific problems. "How do I customize an agent?" lives here.  |
-| **Explanation**   | Understanding-oriented. Deep dives into concepts and architecture. Read when you want to know *why*.       |
-| **Reference**     | Information-oriented. Technical specifications for agents, workflows, and configuration.                   |
+**[Try the Django playground](./tutorials/getting-deeper.md)**
 
-## Expand and Customize
+## Find a Specific Answer
 
-Want to expand BMad with your own agents, workflows, or modules? The **[BMad Builder](https://bmad-builder-docs.bmad-method.org/)** provides the framework and tools for creating custom extensions, whether you're adding new capabilities to BMad or building entirely new modules from scratch.
+Use the search box or sidebar when you already know what you need. These common
+tasks lead directly to the relevant documentation:
 
-## What You'll Need
+- [Install or update BMad](./how-to/install-bmad.md)
+- [Use BMad in an established project](./how-to/established-projects.md)
+- [Understand how Build works](./explanation/build.md)
+- [Look up installed skills](./reference/commands.md)
 
-BMad works with any AI coding assistant that supports custom system prompts or project context. Popular options include:
+## Build in Your Repository
 
-- **[Claude Code](https://code.claude.com)** — Anthropic's CLI tool (recommended)
-- **[Cursor](https://cursor.sh)** — AI-first code editor
-- **[Codex CLI](https://github.com/openai/codex)** — OpenAI's terminal coding agent
+Choose a real change in a repository you already use. Install BMad in that
+repository, run the installed `bmad-build` skill, and describe the result you
+want. You can settle the important choices, approve or revise the plan, and
+inspect the finished change in its real context.
 
-You should be comfortable with basic software development concepts like version control, project structure, and agile workflows. No prior experience with BMad-style agent systems is required—that's what these docs are for.
-
-## Join the Community
-
-Get help, share what you're building, or contribute to BMad:
-
-- **[Discord](https://discord.gg/gk8jAdXWmj)** — Chat with other BMad users, ask questions, share ideas
-- **[GitHub](https://github.com/bmad-code-org/BMAD-METHOD)** — Source code, issues, and contributions
-- **[YouTube](https://www.youtube.com/@BMadCode)** — Video tutorials and walkthroughs
-
-## Next Step
-
-Ready to dive in? **[Get Started with BMad](./tutorials/getting-started.md)** and build your first project.
+**[Use BMad in your repository](./how-to/install-bmad.md)**

--- a/docs/tutorials/getting-deeper.md
+++ b/docs/tutorials/getting-deeper.md
@@ -1,0 +1,136 @@
+---
+title: 'Getting Deeper'
+description: Use Quick Dev to make and inspect a small change in a specific Django version
+sidebar:
+  order: 2
+---
+
+You already know Quick Dev from small projects. Here, you will use it in a
+specific version of Django, approve one small command change, and inspect the
+code, tests, and documentation it produces.
+
+:::note[Prerequisites]
+Use a macOS or Linux shell with Git, Node.js 20.12+ and `npx`,
+[uv](https://docs.astral.sh/uv/getting-started/installation/), and a coding tool
+supported by BMad. Complete [Getting Started](./getting-started.md) before
+continuing. The exact install and launch commands below are for Claude Code. If
+you use another supported tool, you can run Quick Dev there instead. VS Code is
+optional but useful. Quick Dev can open the finished work for you when VS Code's
+`code` command is available.
+:::
+
+## 1. Check Out the Exact Django Version
+
+Clone Django 5.2.4 into a new directory, confirm that you have the expected
+source code, and create a branch for the exercise:
+
+```bash
+git clone --depth 1 --branch 5.2.4 https://github.com/django/django.git bmad-django
+cd bmad-django
+git rev-parse HEAD
+git switch -c bmad-getting-deeper
+```
+
+`git rev-parse HEAD` should print:
+
+```text
+c941d0deec0ea08a30670be0fac879f2372f071b
+```
+
+## 2. Set Up Django for Editing
+
+Set up Python 3.12, install your Django checkout so the example app uses it,
+and create a small Django project next to the repository:
+
+```bash
+uv python install 3.12
+uv venv --python 3.12
+uv pip install -e .
+mkdir ../bmad-django-app
+uv run django-admin startproject tutorial_project ../bmad-django-app
+```
+
+## 3. Check the Starting Behavior
+
+Confirm that JSON output is not yet available:
+
+```bash
+uv run python ../bmad-django-app/manage.py diffsettings --output=json
+```
+
+The command ends with this error:
+
+```text
+manage.py diffsettings: error: argument --output: invalid choice: 'json' (choose from hash, unified)
+```
+
+## 4. Install BMad
+
+Install the BMad Method version used to verify this tutorial. This exact command
+sets it up for Claude Code:
+
+```bash
+npx bmad-method@6.10.0 install --directory . --modules bmm --tools claude-code --yes
+```
+
+Tell Git to ignore the BMad files and uv lockfile created for this tutorial:
+
+```bash
+cat >> .git/info/exclude <<'EOF'
+/_bmad/
+/_bmad-output/
+/.claude/
+/uv.lock
+EOF
+```
+
+## 5. Build It
+
+Open your coding tool from the repository root. For Claude Code, run:
+
+```bash
+claude
+```
+
+```text
+/bmad-quick-dev Add JSON output support to django-admin diffsettings. Preserve
+the existing output formats, add focused tests, and update the command
+documentation. Leave the implementation in the working tree for local
+inspection.
+```
+
+Quick Dev asks any questions it needs before it writes a plan. Answer according
+to your own preferences for the new JSON output. There is no single required
+JSON design for this exercise.
+
+Quick Dev presents a plan and waits for you to approve it or ask for changes.
+Once approved, it builds and reviews the change, handles its findings, and
+shows you the result. Keep this exercise about JSON output for `diffsettings`;
+filtering, redaction, and CI behavior belong in the next exercise.
+
+If `code` is available, Quick Dev opens the project and finished spec in VS
+Code. The Suggested Review Order links lead you through the change.
+
+## 6. See It Work
+
+Back in your shell, run Django's `diffsettings` tests:
+
+```bash
+uv run python tests/runtests.py admin_scripts.tests.DiffSettings --verbosity 1
+```
+
+The tests should pass.
+
+Now run the command again:
+
+```bash
+uv run python ../bmad-django-app/manage.py diffsettings --output=json
+```
+
+Look through the JSON and compare it with the choices you made with Quick Dev.
+
+## 7. You Built It
+
+Congratulations, you've now added something useful to a complex open-source
+codebase. If you use VS Code, you're probably looking at the finished change
+there now.

--- a/docs/tutorials/getting-deeper.md
+++ b/docs/tutorials/getting-deeper.md
@@ -252,3 +252,8 @@ final result still does what you asked for at the start.
 
 If you want several perspectives on the result, `/bmad-party-mode` is an
 optional final step. You do not need it to finish this tutorial.
+
+## 12. Keep Building
+
+Now [install BMad in your own repository](../how-to/install-bmad.md), then use
+the `bmad-build` skill to make a change you want.

--- a/docs/tutorials/getting-deeper.md
+++ b/docs/tutorials/getting-deeper.md
@@ -1,21 +1,21 @@
 ---
 title: 'Getting Deeper'
-description: Use Quick Dev to make and inspect a small change in a specific Django version
+description: Use Build and BMad Spec to extend a command in a specific Django version
 sidebar:
   order: 2
 ---
 
-You already know Quick Dev from small projects. Here, you will use it in a
-specific version of Django, approve one small command change, and inspect the
-code, tests, and documentation it produces.
+You already know Build from small projects. Here, you will use it in a specific
+version of Django: first for one bounded command change, then for three related
+stories defined by one BMad Spec.
 
 :::note[Prerequisites]
 Use a macOS or Linux shell with Git, Node.js 20.12+ and `npx`,
 [uv](https://docs.astral.sh/uv/getting-started/installation/), and a coding tool
 supported by BMad. Complete [Getting Started](./getting-started.md) before
 continuing. The exact install and launch commands below are for Claude Code. If
-you use another supported tool, you can run Quick Dev there instead. VS Code is
-optional but useful. Quick Dev can open the finished work for you when VS Code's
+you use another supported tool, you can run Build there instead. VS Code is
+optional but useful. Build can open the finished work for you when VS Code's
 `code` command is available.
 :::
 
@@ -66,11 +66,11 @@ manage.py diffsettings: error: argument --output: invalid choice: 'json' (choose
 
 ## 4. Install BMad
 
-Install the BMad Method version used to verify this tutorial. This exact command
-sets it up for Claude Code:
+Install BMad Method from the stable release channel. This exact command sets it
+up for Claude Code:
 
 ```bash
-npx bmad-method@6.10.0 install --directory . --modules bmm --tools claude-code --yes
+npx bmad-method install --directory . --modules bmm --tools claude-code --yes
 ```
 
 Tell Git to ignore the BMad files and uv lockfile created for this tutorial:
@@ -93,22 +93,22 @@ claude
 ```
 
 ```text
-/bmad-quick-dev Add JSON output support to django-admin diffsettings. Preserve
+/bmad-build Add JSON output support to django-admin diffsettings. Preserve
 the existing output formats, add focused tests, and update the command
 documentation. Leave the implementation in the working tree for local
 inspection.
 ```
 
-Quick Dev asks any questions it needs before it writes a plan. Answer according
+Build asks any questions it needs before it writes a plan. Answer according
 to your own preferences for the new JSON output. There is no single required
 JSON design for this exercise.
 
-Quick Dev presents a plan and waits for you to approve it or ask for changes.
+Build presents a plan and waits for you to approve it or ask for changes.
 Once approved, it builds and reviews the change, handles its findings, and
 shows you the result. Keep this exercise about JSON output for `diffsettings`;
 filtering, redaction, and CI behavior belong in the next exercise.
 
-If `code` is available, Quick Dev opens the project and finished spec in VS
+If `code` is available, Build opens the project and finished spec in VS
 Code. The Suggested Review Order links lead you through the change.
 
 ## 6. See It Work
@@ -127,10 +127,128 @@ Now run the command again:
 uv run python ../bmad-django-app/manage.py diffsettings --output=json
 ```
 
-Look through the JSON and compare it with the choices you made with Quick Dev.
+Look through the JSON and compare it with the choices you made with Build.
 
 ## 7. You Built It
 
 Congratulations, you've now added something useful to a complex open-source
 codebase. If you use VS Code, you're probably looking at the finished change
 there now.
+
+## 8. Write a Spec for the Larger Change
+
+The next change needs three Build runs. `/bmad-forge-idea` can help you decide
+what to build. `/bmad-advanced-elicitation` can help you improve a draft. You do
+not need either here because the requirements are already clear. Send them
+straight to BMad Spec:
+
+```text
+/bmad-spec Create a spec named diffsettings-audit and break it into
+exactly three stories in this order: filters, redaction, then CI status.
+
+Read the current diffsettings implementation, focused tests, and command
+documentation before writing the spec. Keep every existing output format
+and the JSON design already approved. Add repeatable --include and --exclude
+shell-glob filters. Include patterns are OR, and exclusions always win. Add
+repeatable --redact shell-glob masks that replace current and default values
+with [REDACTED] without changing whether a difference exists. Add
+--fail-on-difference, which exits 1 when differences remain after filtering and
+0 otherwise. Each story adds focused tests and updates the existing command
+documentation. Do not add another Django documentation file or an external
+service. Use diffsettings-audit as the spec folder slug.
+```
+
+BMad Spec writes one spec in
+`_bmad-output/specs/spec-diffsettings-audit/` and the three ordered stories in
+its `stories.yaml`. Read the spec and stories, and answer any questions BMad
+Spec asks. Continue when they match the requirements above.
+
+## 9. Build the Three Stories
+
+Run Build once for each story, in order. Complete each Build run before moving
+to the next one. Every run uses the same spec.
+
+### Story 1: Filters
+
+```text
+/bmad-build Implement story 1, filters, from
+_bmad-output/specs/spec-diffsettings-audit/stories.yaml.
+```
+
+After Build finishes, observe the result:
+
+```bash
+uv run python ../bmad-django-app/manage.py diffsettings \
+  --include=DATABASES --include=DEBUG --include=SECRET_KEY \
+  --exclude=DATABASES
+printf 'exit: %s\n' "$?"
+```
+
+The output has `DEBUG` and `SECRET_KEY`, but no `DATABASES`, followed by
+`exit: 0`. The include patterns are combined, while the exclusion wins.
+
+### Story 2: Redaction
+
+```text
+/bmad-build Implement story 2, redaction, from
+_bmad-output/specs/spec-diffsettings-audit/stories.yaml.
+```
+
+Observe the unified output:
+
+```bash
+uv run python ../bmad-django-app/manage.py diffsettings \
+  --output=unified --include=SECRET_KEY --redact='SECRET*'
+printf 'exit: %s\n' "$?"
+```
+
+The secret does not appear. Both sides of the difference are masked:
+
+```text
+- SECRET_KEY = [REDACTED]
++ SECRET_KEY = [REDACTED]
+exit: 0
+```
+
+### Story 3: CI Status
+
+```text
+/bmad-build Implement story 3, CI status, from
+_bmad-output/specs/spec-diffsettings-audit/stories.yaml.
+```
+
+Observe a difference that remains after filtering:
+
+```bash
+uv run python ../bmad-django-app/manage.py diffsettings \
+  --include=DEBUG --fail-on-difference
+printf 'exit: %s\n' "$?"
+```
+
+The `DEBUG` difference remains visible, and the command finishes with
+`exit: 1`.
+
+## 10. See the Whole Change Work
+
+Now combine the three stories in one observation:
+
+```bash
+uv run python ../bmad-django-app/manage.py diffsettings \
+  --output=json --include=DEBUG --include=SECRET_KEY --exclude=DEBUG \
+  --redact='SECRET*' --fail-on-difference
+printf 'exit: %s\n' "$?"
+```
+
+The JSON contains only `SECRET_KEY`. Every current or default value exposed by
+the JSON shape you chose earlier is `[REDACTED]`; neither original value
+appears. The underlying values still differ, so the final line is `exit: 1`.
+
+## 11. The Stories Work Together
+
+The first exercise gave Build one bounded change directly. This exercise gave
+three separate Build runs one spec. Filtering, redaction, and CI status still
+work together at the end. You have extended a mature Django command, and the
+final result still does what you asked for at the start.
+
+If you want several perspectives on the result, `/bmad-party-mode` is an
+optional final step. You do not need it to finish this tutorial.

--- a/docs/tutorials/getting-started.md
+++ b/docs/tutorials/getting-started.md
@@ -1,6 +1,6 @@
 ---
 title: 'Getting Started'
-description: Install BMad and build two small Python programs
+description: Install BMad and build a small Python program
 sidebar:
   order: 1
 ---
@@ -13,12 +13,11 @@ Already have a repository and a small change you want to make?
 repository, and run the installed `bmad-build` skill. Talk to it about the
 change you want, and it will make it happen.
 
-Otherwise, start here. You will make two working Python programs in an empty
+Otherwise, start here. You will make a working Python program in an empty
 project.
 
 :::note[Before You Start]
-Use a macOS or Linux shell with Node.js 20.12+, Python 3,
-[uv](https://docs.astral.sh/uv/getting-started/installation/), and a coding tool
+Use a macOS or Linux shell with Node.js 20.12+, Python 3, and a coding tool
 supported by BMad. The exact install and launch commands below are for Claude
 Code. If you use another supported tool, select it when installing BMad and run
 the `bmad-build` skill there instead.
@@ -44,43 +43,11 @@ Open your coding tool in this directory. For Claude Code, run:
 claude
 ```
 
-## Make Hello World
+## Build a Mars Rover
 
-Enter this one-sentence request:
-
-```text
-/bmad-build write me a hello world in Python
-```
-
-If the `bmad-build` skill creates `hello.py`, run it from this directory in
-another terminal. If it uses another filename, use that name instead:
-
-```bash
-python3 hello.py
-```
-
-The program prints:
-
-```text
-Hello, World!
-```
-
-You have working software from one sentence.
-
-## Ask BMad Help
-
-The `bmad-help` skill answers questions about BMad. Use it to understand what
-happened, decide what to do next, or solve a problem. Try it now:
-
-```text
-/bmad-help Explain what bmad-build just did.
-```
-
-## Make a Mars Rover
-
-Start a fresh chat in the same directory. This time, ask the `bmad-build` skill
-to make the [Mars Rover programming kata](https://codingdojo.org/kata/mars-rover/),
-a small exercise used to practice coding, without adding any design choices:
+Ask the `bmad-build` skill to make the
+[Mars Rover programming kata](https://codingdojo.org/kata/mars-rover/), a small
+exercise used to practice coding, without adding any design choices:
 
 ```text
 /bmad-build write an implementation of mars rover kata
@@ -128,13 +95,22 @@ rover>  4  . . . . .
 rover> Mission control signing off.
 ```
 
-Open the files listed in the final message to look at your finished change.
+Open the files listed in the final message to look at your finished program.
+
+## Ask BMad Help
+
+The `bmad-help` skill answers questions about BMad. Use it to understand what
+happened, decide what to do next, or solve a problem. Try it now:
+
+```text
+/bmad-help Explain what bmad-build just did.
+```
 
 ## You Built It
 
-Hello World showed how the `bmad-build` skill can finish a clear, tiny request.
-Mars Rover showed how the same skill can ask questions before it starts. Both
-gave you software you could run.
+Mars Rover showed how the `bmad-build` skill turns a short request into working
+software. It clarified the request, presented a plan for your approval, wrote
+the program, and checked its work before showing you the result.
 
 ## Keep Building
 

--- a/docs/tutorials/getting-started.md
+++ b/docs/tutorials/getting-started.md
@@ -1,6 +1,8 @@
 ---
 title: 'Getting Started'
 description: Install BMad and build your first project
+sidebar:
+  order: 1
 ---
 
 Build software faster using AI-powered workflows with specialized agents that guide you through planning, architecture, and implementation.

--- a/docs/tutorials/getting-started.md
+++ b/docs/tutorials/getting-started.md
@@ -1,295 +1,144 @@
 ---
 title: 'Getting Started'
-description: Install BMad and build your first project
+description: Install BMad and build two small Python programs
 sidebar:
   order: 1
 ---
 
-Build software faster using AI-powered workflows with specialized agents that guide you through planning, architecture, and implementation.
+BMad can help you plan and build anything from a small bug fix to a project with
+a million lines of code. Let's start with something small.
 
-## What You'll Learn
+Already have a repository and a small change you want to make?
+[Install BMad there](../how-to/install-bmad.md), open your coding tool in the
+repository, and run the installed `bmad-build` skill. Talk to it about the
+change you want, and it will make it happen.
 
-- Install and initialize BMad Method for a new project
-- Use **BMad-Help** — your intelligent guide that knows what to do next
-- Choose the right planning depth for your project
-- Progress through phases from requirements to working code
-- Use agents and workflows effectively
+Otherwise, start here. You will make two working Python programs in an empty
+project.
 
-:::note[Prerequisites]
-
-- **Node.js 20.12+** — Required for the installer
-- **Git** — Recommended for version control
-- **AI-powered IDE** — Claude Code, Cursor, or similar
-- **A project idea** — Even a simple one works for learning
-  :::
-
-:::tip[The Easiest Path]
-**Install** → `npx bmad-method install`
-**Ask** → `bmad-help what should I do first?`
-**Build** → Let BMad-Help guide you workflow by workflow
+:::note[Before You Start]
+Use a macOS or Linux shell with Node.js 20.12+, Python 3,
+[uv](https://docs.astral.sh/uv/getting-started/installation/), and a coding tool
+supported by BMad. The exact install and launch commands below are for Claude
+Code. If you use another supported tool, select it when installing BMad and run
+the `bmad-build` skill there instead.
 :::
 
-## Meet BMad-Help: Your Intelligent Guide
-
-**BMad-Help is the fastest way to get started with BMad.** You don't need to memorize workflows or phases — just ask, and BMad-Help will:
-
-- **Inspect your project** to see what's already been done
-- **Show your options** based on which modules you have installed
-- **Recommend what's next** — including the first required task
-- **Answer questions** like "I have a SaaS idea, where do I start?"
-
-### How to Use BMad-Help
-
-Run it in your AI IDE by invoking the skill:
-
-```
-bmad-help
-```
-
-Or combine it with a question for context-aware guidance:
-
-```
-bmad-help I have an idea for a SaaS product, I already know all the features I want. where do I get started?
-```
-
-BMad-Help will respond with:
-
-- What's recommended for your situation
-- What the first required task is
-- What the rest of the process looks like
-
-### It Powers Workflows Too
-
-BMad-Help doesn't just answer questions — **it automatically runs at the end of every workflow** to tell you exactly what to do next. No guessing, no searching docs — just clear guidance on the next required workflow.
-
-:::tip[Start Here]
-After installing BMad, invoke the `bmad-help` skill immediately. It will detect what modules you have installed and guide you to the right starting point for your project.
-:::
-
-## Understanding BMad
-
-BMad helps you build software through guided workflows with specialized AI agents. The process follows four phases:
-
-| Phase | Name           | What Happens                                                 |
-| ----- | -------------- | ------------------------------------------------------------ |
-| 1     | Analysis       | Brainstorming, research, forge idea, product brief or PRFAQ _(optional)_ |
-| 2     | Planning       | Create requirements and design PRD, UX, SPEC                 |
-| 3     | Solutioning    | Design architecture spine or detailed project or system architectures          |
-| 4     | Implementation | Implement every change or planned story, optionally through automated orchestration |
-
-**[Open the Workflow Map](../reference/workflow-map.md)** to explore phases, workflows, and context management.
-
-Planning depth is flexible. Start implementation directly when the intent is already clear, or add the planning artifacts that reduce risk for larger work:
-
-| Planning depth | Best For | Context Available Before Implementation |
-| --- | --- | --- |
-| **Direct** | Clear fixes, features, issues, or existing specifications | User intent, issue, or spec |
-| **Product planning** | Products, platforms, and complex features | PRD and optional UX design |
-| **Full solutioning** | Cross-system, high-risk, or coordinated initiatives | PRD, UX, architecture, epics, stories, and sprint plan |
-
-:::note
-These are entry points, not separate implementation tracks. Every path converges on `bmad-build`; planning only changes how much context the workflow receives.
-:::
-
-## Installation
-
-Open a terminal in your project directory and run:
+## Create an Empty Project
 
 ```bash
-npx bmad-method install
+mkdir bmad-first-project
+cd bmad-first-project
 ```
 
-If you want the newest prerelease build instead of the default release channel, use `npx bmad-method@next install`.
+Install the current stable version of BMad Method. This command sets it up for
+Claude Code:
 
-When prompted to select modules, choose **BMad Method**.
-
-The installer creates two folders:
-
-- `_bmad/` — agents, workflows, tasks, and configuration
-- `_bmad-output/` — empty for now, but this is where your artifacts will be saved
-
-:::tip[Your Next Step]
-Open your AI IDE in the project folder and run:
-
-```
-bmad-help
+```bash
+npx bmad-method install --directory . --modules bmm --tools claude-code --yes
 ```
 
-BMad-Help will detect what you've completed and recommend exactly what to do next. You can also ask it questions like "What are my options?" or "I have a SaaS idea, where should I start?"
-:::
+Open your coding tool in this directory. For Claude Code, run:
 
-:::note[How to Load Agents and Run Workflows]
-Each workflow has a **skill** you invoke by name in your IDE (e.g., `bmad-prd`). Your AI tool will recognize the `bmad-*` name and run it — you don't need to load agents separately. You can also invoke an agent skill directly for general conversation (e.g., `bmad-agent-pm` for the PM agent).
-:::
+```bash
+claude
+```
 
-:::caution[Fresh Chats]
-Always start a fresh chat for each workflow. This prevents context limitations from causing issues.
-:::
+## Make Hello World
 
-## Step 1: Choose Your Planning Depth
-
-Use as much of phases 1-3 as the work needs. For clear, bounded work, you can proceed directly to [Step 2](#step-2-build-your-project). **Use fresh chats for each workflow.**
-
-:::tip[Project Context (Optional)]
-Before starting, consider creating `project-context.md` to document your technical preferences and implementation rules. This ensures all AI agents follow your conventions throughout the project.
-
-Create it manually at `_bmad-output/project-context.md` or generate it after architecture using `bmad-generate-project-context`. [Learn more](../explanation/project-context.md).
-:::
-
-### Phase 1: Analysis (Optional)
-
-All workflows in this phase are optional. [**Not sure which to use?**](../explanation/analysis-phase.md)
-
-- **brainstorming** (`bmad-brainstorming`) — Guided ideation
-- **forge-idea** (`bmad-forge-idea`) — Pressure-test an idea until it hardens or dies cheaply
-- **research** (`bmad-deep-recon`) — Draft a deep-research prompt for your own AI tool, process a finished report into a downstream-ready summary, or run the research here, with claim verification and a refresh lifecycle. [Learn more](../explanation/deep-recon.md)
-- **product-brief** (`bmad-product-brief`) — Recommended foundation document when your concept is clear
-- **prfaq** (`bmad-prfaq`) — Working Backwards challenge to stress-test your product concept customer-first
-
-### Phase 2: Planning (As Needed)
-
-For work that benefits from product planning:
-
-1. Run `bmad-prd` in a new chat — state your intent (Create / Update / Validate) or let the skill ask
-2. Output: `prd.md`, `addendum.md`, `.memlog.md`
-
-:::note[`bmad-prd` intents]
-
-- **Create** — coached discovery from scratch; the skill names the workspace folder and guides you to a PRD you're proud of
-- **Update** — point it at an existing PRD and a change signal; it surfaces conflicts before applying changes
-- **Validate** — critique a finished PRD against a checklist and produce an HTML findings report
-  :::
-
-:::note[UX Design (Optional)]
-If your project has a user interface, invoke the **UX-Designer agent** (`bmad-agent-ux-designer`) and run the UX design workflow (`bmad-ux`) after creating your PRD.
-:::
-
-### Phase 3: Solutioning (As Needed)
-
-**Create Architecture**
-
-1. Invoke the **Architect agent** (`bmad-agent-architect`) in a new chat
-2. Run `bmad-architecture` (`bmad-architecture`)
-3. Output: Architecture document with technical decisions
-
-**Create Epics and Stories**
-
-:::tip[V6 Improvement]
-Epics and stories are now created _after_ architecture. This produces better quality stories because architecture decisions (database, API patterns, tech stack) directly affect how work should be broken down.
-:::
-
-1. Invoke the **PM agent** (`bmad-agent-pm`) in a new chat
-2. Run `bmad-create-epics-and-stories` (`bmad-create-epics-and-stories`)
-3. The workflow uses both PRD and Architecture to create technically-informed stories
-
-**Implementation Readiness Check** _(Highly Recommended)_
-
-1. Invoke the **Architect agent** (`bmad-agent-architect`) in a new chat
-2. Run `bmad-check-implementation-readiness` (`bmad-check-implementation-readiness`)
-3. Validates cohesion across all planning documents
-
-## Step 2: Build Your Project
-
-Move to implementation from whatever context you have: a direct request, an issue, a spec, or a fully planned story. **Each workflow should run in a fresh chat.**
-
-For planned work, invoke `bmad-build` and identify the selected story or sprint item, for example: `Implement story 2.3 from _bmad-output/planning-artifacts/epics.md`.
-
-### Initialize Sprint Planning (For Planned Work)
-
-Invoke the **Developer agent** (`bmad-agent-dev`) and run `bmad-sprint-planning` (`bmad-sprint-planning`). This creates `sprint-status.yaml` to track all epics and stories.
-
-When Build resolves a selected story in that file, it moves the story to `in-progress` during implementation and to `review` when implementation is complete.
-
-### The Build Cycle
-
-For each direct change or planned story, repeat this cycle with fresh chats:
-
-| Step | Agent | Workflow | Command | Purpose |
-| ---- | ----- | -------- | ------- | ------- |
-| 1    | DEV   | `bmad-build` | `bmad-build` | Clarify as needed, plan, implement, review, present |
-| 2    | DEV   | `bmad-code-review` | `bmad-code-review` | Additional quality validation _(recommended)_ |
-
-Build's review is part of every run. `bmad-code-review` is an optional fresh-context, independent validation layer.
-
-After completing all stories in an epic, invoke the **Developer agent** (`bmad-agent-dev`) and run `bmad-retrospective` (`bmad-retrospective`).
-
-## What You've Accomplished
-
-You've learned the foundation of building with BMad:
-
-- Installed BMad and configured it for your IDE
-- Chosen planning depth appropriate to your work
-- Created planning documents (PRD, Architecture, Epics & Stories)
-- Understood the build cycle for implementation
-
-Your project now has:
+Enter this one-sentence request:
 
 ```text
-your-project/
-├── _bmad/                                   # BMad configuration
-├── _bmad-output/
-│   ├── planning-artifacts/
-│   │   ├── PRD.md                           # Your requirements document
-│   │   ├── architecture.md                  # Technical decisions
-│   │   └── epics/                           # Epic and story files
-│   ├── implementation-artifacts/
-│   │   └── sprint-status.yaml               # Sprint tracking
-│   └── project-context.md                   # Implementation rules (optional)
-└── ...
+/bmad-build write me a hello world in Python
 ```
 
-## Quick Reference
+If the `bmad-build` skill creates `hello.py`, run it from this directory in
+another terminal. If it uses another filename, use that name instead:
 
-| Workflow                              | Command                               | Agent     | Purpose                                    |
-| ------------------------------------- | ------------------------------------- | --------- | ------------------------------------------ |
-| **`bmad-help`** ⭐                    | `bmad-help`                           | Any       | **Your intelligent guide — ask anything!** |
-| `bmad-prd`                            | `bmad-prd`                            | Any       | Create, update, or validate a PRD          |
-| `bmad-architecture`                   | `bmad-architecture`                   | Architect | Create architecture document               |
-| `bmad-generate-project-context`       | `bmad-generate-project-context`       | Analyst   | Create project context file                |
-| `bmad-create-epics-and-stories`       | `bmad-create-epics-and-stories`       | PM        | Break down PRD into epics                  |
-| `bmad-check-implementation-readiness` | `bmad-check-implementation-readiness` | Architect | Validate planning cohesion                 |
-| `bmad-sprint-planning`                | `bmad-sprint-planning`                | DEV       | Initialize sprint tracking                 |
-| `bmad-build`                      | `bmad-build`                      | DEV       | Implement a feature, fix, or story         |
-| `bmad-code-review`                    | `bmad-code-review`                    | DEV       | Review implemented code                    |
+```bash
+python3 hello.py
+```
 
-## Common Questions
+The program prints:
 
-**Do I always need architecture?**
-No. Use architecture when technical decisions or cross-system constraints need to be explicit. Clear work can enter `bmad-build` directly, while larger initiatives can bring architecture and other planning artifacts into the same workflow.
+```text
+Hello, World!
+```
 
-**Can I change my plan later?**
-Yes. The `bmad-correct-course` workflow handles scope changes mid-implementation.
+You have working software from one sentence.
 
-**What if I want to brainstorm first?**
-Invoke the Analyst agent (`bmad-agent-analyst`) and run `bmad-brainstorming` (`bmad-brainstorming`) before starting your PRD.
+## Ask BMad Help
 
-**Do I need to follow a strict order?**
-Not strictly. Once you learn the flow, you can run workflows directly using the Quick Reference above.
+The `bmad-help` skill answers questions about BMad. Use it to understand what
+happened, decide what to do next, or solve a problem. Try it now:
 
-## Getting Help
+```text
+/bmad-help Explain what bmad-build just did.
+```
 
-:::tip[First Stop: BMad-Help]
-**Invoke `bmad-help` anytime** — it's the fastest way to get unstuck. Ask it anything:
+## Make a Mars Rover
 
-- "What should I do after installing?"
-- "I'm stuck on workflow X"
-- "What are my options for Y?"
-- "Show me what's been done so far"
+Start a fresh chat in the same directory. This time, ask the `bmad-build` skill
+to make the [Mars Rover programming kata](https://codingdojo.org/kata/mars-rover/),
+a small exercise used to practice coding, without adding any design choices:
 
-BMad-Help inspects your project, detects what you've completed, and tells you exactly what to do next.
-:::
+```text
+/bmad-build write an implementation of mars rover kata
+```
 
-- **During workflows** — Agents guide you with questions and explanations
-- **Community** — [Discord](https://discord.gg/gk8jAdXWmj) (#bmad-method-help, #report-bugs-and-issues)
+This gives the `bmad-build` skill room to ask what you want. It may start with a
+question like this:
 
-## Key Takeaways
+```text
+`bmad-build`: Before implementation, I need one choice: which language should I use?
+You: Python 3. Make it a small old-school terminal program I can run locally,
+with no dependencies beyond Python standard library.
+```
 
-:::tip[Remember These]
+Your questions, answers, plan, and finished program may differ. Choose the
+behavior you want rather than copying the example answer.
 
-- **Start with `bmad-help`** — Your intelligent guide that knows your project and options
-- **Always use fresh chats** — Start a new chat for each workflow
-- **Planning depth varies** — direct intent and fully planned stories both enter `bmad-build`
-- **BMad-Help runs automatically** — Every workflow ends with guidance on what's next
-  :::
+After you answer its questions, read its plan. Approve it or ask for changes.
+The skill then writes the program, checks its work, fixes any problems, and
+shows you what changed.
 
-Ready to start? Install BMad, invoke `bmad-help`, and let your intelligent guide lead the way.
+## Run the Mars Rover
+
+Depending on what you told it, the result may look something like this:
+
+```bash
+python3 mars_rover.py --size 5x5 --obstacle 2,2
+```
+
+Enter `FFRFF`, then `MAP`, then `QUIT`. The terminal shows the rover stopping
+before the obstacle:
+
+```text
+MARS ROVER CONTROL
+Commands: F/M forward, B backward, L/R turn, MAP, STATUS, HELP, QUIT
+Position: (0, 0)  Heading: N
+rover> Position: (1, 2)  Heading: E
+OBSTACLE: movement blocked at (2, 2)
+rover>  4  . . . . .
+ 3  . . . . .
+ 2  . > # . .
+ 1  . . . . .
+ 0  . . . . .
+    0 1 2 3 4
+rover> Mission control signing off.
+```
+
+Open the files listed in the final message to look at your finished change.
+
+## You Built It
+
+Hello World showed how the `bmad-build` skill can finish a clear, tiny request.
+Mars Rover showed how the same skill can ask questions before it starts. Both
+gave you software you could run.
+
+## Keep Building
+
+1. [Install BMad in your own repository](../how-to/install-bmad.md), then run
+   the `bmad-build` skill with a short description of a small change.
+2. Continue to [Getting Deeper](./getting-deeper.md) for a small change in a
+   mature codebase, followed by a larger change using a written spec.


### PR DESCRIPTION
## What
Refocus the tutorials on first-use activation instead of workflow exposition.

## Why
The old Getting Started experience explained BMAD well, but it delayed the first concrete win. A separate Hello World exercise also repeated the same Build workflow without adding meaningful learning value.

## How
- replace Getting Started with one Mars Rover build exercise in an empty project
- place BMad Help after the completed build so it can explain meaningful work
- add a follow-on Getting Deeper tutorial for a bounded Django change and a spec-backed sequence
- close the deeper tutorial with a CTA back to installing BMAD in the user's own repository

## Testing
- `HUSKY=0 npm ci && npm run quality`
