### PR TITLE
fix(installer): generate working OpenCode command pointers

### DIFF
--- a/test/test-installation-components.js
+++ b/test/test-installation-components.js
@@ -360,6 +360,7 @@ async function runTests() {
       commandContent.includes('@.agents/skills/bmad-master/SKILL.md'),
       'Command pointer body references the installed skill via @<target_dir>/<canonicalId>/SKILL.md',
     );
+    assert(!commandContent.includes('@skills/bmad-master'), 'Command pointer does not use the legacy @skills/<canonicalId> namespace');
     assert(commandContent.includes('description:'), 'Command pointer carries a description in YAML frontmatter');
 
     // Idempotency: re-running install must not duplicate or rewrite pointers.

--- a/test/test-installation-components.js
+++ b/test/test-installation-components.js
@@ -356,7 +356,10 @@ async function runTests() {
     assert(await fs.pathExists(commandFile), 'OpenCode install writes per-skill command pointer file');
 
     const commandContent = await fs.readFile(commandFile, 'utf8');
-    assert(commandContent.includes('@skills/bmad-master'), 'Command pointer body references the skill via @skills/<canonicalId>');
+    assert(
+      commandContent.includes('@.agents/skills/bmad-master/SKILL.md'),
+      'Command pointer body references the installed skill via @<target_dir>/<canonicalId>/SKILL.md',
+    );
     assert(commandContent.includes('description:'), 'Command pointer carries a description in YAML frontmatter');
 
     // Idempotency: re-running install must not duplicate or rewrite pointers.

--- a/tools/installer/ide/_config-driven.js
+++ b/tools/installer/ide/_config-driven.js
@@ -53,9 +53,14 @@ function isSafeCanonicalId(value) {
 }
 
 // Default body template for command pointer files. Used when a platform's
-// installer config doesn't override `commands_body_template`. Matches
-// OpenCode's native `@skills/<id>` skill-reference syntax.
-const DEFAULT_COMMANDS_BODY_TEMPLATE = '@skills/{canonicalId}';
+// installer config doesn't override `commands_body_template`.
+//
+// OpenCode (the only platform that relies on this default today) resolves
+// `@` references in command bodies as file paths relative to the project
+// worktree root — there is no `@skills/<id>` skill-reference namespace.
+// Pointers therefore reference the installed skill file directly so
+// `/<canonicalId>` expands the full SKILL.md content.
+const DEFAULT_COMMANDS_BODY_TEMPLATE = '@{target_dir}/{canonicalId}/SKILL.md';
 
 // Is this skill a persona agent (vs. a workflow/tool/standalone skill)?
 // Used by platforms that surface only persona agents (e.g. Copilot's Custom
@@ -266,8 +271,10 @@ class ConfigDrivenIdeSetup {
    * Generate per-skill command pointer files for IDEs that surface commands
    * separately from skills (e.g. OpenCode's `.opencode/commands/<name>.md`).
    *
-   * Each pointer is a tiny markdown file whose body is `@skills/<canonicalId>`
-   * so invoking `/<canonicalId>` routes the user straight to the skill instead
+   * Each pointer is a tiny markdown file whose body is
+   * `@{target_dir}/{canonicalId}/SKILL.md` — an OpenCode `@` file reference
+   * resolved relative to the project worktree root — so invoking
+   * `/<canonicalId>` routes the user straight to the skill content instead
    * of forcing them through a `/skills` menu.
    *
    * Skips:

--- a/tools/installer/ide/platform-codes.yaml
+++ b/tools/installer/ide/platform-codes.yaml
@@ -259,6 +259,11 @@ platforms:
       target_dir: .agents/skills
       global_target_dir: ~/.agents/skills
       commands_target_dir: .opencode/commands
+      # OpenCode resolves `@` references in command bodies as file paths
+      # relative to the project worktree root; there is no `@skills/<id>`
+      # namespace. Pointers reference the installed SKILL.md directly so
+      # `/<canonicalId>` expands the full skill content.
+      commands_body_template: "@{target_dir}/{canonicalId}/SKILL.md"
 
   openhands:
     name: "OpenHands"


### PR DESCRIPTION
## Summary

Fixes opencode integration: the command pointers generated by the installer reference skills using `@skills/<id>` syntax, which **opencode does not support**. opencode resolves `@` references as file paths relative to the project root (`packages/opencode/src/config/markdown.ts` `FILE_REGEX`, `packages/opencode/src/session/prompt.ts` `resolvePromptParts`) — there is no `@skills/` namespace. As a result, no skill content is ever injected into the prompt; the LLM must rediscover the skill by agentic file exploration (non-deterministic, and a no-op for non-agentic editors).

This PR changes the installer's default command-pointer body template to emit a **real relative path** (`@{target_dir}/{canonicalId}/SKILL.md`), which opencode resolves correctly.

Related issues:
- #1956 ([BUG] opencode does not load any skills involving a `workflow.md` in the skill folder) — likely the same root cause: skill content never reaches the prompt.
- #2319 ([BUG] Bmad is not working on OpenCode CLI) — closed; this PR addresses the underlying pointer/syntax problem.

## What changed

- `tools/installer/ide/_config-driven.js`
  - `DEFAULT_COMMANDS_BODY_TEMPLATE`: `@skills/{canonicalId}` → `@{target_dir}/{canonicalId}/SKILL.md`
  - `{target_dir}` was already supported by `expandBodyTemplate` (lines 96–97); only the default template and comments were wrong.
  - Corrected misleading comments that claimed `@skills/<id>` "matches OpenCode's native syntax".
- `tools/installer/ide/platform-codes.yaml`
  - opencode entry: added `commands_body_template: "@{target_dir}/{canonicalId}/SKILL.md"` + explanatory comment.
- `test/test-installation-components.js` (Suite 8)
  - Assertion updated to expect `@.agents/skills/bmad-master/SKILL.md`.

## Verification

All green:
- `node test/test-installation-components.js` — all suites pass (incl. updated Suite 8)
- `npm run lint`, `npx prettier --check`, `npm run format:check`
- full `npm test` (test:refs / test:install / test:urls / test:channels / test:renderer / test:retrospective / test:sprint-planning / test:skills / lint / lint:md / format:check)

End-to-end repro with the generated pointer (opencode CLI 1.18.14):

1. Fresh install generates pointer body `@.agents/skills/bmad-master/SKILL.md` (was `@skills/bmad-master`).
2. `opencode run --command bmad-master` → skill marker `PR_MARKER_LOADED_9f2c` seen in the session: content is injected.
3. Proof the reference is resolved as a file: a pointer targeting `pointer-target.md` produced its marker `FROM_POINTER_bbb` in the session.
4. Negative control: the old `@skills/bmad-master` body injected **nothing** — the model had to agentically `Read _bmad/_config/skill-manifest.csv` and the SKILL.md itself to "discover" the skill.
5. Without any pointer, the skill-registered command failed in the CLI (`UnknownError: Unexpected server error`), while a plain `hello.md` command worked — the failure is specific to skill-backed commands.

## Migration note (existing installs)

`commands_body_template` only takes effect on a fresh or re-run install; pointer files that already exist are not rewritten (existing content is respected, and the generator's reserved-guard skips files it doesn't own). Existing opencode installs with old `@skills/<id>` pointers must delete the stale files in `commands_target_dir` (`remove-command-pointers` / manual deletion) and re-run the installer.
