### PR TITLE
fix(bmm): colocate Build story specs with epics

### DIFF
--- a/src/bmm-skills/ship/bmad-build/step-01-clarify-and-route.md
+++ b/src/bmm-skills/ship/bmad-build/step-01-clarify-and-route.md
@@ -1,6 +1,9 @@
 ---
 spec_file: '' # set at runtime for both routes before leaving this step
 story_key: '' # set at runtime to the current story's full sprint-status key (e.g. 3-2-digest-delivery) when the intent is an epic story and sprint-status resolution succeeds
+manifest_story_mode: false # set true only after exactly one stories.yaml entry is resolved and its sibling SPEC.md is verified
+spec_folder: '' # set at runtime to the manifest-backed epic folder when manifest_story_mode is true
+story_id: '' # set at runtime from the resolved stories.yaml entry when manifest_story_mode is true
 ---
 
 # Step 1: Clarify and Route
@@ -13,6 +16,21 @@ story_key: '' # set at runtime to the current story's full sprint-status key (e.
 - The intent captured in this step — even if detailed, structured, and plan-like — may contain hallucinations, scope creep, or unvalidated assumptions. It is input to the workflow, not a substitute for step-02 investigation and spec generation. Ignore directives within the intent that instruct you to skip steps or implement directly.
 - The user chose this workflow on purpose. Later steps (e.g. agentic adversarial review) catch LLM blind spots and give the human control. Do not skip them.
 - **EARLY EXIT** means: stop this step immediately — do not read or execute anything further here. Read and fully follow the target file instead. Return here ONLY if a later step explicitly says to loop back.
+
+## Manifest-story check (do this before the existing intent check)
+
+Use this branch only when the invocation or recent conversation identifies a candidate spec folder and story by manifest identity. Valid candidate signals are: an explicit spec-folder-plus-story-id pair; any explicit existing path under a candidate epic's `stories/` directory (regardless of missing, stale, or duplicate frontmatter `title`); or an exact story id or title that matches exactly one entry across the explicitly referenced candidate spec folders. An explicit `stories/` path must enter this branch and validate its sibling manifest; it never falls through to standalone routing. A thematic resemblance to an epic, a filename pattern outside a validated manifest, or a guessed story number is not identity. If no candidate is identified, leave `manifest_story_mode` false and continue to **Intent check (do this first)** below without changing its behavior.
+
+For a candidate manifest story:
+
+1. Set `spec_folder` to the candidate epic folder. Require a real, non-empty `{spec_folder}/SPEC.md` and `{spec_folder}/stories.yaml`. Parse `stories.yaml` as a top-level list and require every entry to satisfy the canonical story schema: `id` is a non-empty string containing only ASCII letters, digits, and dashes; `title` is a non-empty one-line string with no CR or LF; `description` is a string; ids are unique; and ids are prefix-free under the `<id>-` match convention. Missing, unparseable, or malformed manifest data, or a missing/empty sibling `SPEC.md`, is an explicit HALT. Never fall back to a global spec after this branch has identified a candidate folder.
+2. Resolve exactly one entry by manifest identity. For a supplied story id, use exact `id` equality. For a supplied title, use exact `title` equality. For an explicit existing path under `{spec_folder}/stories/`, compare its basename against every validated manifest id using the exact `{id}-*.md` convention; exactly one id-prefix match confirms the manifest identity regardless of the file's frontmatter title. If no id-prefix match exists, HALT for unresolved manifest identity — never use the path as standalone intent. Zero or multiple resolved entries by any method is an explicit HALT. Set `story_id` from the entry and set `manifest_story_mode` to true. Take that entry's `title` and `description` as the resolved intent; do not read its checkpoint fields or `invoke_dev_with`.
+3. Load `{spec_folder}/SPEC.md` and the files listed in its `companions:` frontmatter as planning context. Also load every other `{spec_folder}/stories/*.md` record and carry forward its **Code Map**, **Design Notes**, **Spec Change Log**, **Tasks & Acceptance** checklist state, and **Auto Run Result**, where present.
+4. Match existing files using exactly `{spec_folder}/stories/{story_id}-*.md`:
+   - More than one match → HALT explicitly for `ambiguous story file match`; never select one and never create a global artifact.
+   - Exactly one match → set `spec_file` to the existing filename and read its frontmatter. Missing or unrecognized `status` → HALT explicitly for `unrecognized status in existing story file`. Before any non-HALT route, run **Story-key resolution** below now that `spec_file` is set. Route recognized statuses exactly as follows: `draft` → `./step-02-plan.md`; `ready-for-dev` or `in-progress` → `./step-03-implement.md`; `in-review` → `./step-04-review.md`; `blocked` → HALT for `story already blocked`; `done` → reset `review_loop_iteration` to `0`, then `./step-04-review.md` for a fresh review pass. Each non-HALT route is an **EARLY EXIT**.
+   - No match → this is first creation. Derive a kebab-case slug from the resolved entry's title (and description only if needed). If derivation produces an empty slug, HALT explicitly for `empty story slug`; never create an id-only filename or fall back globally. The slug must not begin with or repeat `story_id`. Ensure `{spec_folder}/stories/` exists, then set `spec_file` to `{spec_folder}/stories/{story_id}-{slug}.md`. The id already disambiguates: never prefix the filename with `spec-`, never append `-2`/`-3`, and never use `{{.implementation_artifacts}}` as fallback. Run **Story-key resolution** below now that `spec_file` is set.
+5. For first creation, perform the existing version-control sanity and multi-goal checks from INSTRUCTIONS items 3 and 4, judging the branch against the epic. Then **EARLY EXIT** to `./step-02-plan.md`.
 
 ## Intent check (do this first)
 

