### PR TITLE
fix(review): clarify weak test evidence

### DIFF
--- a/src/bmm-skills/ship/bmad-build-auto/review-prompts/verification-gap.md
+++ b/src/bmm-skills/ship/bmad-build-auto/review-prompts/verification-gap.md
@@ -54,6 +54,8 @@ Find and read the relevant test. Ask whether the Demonstration would make an ass
 
 A test counts only if it runs normally and an assertion observes the changed output, branch, or contract. These do not count: no execution; source-text assertions that match a file's wording instead of running it; success/no-throw/snapshot-only checks; mock/log-call checks; human-only checks; tests that mock away the integration; e2e tests that pass through without checking the changed output; stale assertions or fixtures.
 
+For example, `expect(x ?? DEFAULT).toBe(DEFAULT)` passes when `x` is missing.
+
 Common patterns:
 
 - **Caller-path gap** — helper test covers the branch, but caller values skip it.
@@ -66,6 +68,8 @@ Common patterns:
 ### Step 5: Confirm each finding is real
 
 Before writing a finding, re-open the specific tests or search results the finding relies on. Verify the Demonstration would not make any test you checked fail, or that the absence claim is backed by the symbol/import-reference search. Do not claim more than you verified; drop any finding you cannot ground.
+
+Explain why the test misses the bug using what the test sets up and checks.
 
 Do not report: compiler/type-checker-enforced cases; behavior already verified by an integration, contract, or e2e test; implementation-detail or mock-only tests; low coverage or a missing test file by itself; legacy untested code the change did not affect.
 

--- a/src/bmm-skills/ship/bmad-build/review-prompts/verification-gap.md
+++ b/src/bmm-skills/ship/bmad-build/review-prompts/verification-gap.md
@@ -54,6 +54,8 @@ Find and read the relevant test. Ask whether the Demonstration would make an ass
 
 A test counts only if it runs normally and an assertion observes the changed output, branch, or contract. These do not count: no execution; source-text assertions that match a file's wording instead of running it; success/no-throw/snapshot-only checks; mock/log-call checks; human-only checks; tests that mock away the integration; e2e tests that pass through without checking the changed output; stale assertions or fixtures.
 
+For example, `expect(x ?? DEFAULT).toBe(DEFAULT)` passes when `x` is missing.
+
 Common patterns:
 
 - **Caller-path gap** — helper test covers the branch, but caller values skip it.
@@ -66,6 +68,8 @@ Common patterns:
 ### Step 5: Confirm each finding is real
 
 Before writing a finding, re-open the specific tests or search results the finding relies on. Verify the Demonstration would not make any test you checked fail, or that the absence claim is backed by the symbol/import-reference search. Do not claim more than you verified; drop any finding you cannot ground.
+
+Explain why the test misses the bug using what the test sets up and checks.
 
 Do not report: compiler/type-checker-enforced cases; behavior already verified by an integration, contract, or e2e test; implementation-detail or mock-only tests; low coverage or a missing test file by itself; legacy untested code the change did not affect.
 

--- a/src/bmm-skills/ship/bmad-code-review/review-prompts/verification-gap.md
+++ b/src/bmm-skills/ship/bmad-code-review/review-prompts/verification-gap.md
@@ -54,6 +54,8 @@ Find and read the relevant test. Ask whether the Demonstration would make an ass
 
 A test counts only if it runs normally and an assertion observes the changed output, branch, or contract. These do not count: no execution; source-text assertions that match a file's wording instead of running it; success/no-throw/snapshot-only checks; mock/log-call checks; human-only checks; tests that mock away the integration; e2e tests that pass through without checking the changed output; stale assertions or fixtures.
 
+For example, `expect(x ?? DEFAULT).toBe(DEFAULT)` passes when `x` is missing.
+
 Common patterns:
 
 - **Caller-path gap** — helper test covers the branch, but caller values skip it.
@@ -66,6 +68,8 @@ Common patterns:
 ### Step 5: Confirm each finding is real
 
 Before writing a finding, re-open the specific tests or search results the finding relies on. Verify the Demonstration would not make any test you checked fail, or that the absence claim is backed by the symbol/import-reference search. Do not claim more than you verified; drop any finding you cannot ground.
+
+Explain why the test misses the bug using what the test sets up and checks.
 
 Do not report: compiler/type-checker-enforced cases; behavior already verified by an integration, contract, or e2e test; implementation-detail or mock-only tests; low coverage or a missing test file by itself; legacy untested code the change did not affect.
 

--- a/src/core-skills/bmad-review/references/lens-verification-gap.md
+++ b/src/core-skills/bmad-review/references/lens-verification-gap.md
@@ -56,6 +56,8 @@ Find and read the relevant test. Ask whether the Demonstration would make an ass
 
 A test counts only if it runs normally and an assertion observes the changed output, branch, or contract. These do not count: no execution; success/no-throw/snapshot-only checks; mock/log-call checks; human-only checks; tests that mock away the integration; e2e tests that pass through without checking the changed output; stale assertions or fixtures.
 
+For example, `expect(x ?? DEFAULT).toBe(DEFAULT)` passes when `x` is missing.
+
 Common patterns:
 
 - **Caller-path gap** — helper test covers the branch, but caller values skip it.
@@ -68,6 +70,8 @@ Common patterns:
 ### Step 5: Confirm each finding is real
 
 Before writing a finding, re-open the specific tests or search results the finding relies on. Verify the Demonstration would not make any test you checked fail, or that the absence claim is backed by the symbol/import-reference search. Do not claim more than you verified; drop any finding you cannot ground.
+
+Explain why the test misses the bug using what the test sets up and checks.
 
 Do not report: compiler/type-checker-enforced cases; behavior already verified by an integration, contract, or e2e test; implementation-detail or mock-only tests; low coverage or a missing test file by itself; legacy untested code the change did not affect.
 


### PR DESCRIPTION
## Summary

- show how a fallback can let a test pass when the value is missing
- ground explanations in what the test sets up and checks
- keep the four verification-gap prompts aligned

Inspired by #2673.

## Test plan

- `HUSKY=0 npm ci && npm run quality` (Node 22)