### PR TITLE
feat: support spec-folder epics in bmad-retrospective

### DIFF
--- a/docs/explanation/retrospective.md
+++ b/docs/explanation/retrospective.md
@@ -5,7 +5,7 @@ sidebar:
   order: 15
 ---
 
-Run `bmad-retrospective` when an epic is done. It reads what the epic actually produced (the specs, the full diff, the per-story commits, the sprint status) and works from that evidence rather than anyone's recollection of how the work went. What comes back is a written review, a set of owned action items, and a verdict on whether the epic met its bar.
+Run `bmad-retrospective` at the end of an epic. It reads what the epic actually produced (the specs, the full diff, the per-story commits, the sprint status) and works from that evidence rather than anyone's recollection of how the work went. What comes back is a written review, a set of owned action items, and a verdict on whether the epic met its bar.
 
 ## What it does
 
@@ -18,9 +18,9 @@ An epic ships as a stack of stories, each built and reviewed on its own. The ret
 
 Every finding carries a source reference: a file, a line, a commit, a log. A claim it can't point at doesn't make the report.
 
-## Why run it after an epic
+## Why the whole epic needs its own review
 
-Each story passed its own review in isolation, so the bugs that survive to this point are the ones isolation hides. Nine sessions each add a little to the same file, and none of them ever sees the god class they built together. No session judged the epic as a whole against what it set out to deliver, either. That whole-epic view is the gap this closes, and the end of an epic is the moment to close it: the diff is fresh and the session logs haven't been cleared yet.
+Each story passed its own review in isolation, so the bugs that survive to this point are the ones isolation hides. Nine sessions each add a little to the same file, and none of them ever sees how large it has grown between them. No session judged the epic as a whole against what it set out to deliver, either. That whole-epic view is the gap this closes, and the end of an epic is the moment to close it: the diff is fresh and the session logs haven't been cleared yet.
 
 :::note[It reads evidence, it doesn't invent it]
 The retrospective reports what the diff, the commits, and the specs actually show. It won't manufacture a root cause or a pattern the code doesn't back up.
@@ -30,8 +30,8 @@ The retrospective reports what the diff, the commits, and the specs actually sho
 
 Two artifacts and a decision:
 
-- **A retrospective document** in your implementation artifacts — the evidence inventory, findings grouped with their sources, the verdict, and the action items.
-- **An updated sprint status** — the epic's retrospective marked done, each action item appended with a stable id and a link back to its finding.
+- **A retrospective document** stored next to the epic it reviews — the evidence inventory, findings grouped with their sources, the verdict, and the action items.
+- **An updated sprint status** — the epic's retrospective marked done, each action item appended with a stable id and a link back to its finding. Epics that aren't tracked in sprint status keep their action items in the document.
 - **A verdict** of `accepted`, `accepted-with-open-items`, or `rejected`, which tells you whether to start the next epic or hold and fix first. Unfinished stories for that epic make the machine verdict **rejected** (a human can still override interactively).
 
 ## What to do with the output
@@ -46,11 +46,11 @@ A failing epic never closes as quietly accepted. If the criteria aren't met, or 
 
 ## Running it
 
-Say "run a retrospective" or "let's retro epic 3." It finds the completed epic from sprint status, or takes the one you name, and by default stops at the written report and verdict.
+Say "run a retrospective" or "let's retro epic 3." Name an epic and it works out that epic's stories and the commits behind them; name nothing and it finds the epic for you. By default it stops at the written report and verdict.
 
 | You want | Do this |
 | --- | --- |
 | A standard review | "run a retrospective" |
-| A specific epic | "retro epic 3" |
+| A specific epic | "retro epic 3", or name its folder: "retro `_bmad-output/specs/epic-rate-limiting`" |
 | The team to talk it over | Ask to "discuss it as a team" — it convenes [party mode](./party-mode.md) over the real findings, off by default |
 | An unattended run for automation | `-H <epic>` — headless, verdict on the evidence alone |

--- a/package.json
+++ b/package.json
@@ -48,7 +48,7 @@
     "test:install": "node test/test-installation-components.js",
     "test:refs": "node test/test-file-refs-csv.js",
     "test:renderer": "uv run --python 3.11 python -m unittest src/scripts/tests/test_config_utils.py src/scripts/tests/test_resolve_config.py src/scripts/tests/test_resolve_customization.py && node test/test-build-renderer.js && node test/test-build-auto-renderer.js",
-    "test:retrospective": "uv run --python 3.11 src/bmm-skills/ship/bmad-retrospective/scripts/tests/test_git_evidence.py && uv run --python 3.11 src/bmm-skills/ship/bmad-retrospective/scripts/tests/test_sprint_status.py",
+    "test:retrospective": "uv run --python 3.11 src/bmm-skills/ship/bmad-retrospective/scripts/tests/test_git_evidence.py && uv run --python 3.11 src/bmm-skills/ship/bmad-retrospective/scripts/tests/test_sprint_status.py && uv run --python 3.11 src/bmm-skills/ship/bmad-retrospective/scripts/tests/test_stories_status.py",
     "test:site-url": "node test/test-site-url.mjs",
     "test:skills": "node test/test-validate-skills.js",
     "test:urls": "node test/test-parse-source-urls.js",

--- a/src/bmm-skills/ship/bmad-retrospective/SKILL.md
+++ b/src/bmm-skills/ship/bmad-retrospective/SKILL.md
@@ -28,7 +28,7 @@ Run these in order before the retrospective begins:
 1. **Resolve the workflow block.** Run `uv run --no-cache {project-root}/_bmad/scripts/resolve_customization.py --skill {skill-root} --key workflow`. If it fails, resolve `{workflow.*}` yourself by reading `{skill-root}/customize.toml`, then `{project-root}/_bmad/custom/{skill-name}.toml`, then `.user.toml` in that order, merging base → team → user (scalars override, keyed arrays-of-tables merge by `code`/`id`, other arrays append).
 2. **Run prepend steps** — execute each entry in `{workflow.activation_steps_prepend}` in order.
 3. **Load persistent facts** — treat every `{workflow.persistent_facts}` entry as standing context. `file:` entries are paths/globs under `{project-root}` whose contents load as facts; all others are literal facts.
-4. **Load config** from `{project-root}/_bmad/bmm/config.yaml`: `project_name`, `user_name`, `communication_language`, `document_output_language`, `user_skill_level`, `planning_artifacts`, `implementation_artifacts`, and `date` (system datetime). Speak all output in `{communication_language}`; write all documents in `{document_output_language}`. Never state time estimates — AI has changed development speed, so hour/day/week predictions are noise.
+4. **Load config** from `{project-root}/_bmad/bmm/config.yaml`: `project_name`, `user_name`, `communication_language`, `document_output_language`, `user_skill_level`, `planning_artifacts`, `implementation_artifacts`, and `date` (system datetime), plus `output_folder` from `{project-root}/_bmad/core/config.yaml` (spec-folder detection searches under it). Speak all output in `{communication_language}`; write all documents in `{document_output_language}`. Never state time estimates — AI has changed development speed, so hour/day/week predictions are noise.
 5. **Greet and orient** (interactive only). Greet `{user_name}`, name the epic you are about to retro, and optionally invite their going-in concerns ("anything you want weighted — a story that felt rushed, a risky interaction between two stories?"). Use any answer to focus the Phase 1–2 analysis; it directs attention but never becomes a finding without a source.
 6. **Run append steps** — execute each entry in `{workflow.activation_steps_append}` in order.
 
@@ -37,10 +37,20 @@ Run these in order before the retrospective begins:
 | Input | Where | Use |
 |-------|-------|-----|
 | epic | invocation argument, or detected from sprint status | which epic to retro |
+| spec folder | invocation argument, or detected under the spec roots | the stories-mode epic: `SPEC.md`, ordered `stories.yaml`, `stories/<id>-*.md` |
 | sprint status | `{implementation_artifacts}/sprint-status.yaml` | epic detection + final status update |
 | architecture / prd | `{planning_artifacts}/*architecture*`, `*prd*` | context for judging as-built vs intended |
 | previous retro (optional) | `{implementation_artifacts}/**/epic-{{prev}}-retro-*.md` | check whether last epic's actions landed |
 | session logs (optional) | conversation/session records for the epic's stories | process lessons; record the gap when absent |
+
+An epic reaches this skill in one of two shapes, and they are peers. **Sprint mode** reads `{implementation_artifacts}/sprint-status.yaml`. **Stories mode** reads a spec folder holding `SPEC.md`, an ordered `stories.yaml`, and `stories/<id>-*.md` artifacts — the shape an unattended run leaves behind. Resolve which one applies before anything else:
+
+- **A folder was named** → stories mode, whether or not sprint status exists. Run `uv run --no-cache {skill-root}/scripts/stories_status.py inspect --folder "<folder>"` and take its ordered `stories` list as the inventory. If it exits non-zero, surface its JSON `error` and stop — never fall back to sprint mode for a folder the user named.
+- **An epic number was named** → sprint mode. If there is no `sprint-status.yaml`, report that the requested sprint epic cannot be resolved and stop; do not substitute a spec folder for it.
+- **Neither, and sprint status exists** → sprint mode.
+- **Neither, and sprint status does not exist** → run `uv run --no-cache {skill-root}/scripts/stories_status.py detect --root "{output_folder}/specs" --root "{planning_artifacts}" --root "{implementation_artifacts}"`. No candidates: ask the user for a folder; headless, stop. Exactly one: inspect it, take stories mode, and record the auto-selection. More than one: show the paths and let the user pick; headless, stop and require an explicit folder. Never choose silently among candidates.
+
+Once stories mode is selected, do not read or write sprint status for the rest of the run. The rest of this section is sprint mode.
 
 Determine the epic and its unfinished-story list from `sprint_status.py detect-epic` whenever `{implementation_artifacts}/sprint-status.yaml` is available:
 
@@ -51,11 +61,15 @@ If the script exits non-zero it emits `{"ok": false, "error": ...}` instead of a
 
 Then check the epic is actually finished before Phase 1. A successful detect carries `pending_stories` — the selected epic's story keys whose status is not `done`, in file order, scoped to that epic alone (an unfinished story in some *other* epic is out of scope for this retrospective). When the list is non-empty, interactively list those stories and ask whether to retro an unfinished epic: if the user declines, stop and report — do not enter Phase 1; if they accept, record the stories they accepted proceeding over in the document's Epic summary. Headless, proceed and record the same list in the Assumptions section — do not invent a confirmation. Either way the list sits in the document, and Phase 4's machine verdict is **rejected** when any story remained unfinished (see `references/acceptance-verdict.md`); a human may override interactively.
 
+Stories mode runs the same gate on the inspector's `pending_stories` — the `stories.yaml` ids whose story artifact frontmatter `status` is not `done`, in list order. Treat it exactly as above, with one difference: a headless stories-mode run records the ordered ids and the forced **rejected** verdict into `RETROSPECTIVE.md`, finalizes it, and stops without entering Phase 1.
+
 ## Working state and resumption
 
 The retrospective document is the working artifact, not only the final output. Once the epic is fixed, create it as a skeleton (`references/retro-document.md` names the sections) and write each phase's result into it as you finish — inventory, then findings with sources, then dispositions and verdict. Continuity is re-reading the file.
 
 If a retrospective document for this epic already exists, load it, reconcile its recorded state against the current evidence — the current evidence wins, since commits may have landed and questions may have been answered since — and resume at the first incomplete phase instead of redoing finished ones.
+
+In stories mode that document is `{spec-folder}/RETROSPECTIVE.md` — a fixed name, so a resumed run is never mistaken for a new retrospective — and its frontmatter `completed_phases` records which phases finished. Sprint mode keeps its dated `{implementation_artifacts}` filename. `references/retro-document.md` carries the validation an existing file must pass before you resume from it.
 
 ## Flow
 
@@ -63,7 +77,7 @@ Run the phases in order. A default run stops at a written evidence report and ve
 
 ### Phase 1 — Gather
 
-Enumerate what the epic actually produced and record what is missing. Load `references/evidence-gathering.md` for the inventory checklist, the `git_evidence.py` pre-pass that derives the diff range and per-story commits, and the missing-evidence rule: each later analysis declares what it needs and records a narrowed scope when the evidence is absent, so a reader can always tell "checked and clean" from "never checked."
+Enumerate what the epic actually produced and record what is missing. Load `references/evidence-gathering.md` for the inventory checklist, the `git_evidence.py` pre-pass that derives the diff range and per-story commits, and the missing-evidence rule: each later analysis declares what it needs and records a narrowed scope when the evidence is absent, so a reader can always tell "checked and clean" from "never checked." The same file carries the stories-mode inventory and its per-story `baseline_revision..final_revision` ranges.
 
 ### Phase 2 — Analyze
 
@@ -86,4 +100,4 @@ Skip by default; never runs headless. When the user asks to "discuss it as a tea
 
 ### Phase 5 — Finalize
 
-Finalize the retrospective document and update sprint status. Load `references/retro-document.md` for the document's sections and the exact `sprint_status.py update` invocation that marks the retro key `done`, appends the action items, and validates the write. Where the Phase 4 follow-through has evidence a *previous* epic's action item landed, offer `--set-action-status` and pass only the transitions the user confirms — the evidence justifies proposing a transition, and only the user's confirmation justifies writing it; a headless run records the transitions it would have proposed and does not pass the flag at all. Then, if `{workflow.on_complete}` is non-empty, follow it as the final instruction.
+Finalize the retrospective document and update sprint status. Load `references/retro-document.md` for the document's sections and the exact `sprint_status.py update` invocation that marks the retro key `done`, appends the action items, and validates the write. Where the Phase 4 follow-through has evidence a *previous* epic's action item landed, offer `--set-action-status` and pass only the transitions the user confirms — the evidence justifies proposing a transition, and only the user's confirmation justifies writing it; a headless run records the transitions it would have proposed and does not pass the flag at all. In stories mode, finalize `{spec-folder}/RETROSPECTIVE.md` and stop there: no `sprint_status.py` call, no sprint-status file created, and no action-item store anywhere else. Then, if `{workflow.on_complete}` is non-empty, follow it as the final instruction.

--- a/src/bmm-skills/ship/bmad-retrospective/references/acceptance-verdict.md
+++ b/src/bmm-skills/ship/bmad-retrospective/references/acceptance-verdict.md
@@ -20,6 +20,8 @@ Compile fix-now findings and process lessons into specific, owned action items. 
 
 ## Previous-retro follow-through
 
+This section is sprint mode only — stories mode has no action-item store to follow through on, and records relevant earlier lessons in prose where the evidence supports them.
+
 When a prior retro exists, check whether the action items it committed to were completed. Read `action_items` in `{implementation_artifacts}/sprint-status.yaml` and, for every entry belonging to an earlier epic that is not already `done`, record one line in the retrospective document's Previous-retro follow-through section:
 
 - **How to address the item** — its `id`, exactly as the file spells it. Legacy entries written before ids existed have none; for those, record the item's `epic` (the integer in the file) plus its exact `action` text, character for character. One or the other is what Phase 5 needs to name the item at all.
@@ -38,13 +40,13 @@ Judge the final state against the epic's declared acceptance criteria. If the ep
 
 ### Unfinished stories
 
-`pending_stories` from `detect-epic` (with or without `--epic`) is authoritative for this epic's story keys. When that list is non-empty:
+`pending_stories` is authoritative for this epic's incomplete work, whichever mode produced it: `detect-epic` (with or without `--epic`) returns sprint-status story keys in file order; `stories_status.py inspect` returns `stories.yaml` ids in list order. When that list is non-empty:
 
 - The **machine** verdict is **rejected**. Name every unfinished story key in the Acceptance verdict section as the evidence. Do not soften this to accepted-with-open-items: unfinished delivery is not an open finding about a finished epic — the epic itself is incomplete.
 - Record the unfinished keys in Epic summary (interactive) or Assumptions (headless) as the Inputs section already requires.
 - Headless runs have no human at the console: the document's verdict is **rejected** when `pending_stories` was non-empty. Interactive runs may still let a human override (rule 1 below) after seeing the list.
 
-If the completeness check did not run (no readable `sprint-status.yaml`), do **not** render a rejected or accepted verdict from the absence of data — say the check was unavailable and weigh only the criteria and findings you have.
+If the completeness check did not run (no readable `sprint-status.yaml`), do **not** render a rejected or accepted verdict from the absence of data — say the check was unavailable and weigh only the criteria and findings you have. Stories mode cannot reach that state: `inspect` either returns a complete ordered list or fails, and a failure stops the run before Phase 1. Never read an unreadable source as an empty pending list.
 
 Three hard rules:
 

--- a/src/bmm-skills/ship/bmad-retrospective/references/evidence-gathering.md
+++ b/src/bmm-skills/ship/bmad-retrospective/references/evidence-gathering.md
@@ -13,6 +13,19 @@ Collect what the epic produced and note the source path or range of each:
 - **Previous retrospective** — the prior epic's retro doc, if one exists, so Phase 4 can check whether last epic's action items landed.
 - **Session logs** — conversation or session records for the epic's stories, when available. They are the only record of *why* a session took an unexpected turn — what was tried and abandoned. They are also the evidence most likely to be deleted or expire, so capture references now.
 
+## Stories mode
+
+A stories-mode epic is a spec folder, and the `stories_status.py inspect` result from selection *is* the inventory — do not re-derive it. Map it onto the checklist above:
+
+- **Epic spec** → `{spec-folder}/SPEC.md`, the declared intent.
+- **Story files** → every returned story record in `stories.yaml` order, each with its artifact path and current `status`. List order is authoritative; filename sort is not.
+- **Diff range and commits** → each story's own `revision_range` (`baseline_revision..final_revision`), not one epic-wide range. Group the stories sharing an identical range and run `git_evidence.py` once per distinct range, passing every id in that group. No `^` is needed here — unlike the sprint-mode range above, `baseline_revision` is already the pre-change commit. A story whose `revision_range` is `null` — a missing endpoint, or `NO_VCS` — has no commit or diff evidence: record that, and never substitute `HEAD` for the missing endpoint or write a revision back into the story file.
+- **Sprint status** → not read; a stories-mode epic has none.
+- **Previous retrospective** → `{spec-folder}/RETROSPECTIVE.md`, when resuming.
+- **Session logs** → unchanged.
+
+Ranges may overlap or diverge. Count a shared commit or file change once in the aggregate views while keeping each story's range as its provenance, and record any gap between ranges as a limit on the epic-wide picture.
+
 ## Missing evidence
 
 Evidence availability varies; never hide a gap. Each later analysis declares what it needs and, when that input is absent, records a narrowed scope rather than guessing. A reader of the final retro must always be able to tell **"checked and clean"** from **"never checked."**
@@ -20,5 +33,6 @@ Evidence availability varies; never hide a gap. Each later analysis declares wha
 - Missing session logs → process-lesson analysis is skipped, and the retro says so.
 - No declared acceptance criteria → the verdict is profiled from the diff and stories, flagged as profiled rather than declared.
 - Sub-agents unavailable → analyses that would delegate run inline over a narrowed scope, and the narrowing is recorded.
+- No usable revision range for a story → that story's commit and diff history is out of scope, and the retro names which stories that covers.
 
 Carry the inventory forward into Phase 2 as the authoritative list of what is available to read.

--- a/src/bmm-skills/ship/bmad-retrospective/references/retro-document.md
+++ b/src/bmm-skills/ship/bmad-retrospective/references/retro-document.md
@@ -1,6 +1,6 @@
 # Finalize: Retrospective Document and Sprint Status
 
-Phase 5. Finalize the retrospective and update sprint tracking. Two writes: the retrospective document, and the `sprint-status.yaml` update.
+Phase 5. Finalize the retrospective and update sprint tracking. Two writes: the retrospective document, and the `sprint-status.yaml` update. Stories mode makes only the first.
 
 ## The retrospective document
 
@@ -18,13 +18,30 @@ headless: true | false
 ---
 ```
 
+In stories mode the document lives at `{spec-folder}/RETROSPECTIVE.md` instead — a fixed name, so a resumed run is never mistaken for a new retrospective — and its frontmatter carries the working state that resumption reads:
+
+```
+---
+spec_folder: "<the selected folder, as a YAML string>"
+mode: stories
+date: {date}
+verdict: accepted | accepted-with-open-items | rejected
+criteria: declared | profiled
+headless: true | false
+completed_phases: []
+source_hashes: {}
+---
+```
+
+Add a phase to `completed_phases` only once its section is written; the allowed values are `gather`, `analyze`, `discussion`, `decide`, and `finalize`, and `discussion` is optional. Copy `source_hashes` from the selection-time `inspect` in unchanged. Before resuming from an existing file, validate that `mode` is `stories`, that `spec_folder` is exactly the folder you selected, that `completed_phases` holds only allowed values, and that any `verdict` present uses the terminal vocabulary — stop if the file is malformed or belongs to a different folder rather than resuming into it. Then reconcile against current evidence, replace `source_hashes` with fresh pre-run values, and resume at the first required phase not listed.
+
 Keep `verdict` in sync with the Acceptance verdict section below. Do not encode the verdict in the sprint-status retro key — that key's value stays `done` so the existing lifecycle consumers (sprint planning's `optional ↔ done` transition, status TUIs) keep working unchanged.
 
 That holds for a **rejected** epic too: the update below marks the retro key `done` whichever way the verdict went, because `done` there means *the retrospective ran*, not *the epic passed*. The script writes no verdict of any kind into `sprint-status.yaml` — there is no `retro_verdict` key and `--verdict` is only echoed back in the result JSON — so a gate or orchestrator that acts on the verdict **must** read this document's frontmatter. Reading sprint-status alone cannot tell a rejected epic from an accepted one.
 
 Sections:
 
-- **Epic summary** — which epic, the diff range, stories completed, any stories still unfinished (`pending_stories`) that the user accepted retro-ing over, the evidence inventory (what was available, what was missing). Unfinished stories force the machine acceptance verdict to **rejected** (see `references/acceptance-verdict.md`).
+- **Epic summary** — which epic or spec folder, the diff range (in stories mode, each story's own revision range), stories completed, any stories still unfinished (`pending_stories`) that the user accepted retro-ing over, the evidence inventory (what was available, what was missing). Unfinished stories force the machine acceptance verdict to **rejected** (see `references/acceptance-verdict.md`).
 - **Findings** — grouped by aggregate view and by lens, each with its source reference and disposition (fix now / defer / accept). This is the record; do not summarize away the provenance.
 - **Behavior verification** — what was exercised end to end and what was observed, or an explicit note that runtime behavior was not exercised.
 - **Previous-retro follow-through** — if a prior retro exists, whether its action items landed, with evidence, and the selector Phase 5 would need to act on each (`references/acceptance-verdict.md` specifies what to record).
@@ -78,6 +95,17 @@ Rules:
 - Success reports `action_items_updated`.
 
 Only ever apply a status the user confirmed: the evidence justifies proposing a transition, and only the user's confirmation justifies writing it. In a headless run do not use this flag at all — record the transitions you would have proposed in the Previous-retro follow-through section and leave the prior items' statuses alone.
+
+## Stories-mode finalization
+
+Stories mode finalizes `{spec-folder}/RETROSPECTIVE.md` and nothing else. Do not run `sprint_status.py`, do not read or create a `sprint-status.yaml`, do not edit `SPEC.md`, `stories.yaml`, or any story artifact, and do not persist action items anywhere but this document. If the target path exists and is not a regular file, stop rather than writing through it.
+
+Before reporting success:
+
+1. Run `stories_status.py inspect --folder "{spec-folder}"` once more and reconcile the document against the current ordered inventory.
+2. Confirm a non-empty `pending_stories` still yields `verdict: rejected`, unless an interactive human explicitly overrode it.
+3. Compare that final inspection's `source_hashes` against the pre-run mapping. If any differ, stop and report every changed path — the read-only guarantee is checked, not assumed.
+4. Add `finalize` to `completed_phases`, write the file, and parse its frontmatter again to confirm it round-trips.
 
 ## Finish
 

--- a/src/bmm-skills/ship/bmad-retrospective/scripts/stories_status.py
+++ b/src/bmm-skills/ship/bmad-retrospective/scripts/stories_status.py
@@ -1,0 +1,302 @@
+# /// script
+# requires-python = ">=3.10"
+# dependencies = ["ruamel.yaml>=0.18"]
+# ///
+"""Detect and inspect BMAD spec folders for retrospective stories mode.
+
+The CLI prints only JSON to stdout and never writes to the inspected folders.
+"""
+
+import argparse
+import hashlib
+import json
+import re
+import sys
+from pathlib import Path
+
+from ruamel.yaml import YAML
+
+
+ID_RE = re.compile(r"^[A-Za-z0-9-]+$")
+REVISION_RE = re.compile(r"^[A-Za-z0-9][A-Za-z0-9._/@{}^~:+-]*$")
+STORY_STATUSES = {
+    "draft",
+    "ready-for-dev",
+    "in-progress",
+    "in-review",
+    "done",
+    "blocked",
+}
+REQUIRED_FIELDS = {"id": str, "title": str, "description": str}
+OPTIONAL_FIELDS = {
+    "spec_checkpoint": bool,
+    "done_checkpoint": bool,
+    "invoke_dev_with": str,
+}
+
+
+def _emit(payload, code=0):
+    sys.stdout.write(json.dumps(payload))
+    raise SystemExit(code)
+
+
+def _error(message, code=1):
+    _emit({"ok": False, "error": message}, code)
+
+
+class JsonArgumentParser(argparse.ArgumentParser):
+    def error(self, message):
+        _error(f"argument error: {message}", 2)
+
+
+def _load_yaml(path, label):
+    yaml = YAML(typ="safe")
+    yaml.allow_duplicate_keys = False
+    try:
+        return yaml.load(path.read_text(encoding="utf-8"))
+    except (OSError, UnicodeError) as exc:
+        _error(f"cannot read {label} {path}: {exc}")
+    except Exception as exc:  # noqa: BLE001 - normalize parser failures as JSON
+        _error(f"invalid YAML in {label} {path}: {exc}")
+
+
+def _require_text(entry, field, index, path):
+    value = entry.get(field)
+    if type(value) is not str:  # bool is an int subclass; require exact schema types
+        _error(f"story entry {index} field {field!r} in {path} must be a string")
+    if field == "title" and ("\n" in value or "\r" in value):
+        _error(f"story entry {index} field 'title' in {path} must be one line")
+    return value
+
+
+def _load_inventory(path):
+    data = _load_yaml(path, "story inventory")
+    if not isinstance(data, list):
+        _error(f"story inventory {path} must be a top-level list")
+    if not data:
+        _error(f"story inventory {path} must contain at least one story")
+
+    entries = []
+    ids = []
+    for index, entry in enumerate(data, start=1):
+        if not isinstance(entry, dict):
+            _error(f"story entry {index} in {path} must be a mapping")
+        if "status" in entry:
+            _error(f"story entry {index} in {path} must not contain a status field")
+
+        for field in REQUIRED_FIELDS:
+            if field not in entry:
+                _error(f"story entry {index} in {path} is missing required field {field!r}")
+        story_id = _require_text(entry, "id", index, path)
+        title = _require_text(entry, "title", index, path)
+        description = _require_text(entry, "description", index, path)
+        if not ID_RE.fullmatch(story_id):
+            _error(
+                f"story entry {index} id {story_id!r} in {path} must contain only letters, digits, and dashes"
+            )
+        if story_id in ids:
+            _error(f"duplicate story id {story_id!r} in {path}")
+
+        for field, expected_type in OPTIONAL_FIELDS.items():
+            if field in entry and type(entry[field]) is not expected_type:
+                _error(
+                    f"story entry {index} field {field!r} in {path} must be a {expected_type.__name__}"
+                )
+
+        ids.append(story_id)
+        entries.append({"id": story_id, "title": title, "description": description})
+
+    for left in ids:
+        for right in ids:
+            if left != right and right.startswith(f"{left}-"):
+                _error(f"story ids {left!r} and {right!r} in {path} are not prefix-free")
+    return entries
+
+
+def _load_frontmatter(path):
+    try:
+        content = path.read_text(encoding="utf-8")
+    except (OSError, UnicodeError) as exc:
+        _error(f"cannot read story artifact {path}: {exc}")
+
+    lines = content.splitlines()
+    if not lines or lines[0] != "---":
+        _error(f"story artifact {path} must start with YAML frontmatter")
+    try:
+        end = lines.index("---", 1)
+    except ValueError:
+        _error(f"story artifact {path} has unterminated YAML frontmatter")
+
+    yaml = YAML(typ="safe")
+    yaml.allow_duplicate_keys = False
+    try:
+        data = yaml.load("\n".join(lines[1:end]))
+    except Exception as exc:  # noqa: BLE001 - normalize parser failures as JSON
+        _error(f"invalid YAML frontmatter in story artifact {path}: {exc}")
+    if not isinstance(data, dict):
+        _error(f"story artifact {path} frontmatter must be a mapping")
+
+    status = data.get("status")
+    if type(status) is not str or not status.strip():
+        _error(f"story artifact {path} frontmatter status must be a non-empty string")
+    if status not in STORY_STATUSES:
+        _error(
+            f"story artifact {path} has unrecognized frontmatter status {status!r}"
+        )
+
+    revisions = {}
+    for field in ("baseline_revision", "final_revision"):
+        value = data.get(field)
+        if value is not None and (type(value) is not str or not value.strip()):
+            _error(f"story artifact {path} frontmatter {field} must be a non-empty string")
+        if value is not None and value != "NO_VCS" and (
+            not REVISION_RE.fullmatch(value) or ".." in value
+        ):
+            _error(
+                f"story artifact {path} frontmatter {field} contains an invalid revision"
+            )
+        revisions[field] = value
+    return status, revisions
+
+
+def _sha256(path):
+    try:
+        return hashlib.sha256(path.read_bytes()).hexdigest()
+    except OSError as exc:
+        _error(f"cannot hash source artifact {path}: {exc}")
+
+
+def _is_spec_folder(path):
+    """The same triple `inspect` requires, so detection cannot offer a folder it rejects."""
+    return (
+        (path / "SPEC.md").is_file()
+        and (path / "stories.yaml").is_file()
+        and (path / "stories").is_dir()
+    )
+
+
+def inspect_folder(folder):
+    try:
+        folder = Path(folder).expanduser().resolve()
+    except (OSError, RuntimeError) as exc:
+        _error(f"cannot resolve spec folder {folder}: {exc}")
+    if not folder.is_dir():
+        _error(f"spec folder does not exist or is not a directory: {folder}")
+
+    spec_path = folder / "SPEC.md"
+    inventory_path = folder / "stories.yaml"
+    stories_dir = folder / "stories"
+    if not spec_path.is_file():
+        _error(f"spec folder is missing SPEC.md: {folder}")
+    if not inventory_path.is_file():
+        _error(f"spec folder is missing stories.yaml: {folder}")
+    if not stories_dir.is_dir():
+        _error(f"spec folder is missing stories directory: {folder}")
+    try:
+        spec_path.read_text(encoding="utf-8")
+    except (OSError, UnicodeError) as exc:
+        _error(f"cannot read SPEC.md {spec_path}: {exc}")
+
+    source_hashes = {
+        str(spec_path): _sha256(spec_path),
+        str(inventory_path): _sha256(inventory_path),
+    }
+    stories = []
+    pending = []
+    for entry in _load_inventory(inventory_path):
+        try:
+            matches = sorted(stories_dir.glob(f"{entry['id']}-*.md"))
+        except OSError as exc:
+            _error(f"cannot inspect story files for id {entry['id']!r}: {exc}")
+        matches = [path for path in matches if path.is_file()]
+        if len(matches) != 1:
+            _error(
+                f"story id {entry['id']!r} must match exactly one stories/{entry['id']}-*.md file; found {len(matches)}"
+            )
+
+        story_path = matches[0]
+        status, revisions = _load_frontmatter(story_path)
+        source_hashes[str(story_path)] = _sha256(story_path)
+        baseline = revisions["baseline_revision"]
+        final = revisions["final_revision"]
+        revision_range = None
+        if baseline and final and baseline != "NO_VCS" and final != "NO_VCS":
+            revision_range = f"{baseline}..{final}"
+        if status != "done":
+            pending.append(entry["id"])
+        stories.append(
+            {
+                **entry,
+                "file": str(story_path),
+                "status": status,
+                "baseline_revision": baseline,
+                "final_revision": final,
+                "revision_range": revision_range,
+            }
+        )
+
+    return {
+        "ok": True,
+        "mode": "stories",
+        "spec_folder": str(folder),
+        "spec_file": str(spec_path),
+        "inventory_file": str(inventory_path),
+        "retrospective_file": str(folder / "RETROSPECTIVE.md"),
+        "story_count": len(stories),
+        "stories": stories,
+        "pending_stories": pending,
+        "complete": not pending,
+        "source_hashes": source_hashes,
+    }
+
+
+def detect_candidates(roots):
+    candidates = set()
+    for raw_root in roots:
+        root = Path(raw_root).expanduser().resolve()
+        if not root.exists():
+            continue
+        if not root.is_dir():
+            _error(f"spec root is not a directory: {root}")
+        if _is_spec_folder(root):
+            candidates.add(root)
+        try:
+            for inventory in root.rglob("stories.yaml"):
+                folder = inventory.parent
+                if _is_spec_folder(folder):
+                    candidates.add(folder.resolve())
+        except OSError as exc:
+            _error(f"cannot scan spec root {root}: {exc}")
+    return sorted(str(path) for path in candidates)
+
+
+def build_parser():
+    parser = JsonArgumentParser(add_help=False)
+    subparsers = parser.add_subparsers(dest="command", required=True)
+
+    inspect_parser = subparsers.add_parser("inspect", add_help=False)
+    inspect_parser.add_argument("--folder", required=True)
+
+    detect_parser = subparsers.add_parser("detect", add_help=False)
+    detect_parser.add_argument("--root", action="append", required=True)
+    return parser
+
+
+def main(argv=None):
+    args = build_parser().parse_args(argv)
+    if args.command == "inspect":
+        _emit(inspect_folder(args.folder))
+        return
+    candidates = detect_candidates(args.root)
+    _emit(
+        {
+            "ok": True,
+            "mode": "stories",
+            "candidate_count": len(candidates),
+            "candidates": candidates,
+        }
+    )
+
+
+if __name__ == "__main__":
+    main()

--- a/src/bmm-skills/ship/bmad-retrospective/scripts/tests/test_stories_status.py
+++ b/src/bmm-skills/ship/bmad-retrospective/scripts/tests/test_stories_status.py
@@ -1,0 +1,287 @@
+# /// script
+# requires-python = ">=3.10"
+# dependencies = ["pytest>=8", "ruamel.yaml>=0.18"]
+# ///
+"""Subprocess tests for the stories-mode retrospective inspector."""
+
+import json
+import subprocess
+import sys
+from pathlib import Path
+
+import pytest
+
+
+SCRIPT = Path(__file__).parents[1] / "stories_status.py"
+
+
+def _run(*args):
+    return subprocess.run(
+        [sys.executable, str(SCRIPT), *map(str, args)],
+        capture_output=True,
+        text=True,
+        check=False,
+    )
+
+
+def _json(proc):
+    assert proc.stderr == ""
+    return json.loads(proc.stdout)
+
+
+def _folder(tmp_path, entries=None, artifacts=None):
+    folder = tmp_path / "spec-one"
+    (folder / "stories").mkdir(parents=True)
+    (folder / "SPEC.md").write_text("# Spec\n", encoding="utf-8")
+    if entries is None:
+        entries = [
+            '- id: "2"\n  title: Second\n  description: Run second.\n',
+            '- id: "1"\n  title: First\n  description: Run first.\n',
+        ]
+    (folder / "stories.yaml").write_text("".join(entries), encoding="utf-8")
+    if artifacts is None:
+        artifacts = {
+            "2-second.md": "---\nstatus: done\nbaseline_revision: aaa\nfinal_revision: bbb\n---\n",
+            "1-first.md": "---\nstatus: in-progress\n---\n",
+        }
+    for name, content in artifacts.items():
+        (folder / "stories" / name).write_text(content, encoding="utf-8")
+    return folder
+
+
+def test_inspect_preserves_inventory_order_and_reports_revisions(tmp_path):
+    folder = _folder(tmp_path)
+    proc = _run("inspect", "--folder", folder)
+    assert proc.returncode == 0
+    data = _json(proc)
+    assert [story["id"] for story in data["stories"]] == ["2", "1"]
+    assert data["stories"][0]["revision_range"] == "aaa..bbb"
+    assert data["stories"][0] == {
+        "id": "2",
+        "title": "Second",
+        "description": "Run second.",
+        "file": str(folder / "stories" / "2-second.md"),
+        "status": "done",
+        "baseline_revision": "aaa",
+        "final_revision": "bbb",
+        "revision_range": "aaa..bbb",
+    }
+    assert data["pending_stories"] == ["1"]
+    assert data["complete"] is False
+    assert data["retrospective_file"] == str(folder / "RETROSPECTIVE.md")
+    assert set(data["source_hashes"]) == {
+        str(folder / "SPEC.md"),
+        str(folder / "stories.yaml"),
+        str(folder / "stories" / "2-second.md"),
+        str(folder / "stories" / "1-first.md"),
+    }
+
+
+def test_complete_inventory(tmp_path):
+    folder = _folder(
+        tmp_path,
+        entries=['- id: "a-1"\n  title: One\n  description: Complete.\n'],
+        artifacts={"a-1-story.md": "---\nstatus: done\nbaseline_revision: NO_VCS\nfinal_revision: NO_VCS\n---\n"},
+    )
+    data = _json(_run("inspect", "--folder", folder))
+    assert data["complete"] is True
+    assert data["pending_stories"] == []
+    assert data["stories"][0]["revision_range"] is None
+
+
+def test_empty_yaml_list_is_not_an_epic(tmp_path):
+    folder = _folder(tmp_path, entries=["[]\n"], artifacts={})
+    proc = _run("inspect", "--folder", folder)
+    assert proc.returncode == 1
+    assert "at least one story" in _json(proc)["error"]
+
+
+@pytest.mark.parametrize(
+    ("frontmatter", "expected_range"),
+    [
+        ("baseline_revision: aaa\n", None),
+        ("final_revision: bbb\n", None),
+        ("baseline_revision: NO_VCS\nfinal_revision: bbb\n", None),
+        ("baseline_revision: aaa\nfinal_revision: NO_VCS\n", None),
+    ],
+)
+def test_partial_or_no_vcs_revision_pairs_have_no_range(
+    tmp_path, frontmatter, expected_range
+):
+    folder = _folder(
+        tmp_path,
+        entries=['- id: "1"\n  title: One\n  description: One.\n'],
+        artifacts={"1-one.md": f"---\nstatus: done\n{frontmatter}---\n"},
+    )
+    data = _json(_run("inspect", "--folder", folder))
+    assert data["stories"][0]["revision_range"] is expected_range
+
+
+def test_detect_finds_nested_candidates_in_stable_order(tmp_path):
+    second = _folder(tmp_path / "z")
+    first = _folder(tmp_path / "a")
+    data = _json(_run("detect", "--root", tmp_path))
+    assert data["candidate_count"] == 2
+    assert data["candidates"] == sorted([str(first), str(second)])
+
+
+def test_detect_deduplicates_overlapping_roots(tmp_path):
+    folder = _folder(tmp_path)
+    data = _json(_run("detect", "--root", tmp_path, "--root", folder))
+    assert data["candidates"] == [str(folder)]
+
+
+def test_detect_skips_folders_inspect_would_reject(tmp_path):
+    # breakdown ran but no story specs exist yet: not a retrospective candidate
+    partial = tmp_path / "spec-partial"
+    partial.mkdir()
+    (partial / "SPEC.md").write_text("# Spec\n", encoding="utf-8")
+    (partial / "stories.yaml").write_text(
+        '- id: "1"\n  title: One\n  description: One.\n', encoding="utf-8"
+    )
+    assert _json(_run("detect", "--root", tmp_path))["candidates"] == []
+    assert _json(_run("detect", "--root", partial))["candidates"] == []
+    # and the folder detection skipped is indeed one inspect refuses
+    proc = _run("inspect", "--folder", partial)
+    assert proc.returncode == 1
+    assert "missing stories directory" in _json(proc)["error"]
+
+
+def test_inspect_does_not_fall_through_to_detection(tmp_path):
+    data = _json(_run("inspect", "--folder", _folder(tmp_path)))
+    assert "candidates" not in data
+    assert "candidate_count" not in data
+
+
+@pytest.mark.parametrize(
+    ("entries", "message"),
+    [
+        ([], "top-level list"),
+        (["id: nope\n"], "top-level list"),
+        (["- id: [\n"], "invalid YAML"),
+        (['- id: 1\n  title: One\n  description: Bad id type.\n'], "field 'id'"),
+        (['- id: "a/*"\n  title: One\n  description: Bad chars.\n'], "letters, digits, and dashes"),
+        (['- id: "1"\n  title: One\n'], "missing required field 'description'"),
+        (['- id: "1"\n  title: One\n  description: One.\n  status: done\n'], "must not contain a status"),
+        (
+            [
+                '- id: "1"\n  title: One\n  description: One.\n',
+                '- id: "1"\n  title: Again\n  description: Again.\n',
+            ],
+            "duplicate story id",
+        ),
+        (
+            [
+                '- id: "3"\n  title: One\n  description: One.\n',
+                '- id: "3-2"\n  title: Two\n  description: Two.\n',
+            ],
+            "not prefix-free",
+        ),
+        # optional fields are typed too; bool is an int subclass, so both
+        # directions matter
+        (
+            ['- id: "1"\n  title: One\n  description: One.\n  spec_checkpoint: "true"\n'],
+            "field 'spec_checkpoint' in",
+        ),
+        (
+            ['- id: "1"\n  title: One\n  description: One.\n  done_checkpoint: 1\n'],
+            "must be a bool",
+        ),
+        (
+            ['- id: "1"\n  title: One\n  description: One.\n  invoke_dev_with: true\n'],
+            "must be a str",
+        ),
+    ],
+)
+def test_invalid_inventory_is_structured_error(tmp_path, entries, message):
+    folder = _folder(tmp_path, entries=entries, artifacts={})
+    proc = _run("inspect", "--folder", folder)
+    assert proc.returncode == 1
+    data = _json(proc)
+    assert data["ok"] is False
+    assert message in data["error"]
+
+
+@pytest.mark.parametrize(
+    ("artifacts", "message"),
+    [
+        ({}, "found 0"),
+        (
+            {"1-a.md": "---\nstatus: done\n---\n", "1-b.md": "---\nstatus: done\n---\n"},
+            "found 2",
+        ),
+        ({"1-a.md": "status: done\n"}, "must start with YAML frontmatter"),
+        ({"1-a.md": "---\nstatus: [done]\n---\n"}, "status must be a non-empty string"),
+        ({"1-a.md": "---\nstatus: Done\n---\n"}, "unrecognized frontmatter status"),
+        ({"1-a.md": "---\nstatus: done\nbaseline_revision: 123\n---\n"}, "baseline_revision"),
+        (
+            {"1-a.md": "---\nstatus: done\nbaseline_revision: $(bad)\n---\n"},
+            "invalid revision",
+        ),
+        # a revision that already contains `..` would compose into `a..b..c`
+        (
+            {"1-a.md": "---\nstatus: done\nbaseline_revision: aaa..bbb\n---\n"},
+            "invalid revision",
+        ),
+    ],
+)
+def test_broken_story_artifacts_are_structured_errors(tmp_path, artifacts, message):
+    folder = _folder(
+        tmp_path,
+        entries=['- id: "1"\n  title: One\n  description: One.\n'],
+        artifacts=artifacts,
+    )
+    proc = _run("inspect", "--folder", folder)
+    assert proc.returncode == 1
+    assert message in _json(proc)["error"]
+
+
+def test_well_typed_optional_fields_are_accepted(tmp_path):
+    folder = _folder(
+        tmp_path,
+        entries=[
+            '- id: "1"\n  title: One\n  description: One.\n'
+            "  spec_checkpoint: true\n  done_checkpoint: false\n"
+            "  invoke_dev_with: Use the existing client.\n"
+        ],
+        artifacts={"1-one.md": "---\nstatus: done\n---\n"},
+    )
+    data = _json(_run("inspect", "--folder", folder))
+    assert data["stories"][0]["id"] == "1"
+    # caller-only fields stay out of the inspector's output
+    assert "spec_checkpoint" not in data["stories"][0]
+
+
+def test_missing_fixed_files_are_errors(tmp_path):
+    folder = tmp_path / "empty"
+    folder.mkdir()
+    proc = _run("inspect", "--folder", folder)
+    assert proc.returncode == 1
+    assert "missing SPEC.md" in _json(proc)["error"]
+
+
+def test_inspection_preserves_all_source_bytes(tmp_path):
+    folder = _folder(tmp_path)
+    sources = [folder / "SPEC.md", folder / "stories.yaml", *sorted((folder / "stories").iterdir())]
+    before = {path: path.read_bytes() for path in sources}
+    assert _run("inspect", "--folder", folder).returncode == 0
+    assert {path: path.read_bytes() for path in sources} == before
+    assert not (folder / "RETROSPECTIVE.md").exists()
+
+
+def test_argument_errors_are_json_only():
+    proc = _run("inspect")
+    assert proc.returncode == 2
+    assert _json(proc)["error"].startswith("argument error:")
+
+
+def test_folder_resolution_errors_are_json_only(tmp_path):
+    loop = tmp_path / "loop"
+    loop.symlink_to(loop)
+    proc = _run("inspect", "--folder", loop)
+    assert proc.returncode == 1
+    assert _json(proc)["error"].startswith("cannot resolve spec folder")
+
+
+if __name__ == "__main__":
+    raise SystemExit(pytest.main([__file__, "-q"]))


### PR DESCRIPTION
## What

Adds spec-folder epics to `bmad-retrospective` as a peer of sprint-status epics. A folder holding `SPEC.md`, an ordered `stories.yaml`, and `stories/<id>-*.md` artifacts — the shape an unattended build loop leaves behind — can now be selected, completeness-gated, resumed, and finalized without inventing sprint state.

- New `stories_status.py`: a read-only, JSON-only detector/inspector validated against `stories-schema.md` (list order authoritative, ids unique and prefix-free, exactly one artifact per id, `status` and revision range from frontmatter).
- Mode resolution in `SKILL.md`: a named folder selects stories mode over sprint status; a named epic number stays sprint mode; detection runs only when neither was supplied and there is no sprint status. Multiple candidates are never resolved silently.
- Stories mode gathers per-story revision ranges rather than one epic-wide range, writes and resumes `RETROSPECTIVE.md` in the spec folder, and never reads, creates, or writes sprint status.
- Source artifacts are hashed at selection and re-checked before finalization, so the read-only guarantee is verified rather than assumed.

Sprint-mode selection, evidence, verdict, and finalization behavior is unchanged.

## Why

An unattended build loop represents an epic as a spec folder, not as an entry in `sprint-status.yaml`. That shape previously could not be retrospected at all without synthesizing sprint state for it.

## Notes for review

This supersedes #2660, which delivered the same feature but rewrote the surrounding prompt prose wholesale. That rewrite deleted two behavioral rules that were each stated in two places — the absent-evidence guard (never render a verdict from the absence of a completeness check) and the rule that a gate must read the retrospective's frontmatter, since `sprint-status.yaml` records the retro key `done` whether the epic passed or failed. Both are preserved here.

The prompt diff is 72 lines across four files, and every one of the 12 deleted lines in the change is a line replaced by an extended version of itself.

`stories_status.py` is carried over from #2660 with four fixes: detection no longer offers folders inspection rejects (it now requires the same `SPEC.md` + `stories.yaml` + `stories/` triple), revisions containing `..` are rejected before they compose into a malformed range, and `inspect` returns explicitly rather than relying on `_emit` raising to avoid falling through into detection. Tests go from 27 to 32.