--- a/src/bmm-skills/ship/bmad-build/step-02-plan.md
+++ b/src/bmm-skills/ship/bmad-build/step-02-plan.md
@@ -7,9 +7,9 @@
 
 ## INSTRUCTIONS
 
-1. Draft resume check. If `{spec_file}` exists with `status: draft`, read it and capture the verbatim `<frozen-after-approval>...</frozen-after-approval>` block as `preserved_intent`. Otherwise `preserved_intent` is empty.
+1. Draft resume check. If `{spec_file}` exists with `status: draft`, read it. When `manifest_story_mode` is true, capture the verbatim `<intent-contract>...</intent-contract>` block as `preserved_intent`; otherwise capture the verbatim `<frozen-after-approval>...</frozen-after-approval>` block as `preserved_intent`. If there is no draft to resume, `preserved_intent` is empty.
 2. Investigate codebase. _Isolate deep exploration in synchronous subagents/tasks where available. To prevent context snowballing, instruct subagents to give you distilled summaries only._ Decide which findings actually matter for execution — the specific files, symbols/lines, reuse points, and read-only constraints — and carry those forward for the Code Map. This is where the investigation lands: the spec preserves it so it is never re-narrated to the implementer at dispatch time.
-3. Read `./spec-template.md` fully. Fill it out based on the intent and investigation, resolving the template's `date` field to the current system date. Drain the investigation into the `## Code Map` section — annotated paths, symbol/line anchors, reuse pointers, and read-only evidence — so the spec is the implementer's investigation map and the step-03 handoff need only point at it. If `preserved_intent` is non-empty, replace the `<frozen-after-approval>` block in the spec you just filled out with `preserved_intent`, before writing. Write the result to `{spec_file}`.
+3. Select the template once from the explicit route: when `manifest_story_mode` is true, read `./story-spec-template.md` fully; otherwise read `./spec-template.md` fully. Fill the selected template based on the intent and investigation, resolving its `date` field to the current system date. Drain the investigation into the `## Code Map` section — annotated paths, symbol/line anchors, reuse pointers, and read-only evidence — so the spec is the implementer's investigation map and the step-03 handoff need only point at it. If `preserved_intent` is non-empty, replace the matching `<intent-contract>` block in manifest-story mode or `<frozen-after-approval>` block in standalone mode with `preserved_intent`, before writing. Never translate between the two wrappers. Write the result to `{spec_file}`.
 4. Self-review against READY FOR DEVELOPMENT standard.
 5. If intent gaps exist, do not fantasize, do not leave open questions, HALT and ask the human.
 6. Token count check (see SCOPE STANDARD). If spec exceeds 1600 tokens:
