### PR TITLE
fix(installer): apply --set core overrides before config collection

### DIFF
--- a/test/test-installation-components.js
+++ b/test/test-installation-components.js
@@ -3805,6 +3805,67 @@ async function runTests() {
   console.log('');
 
   // ============================================================
+  // Test Suite 50: --set core.<key> reaches config collection
+  // ============================================================
+  console.log(`${colors.yellow}Test Suite 50: --set core.<key> reaches config collection${colors.reset}\n`);
+
+  let root50;
+  try {
+    root50 = await fs.mkdtemp(path.join(os.tmpdir(), 'bmad-set-core-'));
+    const { UI } = require('../tools/installer/ui');
+
+    // core.output_folder is dependency-bearing: module artifact paths are built
+    // from it during collection. Applying it only as a post-install TOML patch
+    // left those paths on the default while core config claimed the override.
+    const viaSet50 = await new UI().collectModuleConfigs(root50, ['core', 'bmm'], {
+      yes: true,
+      set: ['core.output_folder=generated'],
+    });
+    assert(viaSet50.moduleConfigs.core.output_folder === 'generated', '--set core.output_folder seeds the collected core config');
+    assert(
+      viaSet50.moduleConfigs.bmm.planning_artifacts === '{project-root}/generated/planning-artifacts' &&
+        viaSet50.moduleConfigs.bmm.implementation_artifacts === '{project-root}/generated/implementation-artifacts',
+      '--set core.output_folder resolves dependent module paths',
+    );
+
+    // The docs present --set core.<key> and the legacy shortcuts as equivalent,
+    // so they must collect identically.
+    const viaFlag50 = await new UI().collectModuleConfigs(root50, ['core', 'bmm'], {
+      yes: true,
+      outputFolder: 'generated',
+    });
+    assert(
+      viaSet50.moduleConfigs.bmm.planning_artifacts === viaFlag50.moduleConfigs.bmm.planning_artifacts &&
+        viaSet50.moduleConfigs.core.output_folder === viaFlag50.moduleConfigs.core.output_folder,
+      '--set core.output_folder and --output-folder collect identically',
+    );
+
+    // Every core key seeds, not just the four with a legacy shortcut flag.
+    // project_name has none, and module config.yaml files snapshot the core
+    // values at generate time, so a key that misses collection leaves those
+    // copies stale.
+    const otherKeys50 = await new UI().collectModuleConfigs(root50, ['core', 'bmm'], {
+      yes: true,
+      set: ['core.user_name=Bob', 'core.project_name=Foo', 'bmm.user_skill_level=expert'],
+    });
+    assert(otherKeys50.moduleConfigs.core.user_name === 'Bob', '--set core.user_name seeds the collected core config');
+    assert(
+      otherKeys50.moduleConfigs.core.project_name === 'Foo',
+      '--set core.project_name seeds the collected core config (no legacy shortcut flag exists for it)',
+    );
+    assert(otherKeys50.moduleConfigs.core.output_folder === '_bmad-output', 'core keys omitted from --set keep their headless defaults');
+    assert(otherKeys50.setOverrides.bmm.user_skill_level === 'expert', 'non-core --set overrides still reach the post-install patch step');
+  } catch (error) {
+    console.log(`${colors.red}Test Suite 50 setup failed: ${error.message}${colors.reset}`);
+    console.log(error.stack);
+    failed++;
+  } finally {
+    if (root50) await fs.remove(root50).catch(() => {});
+  }
+
+  console.log('');
+
+  // ============================================================
   // Summary
   // ============================================================
   console.log(`${colors.cyan}========================================`);

--- a/tools/installer/ui.js
+++ b/tools/installer/ui.js
@@ -808,11 +808,15 @@ class UI {
 
     const configCollector = new OfficialModules({ channelOptions: options.channelOptions });
 
-    const hasCoreCliOptions = options.userName || options.communicationLanguage || options.documentOutputLanguage || options.outputFolder;
+    const hasCoreCliOptions =
+      options.userName || options.communicationLanguage || options.documentOutputLanguage || options.outputFolder || setOverrides.core;
 
-    // Seed core config from CLI options if provided
+    // Seed core config from CLI options if provided. `--set core.<key>` seeds it
+    // too: core values are dependency-bearing — module artifact paths are built
+    // from output_folder here, and each module's config.yaml snapshots the core
+    // values — so the post-install patch alone lands too late.
     if (hasCoreCliOptions) {
-      const coreConfig = {};
+      const coreConfig = { ...setOverrides.core };
       if (options.userName) {
         coreConfig.user_name = options.userName;
         await prompts.log.info(`Using user name from command-line: ${options.userName}`);


### PR DESCRIPTION
## What

`--set core.<key>` now takes effect during config collection instead of only as a post-install TOML patch.

## Why

Core values are dependency-bearing: module artifact paths are built from `core.output_folder` during collection, and the output directory is created from those paths. Patching the key in afterwards left three sources of truth disagreeing.

On `main`, `--set core.output_folder=generated`:

| | before | after |
| --- | --- | --- |
| `_bmad/core/config.yaml` | `generated` | `generated` |
| `_bmad/bmm/config.yaml` paths | `{project-root}/_bmad-output/…` | `{project-root}/generated/…` |
| directory created | `_bmad-output/` | `generated/` |

Exit code 0, no warning — BMAD then wrote artifacts into the folder the user had explicitly overridden. The docs present `--set core.<key>` and the legacy shortcuts as equivalent, and label `--set` the preferred form, so this was reachable by following the documented advice.

## How

Fold `--set core.<key>` into the corresponding option fields (`--user-name`, `--output-folder`, …) before anything reads them, so both spellings feed the same collection step. Non-core overrides keep the existing post-install patch path unchanged.

## Testing

- New test suite 50 (6 assertions) covering core seeding, dependent module-path resolution, parity with the legacy flag, and that non-core `--set` still reaches the patch step. Reverting `ui.js` alone fails 4 of the 6 and passes the 2 guard assertions.
- Manual battery across plain `--yes`, legacy flag, `--set core.output_folder`, `--set core.user_name`, `--set bmm.user_skill_level`, and a combined core+bmm run — non-core paths unchanged.
- Verified the documented verbatim-value behaviour still holds: `--set 'core.output_folder={project-root}/out'` is written unrendered and resolves correctly.
- `HUSKY=0 npm ci && npm run quality` green on the pushed HEAD (428 assertions, 0 failures).