### PR TITLE
fix: pin UTF-8 stdout in resolve_config so Windows cp1252 doesn't crash

### DIFF
--- a/src/scripts/resolve_config.py
+++ b/src/scripts/resolve_config.py
@@ -34,6 +34,14 @@ def extract_key(data, dotted_key: str):
     return current
 
 
+def write_json_stdout(output) -> None:
+    """Pin stdout to UTF-8 — a Windows cp1252 default cannot encode emoji icons."""
+    reconfigure = getattr(sys.stdout, "reconfigure", None)
+    if reconfigure is not None:
+        reconfigure(encoding="utf-8")
+    sys.stdout.write(json.dumps(output, indent=2, ensure_ascii=False) + "\n")
+
+
 def main() -> int:
     parser = argparse.ArgumentParser(
         description="Resolve BMad central config using four-layer TOML merge."
@@ -66,7 +74,7 @@ def main() -> int:
             value = extract_key(merged, key)
             if value is not _MISSING:
                 output[key] = value
-    sys.stdout.write(json.dumps(output, indent=2, ensure_ascii=False) + "\n")
+    write_json_stdout(output)
     return 0
 
 

--- a/src/scripts/tests/test_resolve_config.py
+++ b/src/scripts/tests/test_resolve_config.py
@@ -1,4 +1,5 @@
 import json
+import os
 import shutil
 import subprocess
 import sys
@@ -73,6 +74,33 @@ class ResolveConfigCliTests(unittest.TestCase):
             result = self._run(root)
             self.assertNotEqual(result.returncode, 0)
             self.assertIn("failed to parse", result.stderr)
+
+    def test_writes_emoji_json_when_stdout_encoding_is_cp1252(self):
+        with tempfile.TemporaryDirectory() as temp_dir:
+            root = Path(temp_dir)
+            (root / "_bmad").mkdir(parents=True)
+            (root / "_bmad" / "config.toml").write_text(
+                '[agents]\nname = "Analyst"\nicon = "📊"\n',
+                encoding="utf-8",
+            )
+
+            env = os.environ.copy()
+            env["PYTHONIOENCODING"] = "cp1252"
+            result = subprocess.run(
+                [sys.executable, str(SCRIPT), "--project-root", str(root)],
+                stdout=subprocess.PIPE,
+                stderr=subprocess.PIPE,
+                env=env,
+                check=False,
+            )
+
+            stderr = result.stderr.decode("utf-8", errors="replace")
+            self.assertEqual(result.returncode, 0, msg=stderr)
+
+            output = result.stdout.decode("utf-8")
+            self.assertIn("📊", output)
+            resolved = json.loads(output)
+            self.assertEqual(resolved["agents"]["icon"], "📊")
 
     @staticmethod
     def _run(root: Path, *args: str) -> subprocess.CompletedProcess[str]:


### PR DESCRIPTION
## What

Pins `resolve_config.py`'s stdout to UTF-8 before the JSON dump, and adds the stdout regression test the suite was missing.

## Why

The full-config dump writes `ensure_ascii=False` JSON to a stdout still bound to the platform default. On Windows that is cp1252, which cannot encode the emoji icons in the shipped agent configs, so the script raises `UnicodeEncodeError` and exits having produced no output.

Fixes #2682

That issue was auto-closed by #2687, but #2687 changed only the **consumer** side (`encoding="utf-8"` on party mode's `subprocess.run`). That governs how the parent decodes the child's bytes; it does not change the child's stdout encoding, so the producer still raises before writing anything and `_run_json` still sees a non-zero exit. Verified still reproducible on `main`.

## How

- Adopt `write_json_stdout()` verbatim from the sibling `resolve_customization.py`, which already guards the identical write (fixed in #2414).
- Add `test_writes_emoji_json_when_stdout_encoding_is_cp1252`, mirroring the existing test of the same name in `test_resolve_customization.py`. The issue noted the suite never exercised the stdout path — it does now.

## Testing

`npm run test:renderer` → 11 tests, OK. The new test fails against the unpatched script (confirmed by reverting the fix and re-running), so it is a real tripwire.

## Note on #2578

@aranellaeth's #2578 proposed this same `resolve_config.py` guard back on 2026-07-12 and deserves the credit. Its consumer hunks have since been merged piecemeal (#2687 party mode, #2688 forge-idea), leaving the producer fix — the part that actually closes #2682 — outstanding. This PR is deliberately scoped to just that piece plus its test, so it can land independently; close it in favour of #2578 if you would rather merge that whole.

One review note for whichever lands: `reconfigure(encoding="utf-8")` without `errors=` also resets the handler to `strict`. Harmless for stdout (this PR), but #2578 also reconfigures **stderr** in `brain.py`, which silently downgrades POSIX's default `backslashreplace` — a surrogateescaped path in an error message would turn a clean diagnostic into a traceback. Passing `errors=stream.errors` preserves it.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