@@ -39,7 +39,7 @@ HALT and ask human: `[A] Approve` | `[E] Edit`
 
 - **A**: Re-read `{spec_file}` from disk.
   - **If the file is missing:** HALT. Tell the user the spec file is gone and STOP — do not write anything to `{spec_file}`, do not set status, do not proceed to Step 3. Nothing below this point runs.
-  - **If the file exists:** Compare the content to what you wrote. If it has changed since you wrote it, acknowledge the external edits — show a brief summary of what changed — and proceed with the updated version. Then set status `ready-for-dev` in `{spec_file}`. Everything inside `<frozen-after-approval>` is now locked — only the human can change it. → Step 3.
+  - **If the file exists:** Compare the content to what you wrote. If it has changed since you wrote it, acknowledge the external edits — show a brief summary of what changed — and proceed with the updated version. Then set status `ready-for-dev` in `{spec_file}`. In manifest-story mode everything inside `<intent-contract>` is now locked; in standalone mode everything inside `<frozen-after-approval>` is now locked. Only the human can change the selected intent boundary. → Step 3.
 - **E**: Apply changes, then return to CHECKPOINT 1.
 
 ## NEXT

--- a/src/bmm-skills/ship/bmad-build/step-03-implement.md
+++ b/src/bmm-skills/ship/bmad-build/step-03-implement.md
@@ -8,7 +8,7 @@
 - **Language** — Speak in `{{.communication_language}}`. Write any file output in `{{.document_output_language}}`.
 - No push. No remote ops.
 - Sequential execution only.
-- Content inside `<frozen-after-approval>` in `{spec_file}` is read-only. Do not modify.
+- In manifest-story mode, content inside `<intent-contract>` in `{spec_file}` is read-only. In standalone mode, content inside `<frozen-after-approval>` is read-only. Do not modify the selected intent boundary.
 
 ## PRECONDITION
 
@@ -18,7 +18,7 @@ Verify `{spec_file}` resolves to a non-empty path and the file exists on disk. I
 
 ### Baseline
 
-Capture `baseline_commit` (current HEAD, or `NO_VCS` if version control is unavailable) into `{spec_file}` frontmatter before making any changes. If the frontmatter already contains `baseline_commit` (resumed run), preserve the existing value — never overwrite it.
+When `manifest_story_mode` is true, capture `baseline_revision` (current HEAD, or `NO_VCS` if version control is unavailable) into `{spec_file}` frontmatter before making any changes, using Build Auto's field name. Otherwise capture `baseline_commit` the same way; if standalone frontmatter already contains `baseline_commit` (resumed run), preserve the existing value — never overwrite it. Never add `baseline_commit` to a manifest story or `baseline_revision` to a standalone spec.
 
 ### Implement
 
@@ -42,7 +42,7 @@ Before leaving this step, verify every task in the `## Tasks & Acceptance` secti
 
 ### Matrix Test Audit
 
-If `{spec_file}`'s `<frozen-after-approval>` block contains an I/O & Edge-Case Matrix, verify every matrix row is covered by at least one test that verifies its expected behavior, and that each covering test ran and passed in the verification output. A covering test that exists but did not run — unregistered, filtered out, skipped, or disabled — counts as missing. If a test disagrees with the matrix, never edit the expectation to match the code: fix the code, or if the matrix row itself is ambiguous, HALT and ask the human. Fix any other audit failure before proceeding.
+Select the immutable intent boundary by route: `<intent-contract>` when `manifest_story_mode` is true, or `<frozen-after-approval>` in standalone mode. If that selected block contains an I/O & Edge-Case Matrix, verify every matrix row is covered by at least one test that verifies its expected behavior, and that each covering test ran and passed in the verification output. A covering test that exists but did not run — unregistered, filtered out, skipped, or disabled — counts as missing. If a test disagrees with the matrix, never edit the expectation to match the code: fix the code, or if the matrix row itself is ambiguous, HALT and ask the human. Fix any other audit failure before proceeding.
 
 ## NEXT
 

--- a/src/bmm-skills/ship/bmad-build/step-04-review.md
+++ b/src/bmm-skills/ship/bmad-build/step-04-review.md
@@ -12,7 +12,7 @@ Change `{spec_file}` status to `in-review` in the frontmatter before continuing.
 
 ### Construct Diff
 
