### PR TITLE
fix(forge-idea): decode persona resolver JSON as UTF-8

### DIFF
--- a/src/core-skills/bmad-forge-idea/scripts/resolve_personas.py
+++ b/src/core-skills/bmad-forge-idea/scripts/resolve_personas.py
@@ -48,7 +48,9 @@ PARTY_SKILL = "bmad-party-mode"
 def _run_json(cmd):
     """Run a resolver script and parse its JSON stdout. None on any failure."""
     try:
-        out = subprocess.run(cmd, capture_output=True, text=True, timeout=60)
+        out = subprocess.run(
+            cmd, capture_output=True, text=True, encoding="utf-8", timeout=60
+        )
     except (OSError, subprocess.SubprocessError):
         return None
     if out.returncode != 0 or not out.stdout.strip():


### PR DESCRIPTION
## What

Decode Forge Idea's persona resolver subprocess JSON explicitly as UTF-8.

## Why

`resolve_personas.py` consumes the same UTF-8 resolver output as Party Mode, including emoji-bearing customization data. On Windows, relying on the locale encoding can misdecode that output.

This intentionally adds only the encoding argument and preserves the existing exception behavior. Follow-up to #2687.

## Testing

No change-specific tests added. The repository quality gate passes.
