### PR TITLE
fix(party-mode): decode subprocess JSON as UTF-8 on Windows

### DIFF
--- a/src/core-skills/bmad-party-mode/scripts/resolve_party.py
+++ b/src/core-skills/bmad-party-mode/scripts/resolve_party.py
@@ -46,13 +46,16 @@ except ImportError:  # pragma: no cover - guarded for <3.11
 def _run_json(cmd):
     """Run a resolver script and parse its JSON stdout. None on any failure."""
     try:
-        out = subprocess.run(cmd, capture_output=True, text=True, timeout=60)
-    except (OSError, subprocess.SubprocessError):
+        out = subprocess.run(
+            cmd, capture_output=True, text=True, encoding="utf-8", timeout=60
+        )
+    except (OSError, subprocess.SubprocessError, UnicodeDecodeError):
         return None
-    if out.returncode != 0 or not out.stdout.strip():
+    stdout = out.stdout or ""
+    if out.returncode != 0 or not stdout.strip():
         return None
     try:
-        return json.loads(out.stdout)
+        return json.loads(stdout)
     except json.JSONDecodeError:
         return None
 

--- a/src/core-skills/bmad-party-mode/scripts/tests/test_resolve_party.py
+++ b/src/core-skills/bmad-party-mode/scripts/tests/test_resolve_party.py
@@ -7,6 +7,7 @@
 import sys
 import unittest
 from pathlib import Path
+from unittest.mock import MagicMock, patch
 
 sys.path.insert(0, str(Path(__file__).resolve().parent.parent))
 import resolve_party as rp  # noqa: E402
@@ -15,6 +16,22 @@ AGENTS = {
     "bmad-agent-analyst": {"name": "Mary", "icon": "📊", "title": "Analyst"},
     "bmad-agent-pm": {"name": "John", "icon": "📋", "title": "PM"},
 }
+
+
+class TestRunJson(unittest.TestCase):
+    """Pins UTF-8 decoding when reading resolver subprocess stdout."""
+
+    def test_decodes_utf8_emoji_subprocess_stdout(self):
+        mock_result = MagicMock()
+        mock_result.returncode = 0
+        mock_result.stdout = '{"agent": {"icon": "🧭"}}'
+
+        with patch.object(rp.subprocess, "run", return_value=mock_result) as mock_run:
+            result = rp._run_json(["fake", "cmd"])
+
+        _, kwargs = mock_run.call_args
+        self.assertEqual(kwargs.get("encoding"), "utf-8")
+        self.assertEqual(result["agent"]["icon"], "🧭")
 
 
 class TestAlias(unittest.TestCase):


### PR DESCRIPTION
## What
Decode resolver subprocess stdout as UTF-8 in `resolve_party.py` so Party Mode can read emoji agent icons on Windows cp1252 locales.

## Why
Fixes follow-up to #2406. After #2414, `resolve_customization.py` writes UTF-8 JSON (including emoji icons) to stdout when piped. On Windows with cp1252 locale, `resolve_party.py` `_run_json()` still called `subprocess.run(..., text=True)` without `encoding=`, causing `UnicodeDecodeError` in the reader thread when Party Mode activates.

## How
- Pass `encoding="utf-8"` to `subprocess.run` in `_run_json()`
- Guard empty stdout with `stdout = out.stdout or ""`
- Catch `UnicodeDecodeError` alongside other subprocess failures
- Add regression test pinning UTF-8 decoding

## Testing
- `python src/core-skills/bmad-party-mode/scripts/tests/test_resolve_party.py` — 17 tests pass
- Repro context: Windows + cp1252 + agents with emoji icons in `customize.toml`