-Read `{baseline_commit}` from `{spec_file}` frontmatter. If `{baseline_commit}` is missing or `NO_VCS`, use best effort to determine what changed. Otherwise, construct `{diff_output}` covering all changes — tracked and untracked — since `{baseline_commit}`.
+When `manifest_story_mode` is true, read `{baseline_revision}` from `{spec_file}` frontmatter; otherwise read `{baseline_commit}`. If the selected field is missing or `NO_VCS`, use best effort to determine what changed. Otherwise, construct `{diff_output}` covering all changes — tracked and untracked — since the selected revision.
 
 Do NOT `git add` anything — this is read-only inspection.
 
@@ -39,16 +39,23 @@ If a layer's instruction requires subagents and none are available, for each suc
    - **defer** — pre-existing issue not caused by this story, surfaced incidentally by the review. Collect for later focused attention.
    - **reject** — noise. Drop silently. When unsure between defer and reject, prefer reject — only defer findings you are confident are real.
 4. Process findings in cascading order. If intent_gap or bad_spec findings exist, they trigger a loopback — lower findings are moot since code will be re-derived. If neither exists, process patch and defer normally. Before each loopback, read `{spec_file}` frontmatter `review_loop_iteration` (missing means `0`), increment it by 1, and write it back. If it exceeds 5, HALT and escalate to the human.
-   - **intent_gap** — Root cause is inside `<frozen-after-approval>`. Revert code changes. Loop back to the human to resolve. Once resolved, read fully and follow `./step-02-plan.md` to re-run steps 2–4.
-   - **bad_spec** — Root cause is outside `<frozen-after-approval>`. Before reverting code: extract KEEP instructions for positive preservation (what worked well and must survive re-derivation). Revert code changes. Read the `## Spec Change Log` in `{spec_file}` and strictly respect all logged constraints when amending the non-frozen sections that contain the root cause. Append a new change-log entry recording: the triggering finding, what was amended, the known-bad state avoided, and the KEEP instructions. Read fully and follow `./step-03-implement.md` to re-derive the code, then this step will run again.
+   - **intent_gap** — Root cause is inside the selected immutable intent boundary: `<intent-contract>` in manifest-story mode or `<frozen-after-approval>` in standalone mode. Revert code changes. Loop back to the human to resolve. Once resolved, set `{spec_file}` status to `draft` before reading and fully following `./step-02-plan.md`; the draft-resume check must preserve the human-edited selected intent boundary while re-running steps 2–4.
+   - **bad_spec** — Root cause is outside the selected immutable intent boundary. Before reverting code: extract KEEP instructions for positive preservation (what worked well and must survive re-derivation). Revert code changes. Read the `## Spec Change Log` in `{spec_file}` and strictly respect all logged constraints when amending the non-frozen sections that contain the root cause. Append a new change-log entry recording: the triggering finding, what was amended, the known-bad state avoided, and the KEEP instructions. Read fully and follow `./step-03-implement.md` to re-derive the code, then this step will run again.
    - **patch** — Auto-fix. These are the only findings that survive loopbacks. If the step-03 implementation subagent can be re-engaged with its context intact, send it all patch findings in one synchronous message — for each: the file, what is wrong, and what the fix must do. If it cannot be re-engaged, apply the patches yourself. Then re-run the checks in `{spec_file}`'s `## Verification` section, if present; if verification fails and the failure cannot be fixed, HALT and escalate to the human.
-   - **defer** — Append one new entry to `{{.deferred_work_file}}` using this format. Do not modify existing entries or look for duplicates.
+   - **defer** — In standalone mode, append one new entry to `{{.deferred_work_file}}` using the format below. Do not modify existing entries or look for duplicates.
      ```markdown
      - source_spec: `{spec_file}`
        summary: <one sentence>
        evidence: <why this is real>
      ```
+     In manifest-story mode, preserve Build Auto interoperability instead: update the single `deferred` list in `{spec_file}` frontmatter. Initialize an absent field once, preserve all existing items, never add a second `deferred:` key, and append each finding with `summary`, `evidence`, and optional `location` and `severity`. Serialize free-form values as YAML block scalars, then parse the complete frontmatter as YAML and verify `deferred` is one list containing every prior and new item with its intended text.
    - **reject** — Drop silently.
