### PR TITLE
refactor(review): sequence verification-gap Step 1 per part

### DIFF
--- a/src/bmm-skills/ship/bmad-build-auto/review-prompts/verification-gap.md
+++ b/src/bmm-skills/ship/bmad-build-auto/review-prompts/verification-gap.md
@@ -20,11 +20,13 @@ The main verification gap shapes are:
 
 ### Step 1: Screen for behavioral change
 
-If the change is non-behavioral, stop here and output the clean result (see Output Format). Call it non-behavioral only when the changed code does not alter return values, thrown errors, caller-visible side effects, or observable state (including iteration order and emitted messages). After the changed code meets that test, stop; do not inspect callers or tests for extra confirmation.
+Screen each part of the change separately. If a part is non-behavioral, skip it. Call a part non-behavioral only when the changed code does not alter return values, thrown errors, caller-visible side effects, or observable state (including iteration order and emitted messages). Once a part meets that test, move on; do not inspect callers or tests for extra confirmation.
 
 Common non-behavioral examples: formatting, comments, whitespace; pure renames; trivial getters/setters and pass-throughs; type-only or compiler-enforced changes with no runtime effect; etc.
 
-Screen each part of the change separately. Only outcomes produced by deterministic code are worth automatically testing; tests are useless on static source text and brittle on LLM output. Skip those parts and review the rest normally.
+Only outcomes produced by deterministic code are worth automatically testing; tests are useless on static source text and brittle on LLM output. Skip those parts.
+
+If every part is skipped, output the clean result (see Output Format).
 
 ### Step 2: Find the behavior that changed
 

--- a/src/bmm-skills/ship/bmad-build/review-prompts/verification-gap.md
+++ b/src/bmm-skills/ship/bmad-build/review-prompts/verification-gap.md
@@ -20,11 +20,13 @@ The main verification gap shapes are:
 
 ### Step 1: Screen for behavioral change
 
-If the change is non-behavioral, stop here and output the clean result (see Output Format). Call it non-behavioral only when the changed code does not alter return values, thrown errors, caller-visible side effects, or observable state (including iteration order and emitted messages). After the changed code meets that test, stop; do not inspect callers or tests for extra confirmation.
+Screen each part of the change separately. If a part is non-behavioral, skip it. Call a part non-behavioral only when the changed code does not alter return values, thrown errors, caller-visible side effects, or observable state (including iteration order and emitted messages). Once a part meets that test, move on; do not inspect callers or tests for extra confirmation.
 
 Common non-behavioral examples: formatting, comments, whitespace; pure renames; trivial getters/setters and pass-throughs; type-only or compiler-enforced changes with no runtime effect; etc.
 
-Screen each part of the change separately. Only outcomes produced by deterministic code are worth automatically testing; tests are useless on static source text and brittle on LLM output. Skip those parts and review the rest normally.
+Only outcomes produced by deterministic code are worth automatically testing; tests are useless on static source text and brittle on LLM output. Skip those parts.
+
+If every part is skipped, output the clean result (see Output Format).
 
 ### Step 2: Find the behavior that changed
 

--- a/src/bmm-skills/ship/bmad-code-review/review-prompts/verification-gap.md
+++ b/src/bmm-skills/ship/bmad-code-review/review-prompts/verification-gap.md
@@ -20,11 +20,13 @@ The main verification gap shapes are:
 
 ### Step 1: Screen for behavioral change
 
-If the change is non-behavioral, stop here and output the clean result (see Output Format). Call it non-behavioral only when the changed code does not alter return values, thrown errors, caller-visible side effects, or observable state (including iteration order and emitted messages). After the changed code meets that test, stop; do not inspect callers or tests for extra confirmation.
+Screen each part of the change separately. If a part is non-behavioral, skip it. Call a part non-behavioral only when the changed code does not alter return values, thrown errors, caller-visible side effects, or observable state (including iteration order and emitted messages). Once a part meets that test, move on; do not inspect callers or tests for extra confirmation.
 
 Common non-behavioral examples: formatting, comments, whitespace; pure renames; trivial getters/setters and pass-throughs; type-only or compiler-enforced changes with no runtime effect; etc.
 
-Screen each part of the change separately. Only outcomes produced by deterministic code are worth automatically testing; tests are useless on static source text and brittle on LLM output. Skip those parts and review the rest normally.
+Only outcomes produced by deterministic code are worth automatically testing; tests are useless on static source text and brittle on LLM output. Skip those parts.
+
+If every part is skipped, output the clean result (see Output Format).
 
 ### Step 2: Find the behavior that changed
 


### PR DESCRIPTION
## What

Reorders Step 1 of `review-prompts/verification-gap.md` so it reads in the order it is executed: screen each part separately, skip non-behavioral parts, skip parts with no deterministic outcome, then output the clean result if every part was skipped. The wording of the individual rules is unchanged, as are the non-behavioral examples. Applied identically to all three copies (`bmad-build`, `bmad-build-auto`, `bmad-code-review`).

## Why

Step 1 opened with a whole-change stop — "If the change is non-behavioral, stop here and output the clean result" — and then, three paragraphs later, told the reviewer to screen each part separately. The two framings contradicted each other, and the clean-result instruction sat before the second skip rule had even been introduced. Follow-up to #2662, which introduced the per-part sentence without reconciling it with the opening line.

## Evidence

**This is a clarity change, not a behavior fix, and the eval says so.**

12 context-free reviewer subagents — 4 diff shapes, dispatched exactly as `customize.toml` dispatches this layer, against real fixture repos. Arm M was `main`, arm N this branch.

| Scenario | Diff shape | `main` | This PR |
|---|---|---|---|
| Non-behavioral code first, then behavioral code with a real gap | mixed code | gap found 2/2, no early stop | gap found 2/2 |
| Prompt + Python, real gap | mixed | code gap 2/2, prompt gap 0/2 | code gap 2/2, prompt gap 0/2 |
| Prose only | prose | clean 1/1 | clean 1/1 |
| Code only, real gap | code | gap found 1/1 | gap found 1/1 |

No difference in either direction. The first scenario was built specifically to trigger early termination — a docstring/comment/local-rename change leading the diff (verified non-behavioral: the suite passes unchanged), followed by a config-precedence flip with a genuine gap. On `main`, both runs skipped the non-behavioral part and found the gap anyway. Reviewers were already screening per part regardless of the opening sentence.

Cost is a wash: 221,024 vs 216,064 output tokens across 6 runs per arm (+2.3%), inside the per-cell spread.

The case for merging is therefore readability, plus one thing the eval cannot speak to: every run was a single model tier, and this prompt executes across many. A latent contradiction between "stop here" and "screen each part" is the kind of thing a weaker model resolves badly, and the fix costs nothing measurable.

## Testing

No automated test. The change is prompt prose, and asserting on it is the exact thing #2662 prohibited. Verified by `npm run quality` (exit 0, clean tree) plus the A/B above.
