### PR TITLE
docs: move roadmap to end of sidebar

### DIFF
--- a/website/astro.config.mjs
+++ b/website/astro.config.mjs
@@ -98,11 +98,6 @@ export default defineConfig({
           slug: 'index',
         },
         {
-          label: 'Roadmap',
-          translations: { 'vi-VN': 'Lộ trình', 'zh-CN': '路线图', 'fr-FR': 'Feuille de route', 'cs-CZ': 'Plán rozvoje' },
-          slug: 'roadmap',
-        },
-        {
           label: 'Tutorials',
           translations: { 'vi-VN': 'Hướng dẫn nhập môn', 'zh-CN': '教程', 'fr-FR': 'Tutoriels', 'cs-CZ': 'Tutoriály' },
           collapsed: false,
@@ -172,6 +167,11 @@ export default defineConfig({
               attrs: { target: '_blank' },
             },
           ],
+        },
+        {
+          label: 'Roadmap',
+          translations: { 'vi-VN': 'Lộ trình', 'zh-CN': '路线图', 'fr-FR': 'Feuille de route', 'cs-CZ': 'Plán rozvoje' },
+          slug: 'roadmap',
         },
       ],
 


### PR DESCRIPTION
## What
Move Roadmap from immediately below Welcome to the end of the documentation sidebar.

## Why
The primary sidebar path should lead new readers into the task-oriented documentation before showing future plans. Keeping Roadmap last preserves discoverability without interrupting the onboarding sequence.

## How
- relocate the existing Roadmap sidebar entry after BMad Ecosystem
- preserve its slug and all translations unchanged

## Testing
`HUSKY=0 npm ci && npm run quality`
