### PR TITLE
docs: refocus README on first-use conversion

### DIFF
--- a/README.md
+++ b/README.md
@@ -75,10 +75,6 @@ BMad is free for everyone and always will be. Star the repository, [buy me a cof
 
 Contributions are welcome. Read [CONTRIBUTING.md](CONTRIBUTING.md) before opening a pull request.
 
-[![Version](https://img.shields.io/npm/v/bmad-method?color=blue&label=version)](https://www.npmjs.com/package/bmad-method)
-[![License: MIT](https://img.shields.io/badge/License-MIT-yellow.svg)](LICENSE)
-[![Discord](https://img.shields.io/badge/Discord-Join%20Community-7289da?logo=discord&logoColor=white)](https://discord.gg/gk8jAdXWmj)
-
 ## License
 
 MIT License — see [LICENSE](LICENSE) for details.
@@ -88,3 +84,7 @@ MIT License — see [LICENSE](LICENSE) for details.
 [![Contributors](https://contrib.rocks/image?repo=bmad-code-org/BMAD-METHOD)](https://github.com/bmad-code-org/BMAD-METHOD/graphs/contributors)
 
 See [CONTRIBUTORS.md](CONTRIBUTORS.md) for contributor information.
+
+[![Version](https://img.shields.io/npm/v/bmad-method?color=blue&label=version)](https://www.npmjs.com/package/bmad-method)
+[![License: MIT](https://img.shields.io/badge/License-MIT-yellow.svg)](LICENSE)
+[![Discord](https://img.shields.io/badge/Discord-Join%20Community-7289da?logo=discord&logoColor=white)](https://discord.gg/gk8jAdXWmj)

--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 
 **Turn an idea or change request into working software without giving up the thinking.**
 
-BMad gives your AI coding tool a structured way to clarify what matters, plan only what the work needs, and carry those decisions through implementation and review. Start with a bug fix or use the full path for a product.
+Fix a bug without ceremony. Plan deeply when the work demands it. BMad adapts the path to the size and complexity of the change while keeping decisions connected from intent through implementation and review.
 
 ![The BMad delivery loop: Idea or change, Clarify and plan, Build and verify, Learn and adapt, then repeat](docs/images/bmad-delivery-loop.svg)
 

--- a/README.md
+++ b/README.md
@@ -6,7 +6,7 @@ Fix a bug without ceremony. Plan deeply when the work demands it. BMad adapts th
 
 ![The BMad delivery loop: Idea or change, Clarify and plan, Build and verify, Learn and adapt, then repeat](docs/images/bmad-delivery-loop.svg)
 
-_Start anywhere. Use the full loop for a product, or go directly to building when the work is already clear._
+_Start anywhere. Use BMad end to end, or carry its briefs, specifications, and architecture into your existing delivery workflow._
 
 ## Start Building
 

--- a/README.md
+++ b/README.md
@@ -4,13 +4,7 @@
 
 BMad gives your AI coding tool a structured way to clarify what matters, plan only what the work needs, and carry those decisions through implementation and review. Start with a bug fix or use the full path for a product.
 
-```mermaid
-graph LR;
-    I["Idea or change"] --> P["Clarify and plan"];
-    P --> B["Build and verify"];
-    B --> L["Learn and adapt"];
-    L -.-> P;
-```
+![The BMad delivery loop: Idea or change, Clarify and plan, Build and verify, Learn and adapt, then repeat](docs/images/bmad-delivery-loop.svg)
 
 _Start anywhere. Use the full loop for a product, or go directly to building when the work is already clear._
 

--- a/README.md
+++ b/README.md
@@ -2,9 +2,9 @@
 
 **Turn an idea or change request into working software without giving up the thinking.**
 
-**Heard BMad means heavyweight process for every change? It doesn't.** Clear changes can go straight to implementation. Complex work gets the depth it needs.
+**Heard BMad means heavyweight process for every change? It doesn't.** Clear changes go straight to build. Complex work gets the depth it needs.
 
-![The BMad delivery loop: Idea or change, Clarify and plan, Build and verify, Learn and adapt, then repeat](docs/images/bmad-delivery-loop.svg)
+![The BMad delivery loop: a vague notion starts at Clarify, a big clear idea at Plan, and a small clear idea at Build and verify; Learn and adjust loops back to Plan](docs/images/bmad-delivery-loop.svg)
 
 _Start anywhere. Use BMad end to end, or carry its briefs, specifications, and architecture into your existing delivery workflow._
 

--- a/README.md
+++ b/README.md
@@ -5,11 +5,11 @@
 BMad gives your AI coding tool a structured way to clarify what matters, plan only what the work needs, and carry those decisions through implementation and review. Start with a bug fix or use the full path for a product.
 
 ```mermaid
-flowchart LR
-    I[Idea or change] --> P[Clarify and plan]
-    P --> B[Build and verify]
-    B --> L[Learn and adapt]
-    L -.-> P
+graph LR;
+    I["Idea or change"] --> P["Clarify and plan"];
+    P --> B["Build and verify"];
+    B --> L["Learn and adapt"];
+    L -.-> P;
 ```
 
 _Start anywhere. Use the full loop for a product, or go directly to building when the work is already clear._

--- a/README.md
+++ b/README.md
@@ -2,9 +2,9 @@
 
 **Turn an idea or change request into working software without giving up the thinking.**
 
-**Heard BMad means heavyweight process for every change? It doesn't.** Clear changes go straight to build. Complex work gets the depth it needs.
+**Heard BMad means heavyweight process for every change? It doesn't.** Small changes go straight to build. Complex work gets the depth it needs.
 
-![The BMad delivery loop: a vague notion starts at Clarify, a big clear idea at Plan, and a small clear idea at Build and verify; Learn and adjust loops back to Plan](docs/images/bmad-delivery-loop.svg)
+![The BMad delivery loop: a vague notion starts at Clarify, a big clear idea at Plan, and a small change at Build and verify; Learn and adjust loops back to Plan](docs/images/bmad-delivery-loop.svg)
 
 _Start anywhere. Use BMad end to end, or carry its briefs, specifications, and architecture into your existing delivery workflow._
 

--- a/README.md
+++ b/README.md
@@ -20,7 +20,7 @@ Open your project in your AI coding tool, invoke `bmad-build` with what you want
 
 **[Build your first project with BMad →](https://docs.bmad-method.org/tutorials/getting-started/)**
 
-BMad is free and open source. For prerelease builds, CI/CD, configuration overrides, and non-interactive setup, see the [installation guide](https://docs.bmad-method.org/how-to/install-bmad/).
+BMad is free and open source, with no paywalled workflows or gated community. For prerelease builds, CI/CD, configuration overrides, and non-interactive setup, see the [installation guide](https://docs.bmad-method.org/how-to/install-bmad/).
 
 ## Why BMad?
 

--- a/README.md
+++ b/README.md
@@ -1,124 +1,93 @@
 ![BMad Method](banner-bmad-method.png)
 
-[![Version](https://img.shields.io/npm/v/bmad-method?color=blue&label=version)](https://www.npmjs.com/package/bmad-method)
-[![License: MIT](https://img.shields.io/badge/License-MIT-yellow.svg)](LICENSE)
-[![Node.js Version](https://img.shields.io/badge/node-%3E%3D20.12.0-brightgreen)](https://nodejs.org)
-[![Python Version](https://img.shields.io/badge/python-%3E%3D3.10-blue?logo=python&logoColor=white)](https://www.python.org)
-[![uv](https://img.shields.io/badge/uv-package%20manager-blueviolet?logo=uv)](https://docs.astral.sh/uv/)
-[![Discord](https://img.shields.io/badge/Discord-Join%20Community-7289da?logo=discord&logoColor=white)](https://discord.gg/gk8jAdXWmj)
+**Turn an idea or change request into working software without giving up the thinking.**
 
-**Build More Architect Dreams** — An AI-driven agile development module for the BMad Method Module Ecosystem, the best and most comprehensive Agile AI Driven Development framework that has true scale-adaptive intelligence that adjusts from bug fixes to enterprise systems.
+BMad gives your AI coding tool a structured way to clarify what matters, plan only what the work needs, and carry those decisions through implementation and review. Start with a bug fix or use the full path for a product.
 
-**100% free and open source.** No paywalls. No gated content. No gated Discord. We believe in empowering everyone, not just those who can pay for a gated community or courses.
+```mermaid
+flowchart LR
+    I[Idea or change] --> P[Clarify and plan]
+    P --> B[Build and verify]
+    B --> L[Learn and adapt]
+    L -.-> P
+```
 
-## Why the BMad Method?
+_Start anywhere. Use the full loop for a product, or go directly to building when the work is already clear._
 
-Traditional AI tools do the thinking for you, producing average results. BMad agents and facilitated workflows act as expert collaborators who guide you through a structured process to bring out your best thinking in partnership with the AI.
+## Start Building
 
-- **AI Intelligent Help** — Invoke the `bmad-help` skill anytime for guidance on what's next
-- **Scale-Domain-Adaptive** — Automatically adjusts planning depth based on project complexity
-- **Structured Workflows** — Grounded in agile best practices across analysis, planning, architecture, and implementation
-- **Specialized Agents** — 12+ domain experts (PM, Architect, Developer, UX, and more)
-- **Party Mode** — Bring multiple agent personas into one session to collaborate and discuss
-- **Complete Lifecycle** — From brainstorming to deployment
-
-[Learn more at **docs.bmad-method.org**](https://docs.bmad-method.org)
-
----
-
-## 🚀 What's Next for BMad?
-
-**V6 is here and we're just getting started!** The BMad Method is evolving rapidly with optimizations including Cross Platform Agent Team and Sub Agent inclusion, Skills Architecture, BMad Builder v1, Dev Loop Automation, and so much more in the works.
-
-**[📍 Check out the complete Roadmap →](https://docs.bmad-method.org/roadmap/)**
-
----
-
-## Quick Start
-
-**Prerequisites**: [Node.js](https://nodejs.org) v20.12+ · [Python](https://www.python.org) 3.10+ · [uv](https://docs.astral.sh/uv/)
+**Prerequisites:** [Node.js](https://nodejs.org) 20.12+, [Python](https://www.python.org) 3.10+, and [uv](https://docs.astral.sh/uv/)
 
 ```bash
 npx bmad-method install
 ```
 
-> Want the newest prerelease build? Use `npx bmad-method@next install`. Expect higher churn than the default install.
+Open your project in your AI coding tool, invoke `bmad-build` with what you want to change, and keep making the decisions that matter. Run `bmad-help` whenever you want guidance on what comes next or what is optional.
 
-Follow the installer prompts, then open your AI IDE (Claude Code, Cursor, etc.) in your project folder.
+**[Build your first project with BMad →](https://docs.bmad-method.org/tutorials/getting-started/)**
 
-**Non-Interactive Installation** (for CI/CD):
+BMad is free and open source. For prerelease builds, CI/CD, configuration overrides, and non-interactive setup, see the [installation guide](https://docs.bmad-method.org/how-to/install-bmad/).
 
-```bash
-npx bmad-method install --directory /path/to/project --modules bmm --tools claude-code --yes
-```
+## Why BMad?
 
-Override any module config option with `--set <module>.<key>=<value>` (repeatable). Run `--list-options [module]` to see locally-known official keys (built-in modules plus any external officials cached on this machine):
+Coding assistants are effective at implementation, but they often turn unstated assumptions into code. BMad keeps you in control while its agents and workflows make the important decisions explicit and preserve them as context for the work that follows.
 
-```bash
-npx bmad-method install --yes \
-  --modules bmm --tools claude-code \
-  --set bmm.project_knowledge=research \
-  --set bmm.user_skill_level=expert
-```
+- **Right-sized process** — Go directly to implementation for clear changes or add deeper planning for larger initiatives.
+- **Durable context** — Carry product and technical decisions forward instead of re-explaining them in every chat.
+- **Specialized perspectives** — Bring in product, architecture, UX, development, and testing expertise when it helps.
+- **Guided collaboration** — Use structured workflows and multiple-agent discussions without handing over judgment.
+- **One delivery path** — Move from early thinking through reviewed implementation, correction, and learning.
 
-[See all installation options](https://docs.bmad-method.org/how-to/non-interactive-installation/)
+[See how the workflows fit together →](https://docs.bmad-method.org/reference/workflow-map/)
 
-> **Not sure what to do?** Ask `bmad-help` — it tells you exactly what's next and what's optional. You can also ask questions like `bmad-help I just finished the architecture, what do I do next?`
+## BMad Ecosystem
 
-## Modules
+Install the core method or add official modules for specialized work.
 
-BMad Method extends with official modules for specialized domains. Available during installation or anytime after.
+| Module | Purpose |
+| --- | --- |
+| **[BMad Method (BMM)](https://github.com/bmad-code-org/BMAD-METHOD)** | Plan and deliver software with scale-adaptive workflows |
+| **[BMad Builder (BMB)](https://github.com/bmad-code-org/bmad-builder)** | Create custom BMad agents and workflows |
+| **[Test Architect (TEA)](https://github.com/bmad-code-org/bmad-method-test-architecture-enterprise)** | Design risk-based test strategy and automation |
+| **[Game Dev Studio (BMGD)](https://github.com/bmad-code-org/bmad-module-game-dev-studio)** | Build games with Unity, Unreal, or Godot workflows |
+| **[Creative Intelligence Suite (CIS)](https://github.com/bmad-code-org/bmad-module-creative-intelligence-suite)** | Run innovation, brainstorming, and design-thinking workflows |
 
-| Module                                                                                                            | Purpose                                           |
-| ----------------------------------------------------------------------------------------------------------------- | ------------------------------------------------- |
-| **[BMad Method (BMM)](https://github.com/bmad-code-org/BMAD-METHOD)**                                             | Core framework with 34+ workflows                 |
-| **[BMad Builder (BMB)](https://github.com/bmad-code-org/bmad-builder)**                                           | Create custom BMad agents and workflows           |
-| **[Test Architect (TEA)](https://github.com/bmad-code-org/bmad-method-test-architecture-enterprise)**             | Risk-based test strategy and automation           |
-| **[Game Dev Studio (BMGD)](https://github.com/bmad-code-org/bmad-module-game-dev-studio)**                        | Game development workflows (Unity, Unreal, Godot) |
-| **[Creative Intelligence Suite (CIS)](https://github.com/bmad-code-org/bmad-module-creative-intelligence-suite)** | Innovation, brainstorming, design thinking        |
+## Plan on the Web
 
-## Web Bundles
-
-V4 shipped web bundles. V6 brings them back, new and improved.
-
-Web bundles package selected BMad skills for installation as **Google Gemini Gems** and **ChatGPT Custom GPTs**. Use them to do the upfront planning work (brainstorming, product briefs, PRDs, PRFAQs, UX specs, market and industry research) in your web LLM subscription, then bring the polished artifacts into your IDE for implementation. Planning runs on a flat-rate subscription instead of metered IDE tokens, which is a meaningful cost saver on longer engagements. Choose the best model available to you in Gemini or ChatGPT.
-
-Current shelf: brainstorming, product brief, PRFAQ, PRD, UX, market & industry research.
-
-**Browse and install at [bmadcode.com/web-bundles](https://bmadcode.com/web-bundles/)**. One card per bundle, inline install steps for Gemini and ChatGPT, one-click ZIP download. See [the web bundles guide](https://docs.bmad-method.org/explanation/web-bundles/) for the concept.
+[Web bundles](https://bmadcode.com/web-bundles/) package selected BMad workflows as Google Gemini Gems and ChatGPT Custom GPTs. Use them for planning in your existing web subscription, then bring the resulting artifacts into your AI coding tool for implementation.
 
 ## Documentation
 
-[BMad Method Docs Site](https://docs.bmad-method.org) — Tutorials, guides, concepts, and reference
+- **[Getting Started](https://docs.bmad-method.org/tutorials/getting-started/)** — Install BMad and build a small project.
+- **[Workflow Map](https://docs.bmad-method.org/reference/workflow-map/)** — Understand the available paths and outputs.
+- **[Established Projects](https://docs.bmad-method.org/how-to/established-projects/)** — Add BMad to an existing codebase.
+- **[Upgrade to V6](https://docs.bmad-method.org/how-to/upgrade-to-v6/)** — Migrate from an earlier version.
 
-**Quick links:**
+## Roadmap
 
-- [Getting Started Tutorial](https://docs.bmad-method.org/tutorials/getting-started/)
-- [Upgrading from Previous Versions](https://docs.bmad-method.org/how-to/upgrade-to-v6/)
-- [Test Architect Documentation](https://bmad-code-org.github.io/bmad-method-test-architecture-enterprise/)
+See what is in progress and what is planned on the [public roadmap](https://docs.bmad-method.org/roadmap/).
 
 ## Community
 
-- [Discord](https://discord.gg/gk8jAdXWmj) — Get help, share ideas, collaborate
-- [YouTube](https://youtube.com/@BMadCode) — Tutorials, master class, and more
-- [X / Twitter](https://x.com/BMadCode)
-- [Website](https://bmadcode.com)
-- [GitHub Issues](https://github.com/bmad-code-org/BMAD-METHOD/issues) — Bug reports and feature requests
-- [Discussions](https://github.com/bmad-code-org/BMAD-METHOD/discussions) — Community conversations
+- [Discord](https://discord.gg/gk8jAdXWmj) — Get help, share ideas, and collaborate.
+- [YouTube](https://youtube.com/@BMadCode) — Watch tutorials and master classes.
+- [GitHub Issues](https://github.com/bmad-code-org/BMAD-METHOD/issues) — Report bugs and request features.
+- [GitHub Discussions](https://github.com/bmad-code-org/BMAD-METHOD/discussions) — Join longer community conversations.
+- [BMad Code](https://bmadcode.com) — Explore the wider ecosystem.
 
-## Support BMad
+## Support and Contributing
 
-BMad is free for everyone and always will be. Star this repo, [buy me a coffee](https://buymeacoffee.com/bmad), or email <contact@bmadcode.com> for corporate sponsorship.
+BMad is free for everyone and always will be. Star the repository, [buy me a coffee](https://buymeacoffee.com/bmad), or email <contact@bmadcode.com> for corporate sponsorship.
 
-## Contributing
+Contributions are welcome. Read [CONTRIBUTING.md](CONTRIBUTING.md) before opening a pull request.
 
-We welcome contributions! See [CONTRIBUTING.md](CONTRIBUTING.md) for guidelines.
+[![Version](https://img.shields.io/npm/v/bmad-method?color=blue&label=version)](https://www.npmjs.com/package/bmad-method)
+[![License: MIT](https://img.shields.io/badge/License-MIT-yellow.svg)](LICENSE)
+[![Discord](https://img.shields.io/badge/Discord-Join%20Community-7289da?logo=discord&logoColor=white)](https://discord.gg/gk8jAdXWmj)
 
 ## License
 
 MIT License — see [LICENSE](LICENSE) for details.
-
----
 
 **BMad** and **BMAD-METHOD** are trademarks of BMad Code, LLC. See [TRADEMARK.md](TRADEMARK.md) for details.
 

--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 
 **Turn an idea or change request into working software without giving up the thinking.**
 
-Fix a bug without ceremony. Plan deeply when the work demands it. BMad adapts the path to the size and complexity of the change while keeping decisions connected from intent through implementation and review.
+**Heard BMad means heavyweight process for every change? It doesn't.** Clear changes can go straight to implementation. Complex work gets the depth it needs.
 
 ![The BMad delivery loop: Idea or change, Clarify and plan, Build and verify, Learn and adapt, then repeat](docs/images/bmad-delivery-loop.svg)
 

--- a/docs/images/bmad-delivery-loop.svg
+++ b/docs/images/bmad-delivery-loop.svg
@@ -1,6 +1,6 @@
 <svg xmlns="http://www.w3.org/2000/svg" width="1120" height="420" viewBox="0 0 1120 420" role="img" aria-labelledby="title description">
   <title id="title">The BMad delivery loop</title>
-  <desc id="description">Three kinds of input enter the delivery loop at different points: a vague notion enters at Clarify, a big clear idea enters at Plan, and a small clear idea goes straight to Build and verify. The loop continues through Learn and adjust, which feeds back into planning as the work evolves.</desc>
+  <desc id="description">Three kinds of input enter the delivery loop at different points: a vague notion enters at Clarify, a big clear idea enters at Plan, and a small change goes straight to Build and verify. The loop continues through Learn and adjust, which feeds back into planning as the work evolves.</desc>
   <defs>
     <linearGradient id="background" x1="0" y1="0" x2="1" y2="1">
       <stop offset="0" stop-color="#041629"/>
@@ -38,7 +38,7 @@
   <rect x="415" y="92" width="20" height="9" rx="2.5" fill="#112f49" stroke="#ffe34f" stroke-width="2.5"/>
   <path d="M401 42L394 35M449 42L456 35" stroke="#ffe34f" stroke-width="2.5" stroke-linecap="round"/>
 
-  <!-- Small clear idea: small bulb -->
+  <!-- Small change: small bulb -->
   <circle cx="695" cy="80" r="14" fill="#112f49" stroke="#ffe34f" stroke-width="2"/>
   <rect x="688.5" y="94" width="13" height="6" rx="2" fill="#112f49" stroke="#ffe34f" stroke-width="2"/>
   <path d="M681.5 66.5L676.5 61.5M708.5 66.5L713.5 61.5" stroke="#ffe34f" stroke-width="2" stroke-linecap="round"/>
@@ -48,7 +48,7 @@
     <text x="155" y="94" fill="#9cc8e2" font-size="32" font-weight="700">?</text>
     <text x="155" y="128" fill="#ffffff" font-size="16" font-weight="600">Vague notion</text>
     <text x="425" y="128" fill="#ffffff" font-size="16" font-weight="600">Big clear idea</text>
-    <text x="695" y="128" fill="#ffffff" font-size="16" font-weight="600">Small clear idea</text>
+    <text x="695" y="128" fill="#ffffff" font-size="16" font-weight="600">Small change</text>
 
     <g transform="translate(60 200)">
       <rect width="190" height="88" rx="12" fill="#112f49" stroke="#39ccff" stroke-opacity=".7" stroke-width="2"/>

--- a/docs/images/bmad-delivery-loop.svg
+++ b/docs/images/bmad-delivery-loop.svg
@@ -1,0 +1,45 @@
+<svg xmlns="http://www.w3.org/2000/svg" width="1120" height="280" viewBox="0 0 1120 280" role="img" aria-labelledby="title description">
+  <title id="title">The BMad delivery loop</title>
+  <desc id="description">Move from an idea or change through planning, building, and learning, then adapt and repeat.</desc>
+  <defs>
+    <linearGradient id="background" x1="0" y1="0" x2="1" y2="1">
+      <stop offset="0" stop-color="#041629"/>
+      <stop offset="1" stop-color="#0a2c47"/>
+    </linearGradient>
+    <marker id="arrow" viewBox="0 0 10 10" refX="8" refY="5" markerWidth="7" markerHeight="7" orient="auto-start-reverse">
+      <path d="M 0 0 L 10 5 L 0 10 z" fill="#39ccff"/>
+    </marker>
+  </defs>
+
+  <rect width="1120" height="280" rx="20" fill="url(#background)"/>
+  <path d="M0 70H1120M0 140H1120M0 210H1120M140 0V280M280 0V280M420 0V280M560 0V280M700 0V280M840 0V280M980 0V280" stroke="#38bdf8" stroke-opacity=".06"/>
+
+  <path d="M235 112H315" stroke="#39ccff" stroke-width="4" stroke-linecap="round" marker-end="url(#arrow)"/>
+  <path d="M505 112H585" stroke="#39ccff" stroke-width="4" stroke-linecap="round" marker-end="url(#arrow)"/>
+  <path d="M775 112H855" stroke="#39ccff" stroke-width="4" stroke-linecap="round" marker-end="url(#arrow)"/>
+  <path d="M965 160C965 237 410 237 410 160" fill="none" stroke="#39ccff" stroke-opacity=".75" stroke-width="3" stroke-dasharray="9 10" marker-end="url(#arrow)"/>
+
+  <g font-family="Avenir Next, Avenir, Segoe UI, sans-serif" text-anchor="middle">
+    <g transform="translate(45 72)">
+      <rect width="190" height="88" rx="12" fill="#112f49" stroke="#ffe34f" stroke-width="2"/>
+      <text x="95" y="40" fill="#ffe34f" font-size="14" font-weight="700" letter-spacing="1.5">START ANYWHERE</text>
+      <text x="95" y="66" fill="#ffffff" font-size="21" font-weight="600">Idea or change</text>
+    </g>
+    <g transform="translate(315 72)">
+      <rect width="190" height="88" rx="12" fill="#112f49" stroke="#39ccff" stroke-opacity=".7" stroke-width="2"/>
+      <text x="95" y="40" fill="#39ccff" font-size="14" font-weight="700" letter-spacing="1.5">THINK</text>
+      <text x="95" y="66" fill="#ffffff" font-size="21" font-weight="600">Clarify and plan</text>
+    </g>
+    <g transform="translate(585 72)">
+      <rect width="190" height="88" rx="12" fill="#112f49" stroke="#39ccff" stroke-opacity=".7" stroke-width="2"/>
+      <text x="95" y="40" fill="#39ccff" font-size="14" font-weight="700" letter-spacing="1.5">DELIVER</text>
+      <text x="95" y="66" fill="#ffffff" font-size="21" font-weight="600">Build and verify</text>
+    </g>
+    <g transform="translate(855 72)">
+      <rect width="190" height="88" rx="12" fill="#112f49" stroke="#39ccff" stroke-opacity=".7" stroke-width="2"/>
+      <text x="95" y="40" fill="#39ccff" font-size="14" font-weight="700" letter-spacing="1.5">ADAPT</text>
+      <text x="95" y="66" fill="#ffffff" font-size="21" font-weight="600">Learn and adjust</text>
+    </g>
+    <text x="560" y="254" fill="#9cc8e2" font-size="17" font-weight="600" letter-spacing="1.4">RIGHT-SIZED FOR THE WORK IN FRONT OF YOU</text>
+  </g>
+</svg>

--- a/docs/images/bmad-delivery-loop.svg
+++ b/docs/images/bmad-delivery-loop.svg
@@ -1,6 +1,6 @@
-<svg xmlns="http://www.w3.org/2000/svg" width="1120" height="280" viewBox="0 0 1120 280" role="img" aria-labelledby="title description">
+<svg xmlns="http://www.w3.org/2000/svg" width="1120" height="420" viewBox="0 0 1120 420" role="img" aria-labelledby="title description">
   <title id="title">The BMad delivery loop</title>
-  <desc id="description">Move from an idea or change through planning, building, and learning, then adapt and repeat.</desc>
+  <desc id="description">Three kinds of input enter the delivery loop at different points: a vague notion enters at Clarify, a big clear idea enters at Plan, and a small clear idea goes straight to Build and verify. The loop continues through Learn and adjust, which feeds back into planning as the work evolves.</desc>
   <defs>
     <linearGradient id="background" x1="0" y1="0" x2="1" y2="1">
       <stop offset="0" stop-color="#041629"/>
@@ -9,37 +9,63 @@
     <marker id="arrow" viewBox="0 0 10 10" refX="8" refY="5" markerWidth="7" markerHeight="7" orient="auto-start-reverse">
       <path d="M 0 0 L 10 5 L 0 10 z" fill="#39ccff"/>
     </marker>
+    <marker id="arrow-gold" viewBox="0 0 10 10" refX="8" refY="5" markerWidth="7" markerHeight="7" orient="auto-start-reverse">
+      <path d="M 0 0 L 10 5 L 0 10 z" fill="#ffe34f"/>
+    </marker>
   </defs>
 
-  <rect width="1120" height="280" rx="20" fill="url(#background)"/>
-  <path d="M0 70H1120M0 140H1120M0 210H1120M140 0V280M280 0V280M420 0V280M560 0V280M700 0V280M840 0V280M980 0V280" stroke="#38bdf8" stroke-opacity=".06"/>
+  <rect width="1120" height="420" rx="20" fill="url(#background)"/>
+  <path d="M0 70H1120M0 140H1120M0 210H1120M0 280H1120M0 350H1120M140 0V420M280 0V420M420 0V420M560 0V420M700 0V420M840 0V420M980 0V420" stroke="#38bdf8" stroke-opacity=".06"/>
 
-  <path d="M235 112H315" stroke="#39ccff" stroke-width="4" stroke-linecap="round" marker-end="url(#arrow)"/>
-  <path d="M505 112H585" stroke="#39ccff" stroke-width="4" stroke-linecap="round" marker-end="url(#arrow)"/>
-  <path d="M775 112H855" stroke="#39ccff" stroke-width="4" stroke-linecap="round" marker-end="url(#arrow)"/>
-  <path d="M965 160C965 237 410 237 410 160" fill="none" stroke="#39ccff" stroke-opacity=".75" stroke-width="3" stroke-dasharray="9 10" marker-end="url(#arrow)"/>
+  <!-- Entry drops: each input lands where it enters the loop -->
+  <path d="M155 140V194" stroke="#ffe34f" stroke-width="3" stroke-linecap="round" marker-end="url(#arrow-gold)"/>
+  <path d="M425 140V194" stroke="#ffe34f" stroke-width="3" stroke-linecap="round" marker-end="url(#arrow-gold)"/>
+  <path d="M695 140V194" stroke="#ffe34f" stroke-width="3" stroke-linecap="round" marker-end="url(#arrow-gold)"/>
+
+  <!-- Main path and feedback loop -->
+  <path d="M250 244H330" stroke="#39ccff" stroke-width="4" stroke-linecap="round" marker-end="url(#arrow)"/>
+  <path d="M520 244H600" stroke="#39ccff" stroke-width="4" stroke-linecap="round" marker-end="url(#arrow)"/>
+  <path d="M790 244H870" stroke="#39ccff" stroke-width="4" stroke-linecap="round" marker-end="url(#arrow)"/>
+  <path d="M965 288C965 368 425 368 425 288" fill="none" stroke="#39ccff" stroke-opacity=".75" stroke-width="3" stroke-dasharray="9 10" marker-end="url(#arrow)"/>
+
+  <!-- Vague notion: cloud with a question mark -->
+  <g transform="translate(155 76) scale(3.8) translate(-12 -12)">
+    <path d="M19.35 10.04C18.67 6.59 15.64 4 12 4 9.11 4 6.6 5.64 5.35 8.04 2.34 8.36 0 10.91 0 14c0 3.31 2.69 6 6 6h13c2.76 0 5-2.24 5-5 0-2.64-2.05-4.78-4.65-4.96z" fill="#112f49" stroke="#9cc8e2" stroke-width=".7" stroke-dasharray="2 2.4"/>
+  </g>
+
+  <!-- Big clear idea: large bulb -->
+  <circle cx="425" cy="66" r="26" fill="#112f49" stroke="#ffe34f" stroke-width="2.5"/>
+  <rect x="415" y="92" width="20" height="9" rx="2.5" fill="#112f49" stroke="#ffe34f" stroke-width="2.5"/>
+  <path d="M401 42L394 35M449 42L456 35" stroke="#ffe34f" stroke-width="2.5" stroke-linecap="round"/>
+
+  <!-- Small clear idea: small bulb -->
+  <circle cx="695" cy="80" r="14" fill="#112f49" stroke="#ffe34f" stroke-width="2"/>
+  <rect x="688.5" y="94" width="13" height="6" rx="2" fill="#112f49" stroke="#ffe34f" stroke-width="2"/>
+  <path d="M681.5 66.5L676.5 61.5M708.5 66.5L713.5 61.5" stroke="#ffe34f" stroke-width="2" stroke-linecap="round"/>
 
   <g font-family="Avenir Next, Avenir, Segoe UI, sans-serif" text-anchor="middle">
-    <g transform="translate(45 72)">
-      <rect width="190" height="88" rx="12" fill="#112f49" stroke="#ffe34f" stroke-width="2"/>
-      <text x="95" y="40" fill="#ffe34f" font-size="14" font-weight="700" letter-spacing="1.5">START ANYWHERE</text>
-      <text x="95" y="66" fill="#ffffff" font-size="21" font-weight="600">Idea or change</text>
-    </g>
-    <g transform="translate(315 72)">
+    <text x="560" y="28" fill="#ffe34f" font-size="14" font-weight="700" letter-spacing="1.5">START ANYWHERE</text>
+    <text x="155" y="94" fill="#9cc8e2" font-size="32" font-weight="700">?</text>
+    <text x="155" y="128" fill="#ffffff" font-size="16" font-weight="600">Vague notion</text>
+    <text x="425" y="128" fill="#ffffff" font-size="16" font-weight="600">Big clear idea</text>
+    <text x="695" y="128" fill="#ffffff" font-size="16" font-weight="600">Small clear idea</text>
+
+    <g transform="translate(60 200)">
       <rect width="190" height="88" rx="12" fill="#112f49" stroke="#39ccff" stroke-opacity=".7" stroke-width="2"/>
-      <text x="95" y="40" fill="#39ccff" font-size="14" font-weight="700" letter-spacing="1.5">THINK</text>
-      <text x="95" y="66" fill="#ffffff" font-size="21" font-weight="600">Clarify and plan</text>
+      <text x="95" y="51" fill="#ffffff" font-size="21" font-weight="600">Clarify</text>
     </g>
-    <g transform="translate(585 72)">
+    <g transform="translate(330 200)">
       <rect width="190" height="88" rx="12" fill="#112f49" stroke="#39ccff" stroke-opacity=".7" stroke-width="2"/>
-      <text x="95" y="40" fill="#39ccff" font-size="14" font-weight="700" letter-spacing="1.5">DELIVER</text>
-      <text x="95" y="66" fill="#ffffff" font-size="21" font-weight="600">Build and verify</text>
+      <text x="95" y="51" fill="#ffffff" font-size="21" font-weight="600">Plan</text>
     </g>
-    <g transform="translate(855 72)">
+    <g transform="translate(600 200)">
       <rect width="190" height="88" rx="12" fill="#112f49" stroke="#39ccff" stroke-opacity=".7" stroke-width="2"/>
-      <text x="95" y="40" fill="#39ccff" font-size="14" font-weight="700" letter-spacing="1.5">ADAPT</text>
-      <text x="95" y="66" fill="#ffffff" font-size="21" font-weight="600">Learn and adjust</text>
+      <text x="95" y="51" fill="#ffffff" font-size="21" font-weight="600">Build and verify</text>
     </g>
-    <text x="560" y="254" fill="#9cc8e2" font-size="17" font-weight="600" letter-spacing="1.4">RIGHT-SIZED FOR THE WORK IN FRONT OF YOU</text>
+    <g transform="translate(870 200)">
+      <rect width="190" height="88" rx="12" fill="#112f49" stroke="#39ccff" stroke-opacity=".7" stroke-width="2"/>
+      <text x="95" y="51" fill="#ffffff" font-size="21" font-weight="600">Learn and adjust</text>
+    </g>
+    <text x="560" y="396" fill="#9cc8e2" font-size="17" font-weight="600" letter-spacing="1.4">RIGHT-SIZED FOR THE WORK IN FRONT OF YOU</text>
   </g>
 </svg>


### PR DESCRIPTION
## What

Rewrite the repository README around first-use conversion.

This is intentionally shorter and more outcome-oriented: it prioritizes understanding and first use over cataloging every capability above the fold.

## Why

The previous opening led with internal terminology, broad claims, and future plans before showing visitors what BMad helps them accomplish or how to try it.

## How

- lead with a concrete outcome and an abstract adaptive-delivery diagram
- put installation, `bmad-help`, and the Getting Started CTA before feature detail
- condense advanced installation, ecosystem, web bundle, and community content into secondary paths
- move Roadmap below activation while preserving support, contribution, license, trademark, and contributor information

## Testing

- rendered and inspected the README on GitHub at desktop and mobile widths
- replaced Mermaid with a static SVG after detecting a GitHub rich-render failure
- `HUSKY=0 npm ci && npm run quality`