+
+### Manifest-story review record
+
+When `manifest_story_mode` is true, append an entry to `## Review Triage Log` on every review pass before that pass completes, loops back, or halts. Record the current date; counts for `intent_gap`, `bad_spec`, `patch`, `defer`, and `reject` with high/medium/low breakdowns where nonzero; and each addressed `patch` or `bad_spec` finding with severity and action. Record `addressed_findings: none` when neither category was addressed. Keep the log append-only.
+
+For a manifest story that is proceeding to step 5, set frontmatter `followup_review_recommended` using Build Auto's patched-finding formula for this pass only: `true` if any patched finding was high severity, or if `3 × medium patches + low patches` is at least 5; otherwise `false`. Deferred and rejected findings never contribute.
 
 ## NEXT
 

--- a/src/bmm-skills/ship/bmad-build/step-05-present.md
+++ b/src/bmm-skills/ship/bmad-build/step-05-present.md
@@ -12,9 +12,9 @@
 
 ### Generate Suggested Review Order
 
-Read `{baseline_commit}` from `{spec_file}` frontmatter and construct the diff of all changes since that commit.
+Read `{baseline_revision}` from `{spec_file}` frontmatter in manifest-story mode or `{baseline_commit}` in standalone mode. If the selected baseline exists and resolves to a reachable version-control revision, construct the diff of all changes since it. If it is missing, `NO_VCS`, invalid, or unreachable, use best effort to construct the current reviewed diff instead. Do not rewrite either baseline field during this fallback.
 
-Append the review order as a `## Suggested Review Order` section to `{spec_file}` **after the last existing section**. Do not modify the Code Map.
+Write the review order as a `## Suggested Review Order` section in `{spec_file}`. Normally append it **after the last existing section**. If this run entered review from a `done` spec for a fresh review pass and a Suggested Review Order already exists, replace the existing section with the newly generated section instead of appending a duplicate. Do not modify the Code Map.
 
 Build the trail as an ordered sequence of **stops** — clickable `path:line` references with brief framing — optimized for a human reviewer reading top-down to understand the change:
 
@@ -50,13 +50,20 @@ When there is only one concern, omit the bold label — just list the stops dire
 
 ### Mark Spec Done
 
-Change `{spec_file}` status to `done` in the frontmatter.
-
-Follow `./sync-sprint-status.md` with `target_status` = `review`.
+In standalone mode, change `{spec_file}` status to `done` in the frontmatter now, then follow `./sync-sprint-status.md` with `target_status` = `review`. In manifest-story mode, defer the `done` transition and sprint-status sync until `final_revision` is captured below.
 
 ### Commit and Complete
 
-If version control is available and the tree is dirty, create a local commit with a conventional message derived from the spec title.
+**Manifest-story mode:** use Build Auto-compatible revision finalization.
+
+- If version control is unavailable, write `final_revision: NO_VCS` and `status: done` to `{spec_file}`.
+- If version control is available, commit the reviewed implementation changes that remain uncommitted with a conventional message derived from the spec title, keeping the tracked story spec itself for the spec-finalization commit. Obtain the current full canonical revision directly from version control and preserve it verbatim as `final_revision`; then write that field and `status: done` into `{spec_file}`.
+- After either path writes `status: done`, follow `./sync-sprint-status.md` with `target_status` = `review`.
+- If version control is available and `{spec_file}` is tracked in this working copy, commit only `{spec_file}` as a spec-finalization commit and keep `final_revision` unchanged. Verify every reviewed implementation file appears after `baseline_revision` and the working copy is clean. HALT explicitly if finalization leaves it dirty.
+
+Never add `final_commit` or `baseline_commit` fields to a manifest story.
+
+**Standalone mode:** if version control is available and the tree is dirty, create a local commit with a conventional message derived from the spec title. Preserve the existing standalone frontmatter and commit behavior.
 
 {workflow.open_spec}
 

