### PR TITLE
fix(review): stop verification-gap from demanding source-text tests

### DIFF
--- a/src/bmm-skills/ship/bmad-build-auto/review-prompts/verification-gap.md
+++ b/src/bmm-skills/ship/bmad-build-auto/review-prompts/verification-gap.md
@@ -24,6 +24,8 @@ If the change is non-behavioral, stop here and output the clean result (see Outp
 
 Common non-behavioral examples: formatting, comments, whitespace; pure renames; trivial getters/setters and pass-throughs; type-only or compiler-enforced changes with no runtime effect; etc.
 
+Screen each part of the change separately. Only outcomes produced by deterministic code are worth automatically testing; tests are useless on static source text and brittle on LLM output. Skip those parts and review the rest normally.
+
 ### Step 2: Find the behavior that changed
 
 Identify what behavior changed compared to the previous version: output, side effect, branch, error path, schema/event shape, config default, validation/authorization rule, external contract, etc. If the change affects more than one behavior, handle each separately.
@@ -48,7 +50,7 @@ Find and read the relevant test. Ask whether the Demonstration would make an ass
 - For a regression-style Demonstration: if no test runs the path, the test is skipped/flaky/not run normally, or the test runs the code without checking the changed result, report a `Regression gap` or `Broken-verification gap`.
 - For a qualifying Missing-adoption case: if none of the site tests you found assert it adopts the new behavior, report a `Missing-adoption gap`.
 
-A test counts only if it runs normally and an assertion observes the changed output, branch, or contract. These do not count: no execution; success/no-throw/snapshot-only checks; mock/log-call checks; human-only checks; tests that mock away the integration; e2e tests that pass through without checking the changed output; stale assertions or fixtures.
+A test counts only if it runs normally and an assertion observes the changed output, branch, or contract. These do not count: no execution; source-text assertions that match a file's wording instead of running it; success/no-throw/snapshot-only checks; mock/log-call checks; human-only checks; tests that mock away the integration; e2e tests that pass through without checking the changed output; stale assertions or fixtures.
 
 Common patterns:
 
@@ -57,7 +59,7 @@ Common patterns:
 - **Migration compatibility** — tests only create new-format rows or fresh schemas.
 - **Phantom exception** — handled partial-failure path has no test.
 - **Missing-adoption gap** — sibling site should use the new rule/helper and does not.
-- **Removed verification** — deleted test or weakened assertion leaves behavior unpinned.
+- **Removed verification** — deleted test or weakened assertion leaves behavior unpinned; removing a source-text assertion is not this, since it never counted.
 
 ### Step 5: Confirm each finding is real
 

--- a/src/bmm-skills/ship/bmad-build/review-prompts/verification-gap.md
+++ b/src/bmm-skills/ship/bmad-build/review-prompts/verification-gap.md
@@ -24,6 +24,8 @@ If the change is non-behavioral, stop here and output the clean result (see Outp
 
 Common non-behavioral examples: formatting, comments, whitespace; pure renames; trivial getters/setters and pass-throughs; type-only or compiler-enforced changes with no runtime effect; etc.
 
+Screen each part of the change separately. Only outcomes produced by deterministic code are worth automatically testing; tests are useless on static source text and brittle on LLM output. Skip those parts and review the rest normally.
+
 ### Step 2: Find the behavior that changed
 
 Identify what behavior changed compared to the previous version: output, side effect, branch, error path, schema/event shape, config default, validation/authorization rule, external contract, etc. If the change affects more than one behavior, handle each separately.
@@ -48,7 +50,7 @@ Find and read the relevant test. Ask whether the Demonstration would make an ass
 - For a regression-style Demonstration: if no test runs the path, the test is skipped/flaky/not run normally, or the test runs the code without checking the changed result, report a `Regression gap` or `Broken-verification gap`.
 - For a qualifying Missing-adoption case: if none of the site tests you found assert it adopts the new behavior, report a `Missing-adoption gap`.
 
-A test counts only if it runs normally and an assertion observes the changed output, branch, or contract. These do not count: no execution; success/no-throw/snapshot-only checks; mock/log-call checks; human-only checks; tests that mock away the integration; e2e tests that pass through without checking the changed output; stale assertions or fixtures.
+A test counts only if it runs normally and an assertion observes the changed output, branch, or contract. These do not count: no execution; source-text assertions that match a file's wording instead of running it; success/no-throw/snapshot-only checks; mock/log-call checks; human-only checks; tests that mock away the integration; e2e tests that pass through without checking the changed output; stale assertions or fixtures.
 
 Common patterns:
 
@@ -57,7 +59,7 @@ Common patterns:
 - **Migration compatibility** — tests only create new-format rows or fresh schemas.
 - **Phantom exception** — handled partial-failure path has no test.
 - **Missing-adoption gap** — sibling site should use the new rule/helper and does not.
-- **Removed verification** — deleted test or weakened assertion leaves behavior unpinned.
+- **Removed verification** — deleted test or weakened assertion leaves behavior unpinned; removing a source-text assertion is not this, since it never counted.
 
 ### Step 5: Confirm each finding is real
 

--- a/src/bmm-skills/ship/bmad-code-review/review-prompts/verification-gap.md
+++ b/src/bmm-skills/ship/bmad-code-review/review-prompts/verification-gap.md
@@ -24,6 +24,8 @@ If the change is non-behavioral, stop here and output the clean result (see Outp
 
 Common non-behavioral examples: formatting, comments, whitespace; pure renames; trivial getters/setters and pass-throughs; type-only or compiler-enforced changes with no runtime effect; etc.
 
+Screen each part of the change separately. Only outcomes produced by deterministic code are worth automatically testing; tests are useless on static source text and brittle on LLM output. Skip those parts and review the rest normally.
+
 ### Step 2: Find the behavior that changed
 
 Identify what behavior changed compared to the previous version: output, side effect, branch, error path, schema/event shape, config default, validation/authorization rule, external contract, etc. If the change affects more than one behavior, handle each separately.
@@ -48,7 +50,7 @@ Find and read the relevant test. Ask whether the Demonstration would make an ass
 - For a regression-style Demonstration: if no test runs the path, the test is skipped/flaky/not run normally, or the test runs the code without checking the changed result, report a `Regression gap` or `Broken-verification gap`.
 - For a qualifying Missing-adoption case: if none of the site tests you found assert it adopts the new behavior, report a `Missing-adoption gap`.
 
-A test counts only if it runs normally and an assertion observes the changed output, branch, or contract. These do not count: no execution; success/no-throw/snapshot-only checks; mock/log-call checks; human-only checks; tests that mock away the integration; e2e tests that pass through without checking the changed output; stale assertions or fixtures.
+A test counts only if it runs normally and an assertion observes the changed output, branch, or contract. These do not count: no execution; source-text assertions that match a file's wording instead of running it; success/no-throw/snapshot-only checks; mock/log-call checks; human-only checks; tests that mock away the integration; e2e tests that pass through without checking the changed output; stale assertions or fixtures.
 
 Common patterns:
 
@@ -57,7 +59,7 @@ Common patterns:
 - **Migration compatibility** — tests only create new-format rows or fresh schemas.
 - **Phantom exception** — handled partial-failure path has no test.
 - **Missing-adoption gap** — sibling site should use the new rule/helper and does not.
-- **Removed verification** — deleted test or weakened assertion leaves behavior unpinned.
+- **Removed verification** — deleted test or weakened assertion leaves behavior unpinned; removing a source-text assertion is not this, since it never counted.
 
 ### Step 5: Confirm each finding is real
 


### PR DESCRIPTION
## What

Three edits to `review-prompts/verification-gap.md`, applied identically to all three byte-identical copies (`bmad-build`, `bmad-build-auto`, `bmad-code-review`): source-text assertions are listed among the checks that do not count as verification, removing one is exempted from the `Removed verification` finding category, and Step 1 now screens each part of a change separately so parts with no deterministic outcome are skipped.

## Why

The prompt reliably pushed implementers to write tests that grep source files for strings — tests that pin wording, break on rewording, and verify nothing.

The reviewer was right to treat a prompt as the executable artifact; editing it does change behavior. The mistake was what followed: having classified it as code, the reviewer reached the "a test counts only if an assertion observes the changed output" rule and demanded an assertion, and the only assertion reachable against prose is a match on the file's own wording. `Removed verification` then flagged deleting such a test as a regression, making it self-reinforcing. Documentation was never affected — the failure was specific to prompts.

The Step 1 screen is per-part rather than whole-change, so a diff touching both a prompt and a script still reports gaps for the script.

## Evidence

A/B run of 16 context-free reviewer subagents — 4 scenarios x 2 arms x 2 replicates — dispatched exactly as `customize.toml` dispatches this layer, against real fixture repos. Arm A was this file at `main`, arm B the version in this PR.

| Scenario | Diff | `main` | This PR |
|---|---|---|---|
| Prompt only | skill step `.md` | gap reported 2/2 | 0/2 |
| README only | docs | 0/2 | 0/2 |
| Prompt **+** Python, real code gap | mixed | code gap 2/2, prompt gap 2/2 | code gap 2/2, prompt gap 0/2 |
| Python only, real gap | code | gap 2/2 | gap 2/2 |

Every genuine code finding survived; the prompt-derived findings stopped. Prompt defects still surface under `Other findings`, so the reviewer is not blinded to them — it just stops classifying them as gaps requiring a test.

Cost went down rather than up: 274,472 vs 287,900 output tokens across the 8 runs per arm (-4.7%), because the Step 1 screen ends prose tracing before Steps 2-4. The added instruction surface is +380 chars (+4.4% words).

## Testing

No automated test. The change is prompt prose, and asserting on it is the exact thing this PR prohibits. Verified by `npm run quality` (exit 0, clean tree) plus the A/B run above.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
