### PR TITLE
fix(party-mode): decode subprocess JSON as UTF-8 on Windows

### DIFF
--- a/src/core-skills/bmad-party-mode/scripts/resolve_party.py
+++ b/src/core-skills/bmad-party-mode/scripts/resolve_party.py
@@ -46,7 +46,9 @@ except ImportError:  # pragma: no cover - guarded for <3.11
 def _run_json(cmd):
     """Run a resolver script and parse its JSON stdout. None on any failure."""
     try:
-        out = subprocess.run(cmd, capture_output=True, text=True, timeout=60)
+        out = subprocess.run(
+            cmd, capture_output=True, text=True, encoding="utf-8", timeout=60
+        )
     except (OSError, subprocess.SubprocessError):
         return None
     if out.returncode != 0 or not out.stdout.strip():


### PR DESCRIPTION
## What

Decode Party Mode resolver subprocess JSON explicitly as UTF-8.

## Why

The resolver emits UTF-8 JSON, including emoji, but Windows may otherwise decode it using a legacy locale such as cp1252.

This intentionally adds only the encoding argument. It does not guard empty stdout or catch `UnicodeDecodeError`: abnormal failures should preserve their Python exception and diagnostic context instead of being collapsed into the resolver's ordinary `None` result.

Fixes #2682

## Testing

No change-specific tests added. The repository quality gate passes.