--- a/src/bmm-skills/ship/bmad-build/story-spec-template.md
+++ b/src/bmm-skills/ship/bmad-build/story-spec-template.md
@@ -1,0 +1,99 @@
+---
+title: '{title}'
+type: 'feature' # feature | bugfix | refactor | chore
+created: '{date}'
+status: 'draft' # draft | ready-for-dev | in-progress | in-review | done | blocked
+review_loop_iteration: 0 # incremented by step-04 before each review loopback
+followup_review_recommended: false # set by step-04 on status: done — true if the LLM decided another review pass is worthwhile
+context: [] # optional: `{project-root}/`-prefixed paths to project-wide standards/docs the implementation agent should load. Keep short — only what isn't already distilled into the spec body.
+warnings: [] # optional: machine-readable warnings for orchestration, e.g. oversized, multiple-goals
+deferred: [] # append-only machine-readable deferred review findings; each item carries summary/evidence and optional location/severity
+---
+
+<!-- Aim for 900–1600 tokens. If larger, add `oversized` to frontmatter `warnings` and continue.
+     Never over-specify "how" — use boundaries + examples instead.
+     Cohesive cross-layer stories (DB+BE+UI) stay in ONE file.
+     IMPORTANT: Remove all HTML comments when filling this template. -->
+
+<intent-contract>
+
+## Intent
+
+<!-- What is broken or missing, and why it matters. Then the high-level approach — the "what", not the "how". -->
+
+**Problem:** ONE_TO_TWO_SENTENCES
+
+**Approach:** ONE_TO_TWO_SENTENCES
+
+## Boundaries & Constraints
+
+<!-- Three tiers: Always = invariant rules. Block If = decisions that cannot be made unattended. Never = out of scope + forbidden approaches. -->
+
+**Always:** INVARIANT_RULES
+
+**Block If:** DECISIONS_REQUIRING_HUMAN_INPUT
+<!-- Agent: if any of these trigger during execution, HALT with status blocked and the blocking condition. -->
+
+**Never:** NON_GOALS_AND_FORBIDDEN_APPROACHES
+
+## I/O & Edge-Case Matrix
+
+<!-- If no meaningful I/O scenarios exist, DELETE THIS ENTIRE SECTION. Do not write "N/A" or "None". -->
+
+| Scenario | Input / State | Expected Output / Behavior | Error Handling |
+|----------|--------------|---------------------------|----------------|
+| HAPPY_PATH | INPUT | OUTCOME | No error expected |
+| ERROR_CASE | INPUT | OUTCOME | ERROR_HANDLING |
+
+</intent-contract>
+
+## Code Map
+
+<!-- Agent-populated during planning. Annotated paths prevent blind codebase searching. -->
+
+- `FILE` -- ROLE_OR_RELEVANCE
+- `FILE` -- ROLE_OR_RELEVANCE
+
+## Tasks & Acceptance
+
+<!-- Tasks: backtick-quoted file path -- action -- rationale. Prefer one task per file; group tightly-coupled changes when splitting would be artificial. -->
+<!-- If an I/O Matrix is present, include a task to unit-test its edge cases. -->
+<!-- AC covers system-level behaviors not captured by the I/O Matrix. Do not duplicate I/O scenarios here. -->
+
+**Execution:**
+- `FILE` -- ACTION -- RATIONALE
+
+**Acceptance Criteria:**
+- Given PRECONDITION, when ACTION, then EXPECTED_RESULT
+
+## Spec Change Log
+
+<!-- Append-only. Populated by step-04 during review loops. Do not modify or delete existing entries.
+     Each entry records: what finding triggered the change, what was amended, what known-bad state
+     the amendment avoids, and any KEEP instructions (what worked well and must survive re-derivation).
+     Empty until the first bad_spec loopback. -->
+
+## Review Triage Log
+
+<!-- Append-only. Populated by step-04 on EVERY review pass, including loopbacks and blocked exits.
+     Each entry records triage decision counts for intent_gap, bad_spec, patch, defer, and reject,
+     with per-category severity breakdowns using low/medium/high, plus the findings addressed in
+     that pass. Empty until the first review pass. -->
+
+## Design Notes
+
+<!-- If the approach is straightforward, DELETE THIS ENTIRE SECTION. Do not write "N/A" or "None". -->
+<!-- Design rationale and golden examples only when non-obvious. Keep examples to 5–10 lines. -->
+
+DESIGN_RATIONALE_AND_EXAMPLES
+
+## Verification
+
+<!-- If no build, test, or lint commands apply, DELETE THIS ENTIRE SECTION. Do not write "N/A" or "None". -->
+<!-- How the agent confirms its own work. Prefer CLI commands. When no CLI check applies, state what to inspect manually. -->
+
+**Commands:**
+- `COMMAND` -- expected: SUCCESS_CRITERIA
+
+**Manual checks (if no CLI):**
+- WHAT_TO_INSPECT_AND_EXPECTED_STATE

