### PR TITLE
fix: bump eval fixture vitest past the CVE-2026-47429 range

### DIFF
--- a/src/bmm-skills/plan/bmad-project-context/evals/files/fixture-brownfield/package.json
+++ b/src/bmm-skills/plan/bmad-project-context/evals/files/fixture-brownfield/package.json
@@ -13,6 +13,6 @@
   },
   "devDependencies": {
     "typescript": "^5.4.0",
-    "vitest": "^1.6.0"
+    "vitest": "^3.2.6"
   }
 }

--- a/src/bmm-skills/plan/bmad-project-context/evals/files/fixture-refresh/package.json
+++ b/src/bmm-skills/plan/bmad-project-context/evals/files/fixture-refresh/package.json
@@ -13,6 +13,6 @@
   },
   "devDependencies": {
     "typescript": "^5.4.0",
-    "vitest": "^1.6.0"
+    "vitest": "^3.2.6"
   }
 }

--- a/src/bmm-skills/plan/bmad-project-context/evals/files/fixture-standalone/package.json
+++ b/src/bmm-skills/plan/bmad-project-context/evals/files/fixture-standalone/package.json
@@ -13,6 +13,6 @@
   },
   "devDependencies": {
     "typescript": "^5.4.0",
-    "vitest": "^1.6.0"
+    "vitest": "^3.2.6"
   }
 }


### PR DESCRIPTION
## What

Bumps the `vitest` pin from `^1.6.0` to `^3.2.6` in the three `bmad-project-context` eval fixtures (`fixture-standalone`, `fixture-refresh`, `fixture-brownfield`).

## Why

`vitest < 3.2.6` carries CVE-2026-47429 (critical, arbitrary file read/execute via the Vitest UI server). The fixtures are inert eval inputs and are never installed, so there is no real exposure — but GitHubs dependency graph parses every `package.json` on the default branch. In any repo that installs BMad into `.claude/skills/`, these three files show up as three open **critical** Dependabot alerts, sitting on top of that repos genuine findings.

Downstream cannot fix this locally: `.claude/skills/` is installer-managed, so a hand-bumped pin is overwritten on the next `bmm` refresh. I bumped it twice in my own repo and the installer reverted it both times.

## How

- Three one-line pin changes, nothing else.
- `^3.2.6` rather than `^4.x` — the minimum that clears the advisory, and it keeps the wavecart fixtures slightly-behind-a-real-project character.
- The lockfile stub in `fixture-brownfield` is deliberately left alone.

## Testing

`evals/cases.json` asserts on the test *command* (`vitest`), never a version, so no expectation changes. Grepped the eval tree to confirm `1.6` appears nowhere else.