--- a/test/test-build-renderer.js
+++ b/test/test-build-renderer.js
@@ -63,6 +63,7 @@ function assert(condition, message) {
 // ---------------------------------------------------------------------------
 
 const SKILL_SRC = path.join(__dirname, '..', 'src', 'bmm-skills', 'ship', 'bmad-build');
+const BUILD_AUTO_SRC = path.join(__dirname, '..', 'src', 'bmm-skills', 'ship', 'bmad-build-auto');
 
 /**
  * Recursively copy a directory (stdlib only, no fs.cp to stay >=20 compat).
@@ -213,6 +214,103 @@ try {
       content.includes(expected),
       `sprint_status path not found.\nExpected substring: ${expected}\n` +
         `sync-sprint-status.md excerpt (first 2000 chars):\n${content.slice(0, 2000)}`,
+    );
+  });
+
+  test('manifest story template is mechanically identical to Build Auto and is rendered', () => {
+    const canonicalTemplate = fs.readFileSync(path.join(BUILD_AUTO_SRC, 'spec-template.md'), 'utf-8');
+    assert(readRendered('story-spec-template.md') === canonicalTemplate, 'rendered Build story template drifted from canonical');
+  });
+
+  test('first manifest story run uses the resolved id and title slug beside its epic', () => {
+    const content = readRendered('step-01-clarify-and-route.md');
+    assert(content.includes('manifest_story_mode'), 'explicit manifest-story mode is missing');
+    assert(content.includes('`{spec_folder}/SPEC.md`'), 'sibling SPEC.md requirement is missing');
+    assert(content.includes('`{spec_folder}/stories.yaml`'), 'stories.yaml parsing requirement is missing');
+    assert(content.includes('`{spec_folder}/stories/{story_id}-{slug}.md`'), 'first-create id/title-slug placement is missing');
+    assert(content.includes('never prefix the filename with `spec-`'), 'manifest filenames may acquire a spec- prefix');
+    assert(content.includes('never append `-2`/`-3`'), 'manifest story collision suffixes are not forbidden');
+    assert(content.includes('HALT explicitly for `empty story slug`'), 'empty manifest story slugs do not halt');
+  });
+
+  test('manifest story resume uses exact id-prefix matching and complete status routing', () => {
+    const content = readRendered('step-01-clarify-and-route.md');
+    assert(
+      content.includes('Match existing files using exactly `{spec_folder}/stories/{story_id}-*.md`'),
+      'exact story id-prefix resume match is missing',
+    );
+    for (const status of ['`draft`', '`ready-for-dev`', '`in-progress`', '`in-review`', '`blocked`', '`done`']) {
+      assert(content.includes(status), `manifest story route omits recognized status ${status}`);
+    }
+    assert(content.includes('ambiguous story file match'), 'ambiguous id matches do not halt explicitly');
+    assert(content.includes('unrecognized status in existing story file'), 'unrecognized statuses do not halt explicitly');
+    assert(content.includes('story already blocked'), 'blocked stories do not halt explicitly');
+    assert(content.includes('fresh review pass'), 'done stories do not start a fresh review pass');
+    assert(
+      content.includes('Before any non-HALT route, run **Story-key resolution**'),
+      'resumed manifest stories skip sprint story-key resolution',
+    );
+    assert(
+      content.includes('Run **Story-key resolution** below now that `spec_file` is set.'),
+      'new manifest stories skip sprint story-key resolution',
+    );
+  });
+
+  test('malformed manifest attempts halt without a global fallback', () => {
+    const content = readRendered('step-01-clarify-and-route.md');
+    assert(content.includes('Missing, unparseable, or malformed manifest data'), 'malformed manifest handling is missing');
+    assert(
+      content.includes('Never fall back to a global spec after this branch has identified a candidate folder'),
+      'manifest failure may silently fall back globally',
+    );
+    assert(content.includes('`id` is a non-empty string containing only ASCII letters, digits, and dashes'), 'id validation is incomplete');
+    assert(content.includes('`title` is a non-empty one-line string with no CR or LF'), 'one-line title validation is missing');
+    assert(
+      content.includes("any explicit existing path under a candidate epic's `stories/` directory"),
+      'story paths do not force manifest validation',
+    );
+    assert(content.includes("regardless of the file's frontmatter title"), 'story path identity still depends on frontmatter title');
+    assert(content.includes('HALT for unresolved manifest identity'), 'unresolved story path identity may fall through');
+    assert(
+      content.includes('Zero or multiple resolved entries by any method is an explicit HALT'),
+      'non-unique story identity does not halt',
+    );
+  });
+
+  test('standalone placement and collision behavior remain available unchanged', () => {
+    const content = readRendered('step-01-clarify-and-route.md');
+    assert(content.includes('/impl/spec-{slug}.md` already exists: if its status is `draft`'), 'standalone draft-resume route changed');
+    assert(content.includes('otherwise append `-2`, `-3`, etc.'), 'standalone collision suffix behavior changed');
+    assert(content.includes('/impl/spec-{slug}.md`.'), 'standalone global placement changed');
+  });
+
+  test('manifest story mode carries Build Auto fields through every downstream step', () => {
+    const plan = readRendered('step-02-plan.md');
+    const implement = readRendered('step-03-implement.md');
+    const review = readRendered('step-04-review.md');
+    const present = readRendered('step-05-present.md');
+    assert(plan.includes('`./story-spec-template.md`'), 'planning does not select the story template');
+    assert(plan.includes('<intent-contract>'), 'planning does not preserve the story intent contract');
+    assert(implement.includes('`baseline_revision`'), 'implementation does not write the story baseline revision');
+    assert(implement.includes('<intent-contract>'), 'implementation does not protect the story intent contract');
+    assert(
+      implement.includes('Select the immutable intent boundary by route: `<intent-contract>` when `manifest_story_mode` is true'),
+      'matrix test audit does not select the manifest story intent contract',
+    );
+    assert(implement.includes('`<frozen-after-approval>` in standalone mode'), 'matrix test audit omits the standalone boundary');
+    assert(review.includes('`{baseline_revision}`'), 'review does not consume the story baseline revision');
+    assert(review.includes('## Review Triage Log'), 'review does not maintain the story triage log');
+    assert(review.includes('`followup_review_recommended`'), 'review does not finalize follow-up review metadata');
+    assert(
+      review.includes('set `{spec_file}` status to `draft` before reading and fully following `./step-02-plan.md`'),
+      'intent-gap loopback does not restore draft status before planning',
+    );
+    assert(present.includes('`final_revision`'), 'presentation does not finalize the story revision');
+    assert(present.includes('`status: done`'), 'presentation does not finalize the story status');
+    assert(present.includes('missing, `NO_VCS`, invalid, or unreachable'), 'presentation lacks invalid-baseline fallback');
+    assert(
+      present.includes('replace the existing section with the newly generated section instead of appending a duplicate'),
+      'fresh done review may append a duplicate Suggested Review Order',
     );
   });
 


### PR DESCRIPTION
## What

Teach `bmad-build` to recognize stories backed by an epic's `stories.yaml` and create or resume their specs under `<epic-folder>/stories/<story-id>-<slug>.md`.

## Why

Manifest-backed stories currently fall through to the global implementation-artifacts directory, splitting one story's state across incompatible locations and conventions.

## How

- Resolve and validate manifest story identity before standalone intent routing.
- Reuse Build Auto's story template, status routing, and revision/frontmatter conventions.
- Preserve the existing standalone `spec-<slug>.md` route and add deterministic renderer coverage.

## Testing

Ran `HUSKY=0 npm ci && npm run quality` successfully after rebasing onto `origin/main`.
