### PR TITLE
fix(installer): stop copying __pycache__ into IDE skill trees

### DIFF
--- a/test/test-installation-components.js
+++ b/test/test-installation-components.js
@@ -420,6 +420,11 @@ async function runTests() {
 
     const tempProjectDir9 = await fs.mkdtemp(path.join(os.tmpdir(), 'bmad-claude-code-test-'));
     const installedBmadDir9 = await createTestBmadFixture();
+    const sourceSkillDir9 = path.join(installedBmadDir9, 'core', 'bmad-master');
+    await fs.ensureDir(path.join(sourceSkillDir9, '__pycache__'));
+    await fs.writeFile(path.join(sourceSkillDir9, '__pycache__', 'cached.pyc'), 'bytecode');
+    await fs.writeFile(path.join(sourceSkillDir9, 'cached.pyc'), 'bytecode');
+    await fs.writeFile(path.join(sourceSkillDir9, 'cached.pyo'), 'bytecode');
 
     const ideManager9 = new IdeManager();
     await ideManager9.ensureInitialized();
@@ -432,6 +437,16 @@ async function runTests() {
 
     const skillFile9 = path.join(tempProjectDir9, '.claude', 'skills', 'bmad-master', 'SKILL.md');
     assert(await fs.pathExists(skillFile9), 'Claude Code install writes SKILL.md directory output');
+    const installedSkillDir9 = path.dirname(skillFile9);
+    assert(
+      !(await fs.pathExists(path.join(installedSkillDir9, '__pycache__'))),
+      'Claude Code skill install excludes Python cache directories',
+    );
+    assert(
+      !(await fs.pathExists(path.join(installedSkillDir9, 'cached.pyc'))) &&
+        !(await fs.pathExists(path.join(installedSkillDir9, 'cached.pyo'))),
+      'Claude Code skill install excludes Python bytecode',
+    );
 
     // Verify name frontmatter matches directory name
     const skillContent9 = await fs.readFile(skillFile9, 'utf8');
@@ -4033,52 +4048,6 @@ async function runTests() {
     console.log(`${colors.red}Test Suite 52 setup failed: ${error.message}${colors.reset}`);
     console.log(error.stack);
     failed++;
-  }
-
-  console.log('');
-
-  // ============================================================
-  // Test 53: Skill copy excludes Python bytecode caches
-  // ============================================================
-  console.log(`${colors.yellow}Test Suite 53: Skill Copy Artifact Filtering${colors.reset}\n`);
-
-  try {
-    const { shouldSkipSkillArtifact } = require('../tools/installer/ide/_config-driven');
-
-    assert(shouldSkipSkillArtifact('__pycache__') === true, '__pycache__ directory is treated as an artifact');
-    assert(shouldSkipSkillArtifact('sprint_plan.cpython-311.pyc') === true, '.pyc files are treated as artifacts');
-    assert(shouldSkipSkillArtifact('.DS_Store') === true, 'existing OS artifact filtering is preserved');
-    assert(shouldSkipSkillArtifact('.gitkeep') === false, '.gitkeep remains copyable');
-    assert(shouldSkipSkillArtifact('sprint_plan.py') === false, 'Python sources remain copyable');
-    assert(shouldSkipSkillArtifact('SKILL.md') === false, 'skill content remains copyable');
-
-    // End-to-end: a cache planted in the source tree must not reach the skill tree.
-    const tempProjectDir53 = await fs.mkdtemp(path.join(os.tmpdir(), 'bmad-pycache-test-'));
-    const installedBmadDir53 = await createTestBmadFixture();
-
-    const sourceScripts53 = path.join(installedBmadDir53, 'core', 'bmad-master', 'scripts');
-    await fs.ensureDir(path.join(sourceScripts53, '__pycache__'));
-    await fs.writeFile(path.join(sourceScripts53, 'helper.py'), 'print("hello")\n');
-    await fs.writeFile(path.join(sourceScripts53, '__pycache__', 'helper.cpython-311.pyc'), 'bytecode');
-
-    const ideManager53 = new IdeManager();
-    await ideManager53.ensureInitialized();
-    const result53 = await ideManager53.setup('claude-code', tempProjectDir53, installedBmadDir53, {
-      silent: true,
-      selectedModules: ['core'],
-    });
-
-    assert(result53.success === true, 'claude-code setup succeeds against temp project');
-
-    const installedSkill53 = path.join(tempProjectDir53, '.claude', 'skills', 'bmad-master');
-    assert(await fs.pathExists(path.join(installedSkill53, 'SKILL.md')), 'skill content is installed');
-    assert(await fs.pathExists(path.join(installedSkill53, 'scripts', 'helper.py')), 'Python sources are installed');
-    assert(!(await fs.pathExists(path.join(installedSkill53, 'scripts', '__pycache__'))), '__pycache__ is not copied into the skill tree');
-
-    await fs.remove(tempProjectDir53);
-    await fs.remove(path.dirname(installedBmadDir53));
-  } catch (error) {
-    assert(false, 'skill copy excludes Python bytecode caches', error.message);
   }
 
   console.log('');

--- a/test/test-installation-components.js
+++ b/test/test-installation-components.js
@@ -4038,6 +4038,52 @@ async function runTests() {
   console.log('');
 
   // ============================================================
+  // Test 53: Skill copy excludes Python bytecode caches
+  // ============================================================
+  console.log(`${colors.yellow}Test Suite 53: Skill Copy Artifact Filtering${colors.reset}\n`);
+
+  try {
+    const { shouldSkipSkillArtifact } = require('../tools/installer/ide/_config-driven');
+
+    assert(shouldSkipSkillArtifact('__pycache__') === true, '__pycache__ directory is treated as an artifact');
+    assert(shouldSkipSkillArtifact('sprint_plan.cpython-311.pyc') === true, '.pyc files are treated as artifacts');
+    assert(shouldSkipSkillArtifact('.DS_Store') === true, 'existing OS artifact filtering is preserved');
+    assert(shouldSkipSkillArtifact('.gitkeep') === false, '.gitkeep remains copyable');
+    assert(shouldSkipSkillArtifact('sprint_plan.py') === false, 'Python sources remain copyable');
+    assert(shouldSkipSkillArtifact('SKILL.md') === false, 'skill content remains copyable');
+
+    // End-to-end: a cache planted in the source tree must not reach the skill tree.
+    const tempProjectDir53 = await fs.mkdtemp(path.join(os.tmpdir(), 'bmad-pycache-test-'));
+    const installedBmadDir53 = await createTestBmadFixture();
+
+    const sourceScripts53 = path.join(installedBmadDir53, 'core', 'bmad-master', 'scripts');
+    await fs.ensureDir(path.join(sourceScripts53, '__pycache__'));
+    await fs.writeFile(path.join(sourceScripts53, 'helper.py'), 'print("hello")\n');
+    await fs.writeFile(path.join(sourceScripts53, '__pycache__', 'helper.cpython-311.pyc'), 'bytecode');
+
+    const ideManager53 = new IdeManager();
+    await ideManager53.ensureInitialized();
+    const result53 = await ideManager53.setup('claude-code', tempProjectDir53, installedBmadDir53, {
+      silent: true,
+      selectedModules: ['core'],
+    });
+
+    assert(result53.success === true, 'claude-code setup succeeds against temp project');
+
+    const installedSkill53 = path.join(tempProjectDir53, '.claude', 'skills', 'bmad-master');
+    assert(await fs.pathExists(path.join(installedSkill53, 'SKILL.md')), 'skill content is installed');
+    assert(await fs.pathExists(path.join(installedSkill53, 'scripts', 'helper.py')), 'Python sources are installed');
+    assert(!(await fs.pathExists(path.join(installedSkill53, 'scripts', '__pycache__'))), '__pycache__ is not copied into the skill tree');
+
+    await fs.remove(tempProjectDir53);
+    await fs.remove(path.dirname(installedBmadDir53));
+  } catch (error) {
+    assert(false, 'skill copy excludes Python bytecode caches', error.message);
+  }
+
+  console.log('');
+
+  // ============================================================
   // Summary
   // ============================================================
   console.log(`${colors.cyan}========================================`);

--- a/tools/installer/ide/_config-driven.js
+++ b/tools/installer/ide/_config-driven.js
@@ -125,23 +125,6 @@ function looksLikeGeneratorOutput(content, canonicalId, { template, targetDir })
   return true;
 }
 
-// Artifacts that must never reach a user's skill tree: OS/editor leftovers and
-// Python bytecode caches built on the maintainer's machine. Mirrors the policy
-// Installer._installSharedScripts already applies to _bmad/scripts.
-const SKILL_ARTIFACT_NAMES = new Set(['.DS_Store', 'Thumbs.db', 'desktop.ini', '__pycache__']);
-const SKILL_ARTIFACT_SUFFIXES = ['~', '.swp', '.swo', '.bak', '.pyc', '.pyo'];
-
-/**
- * Whether a file or directory basename is a build/editor artifact rather than skill content.
- * @param {string} name - Basename of the candidate path
- * @returns {boolean} True when the entry must not be copied into a skill tree
- */
-function shouldSkipSkillArtifact(name) {
-  if (SKILL_ARTIFACT_NAMES.has(name)) return true;
-  if (name.startsWith('.') && name !== '.gitkeep') return true;
-  return SKILL_ARTIFACT_SUFFIXES.some((suffix) => name.endsWith(suffix));
-}
-
 /**
  * Config-driven IDE setup handler
  *
@@ -466,7 +449,16 @@ class ConfigDrivenIdeSetup {
       this.skillWriteTracker?.add(canonicalId);
 
       // Copy all skill files, filtering OS/editor artifacts and Python caches recursively
-      const filter = (src) => src === sourceDir || !shouldSkipSkillArtifact(path.basename(src));
+      const skipPatterns = new Set(['.DS_Store', 'Thumbs.db', 'desktop.ini', '__pycache__']);
+      const skipSuffixes = ['~', '.swp', '.swo', '.bak', '.pyc', '.pyo'];
+      const filter = (src) => {
+        const name = path.basename(src);
+        if (src === sourceDir) return true;
+        if (skipPatterns.has(name)) return false;
+        if (name.startsWith('.') && name !== '.gitkeep') return false;
+        if (skipSuffixes.some((s) => name.endsWith(s))) return false;
+        return true;
+      };
       await fs.copy(sourceDir, skillDir, { filter });
 
       count++;
@@ -977,4 +969,4 @@ class ConfigDrivenIdeSetup {
   }
 }
 
-module.exports = { ConfigDrivenIdeSetup, shouldSkipSkillArtifact };
+module.exports = { ConfigDrivenIdeSetup };

--- a/tools/installer/ide/_config-driven.js
+++ b/tools/installer/ide/_config-driven.js
@@ -125,6 +125,23 @@ function looksLikeGeneratorOutput(content, canonicalId, { template, targetDir })
   return true;
 }
 
+// Artifacts that must never reach a user's skill tree: OS/editor leftovers and
+// Python bytecode caches built on the maintainer's machine. Mirrors the policy
+// Installer._installSharedScripts already applies to _bmad/scripts.
+const SKILL_ARTIFACT_NAMES = new Set(['.DS_Store', 'Thumbs.db', 'desktop.ini', '__pycache__']);
+const SKILL_ARTIFACT_SUFFIXES = ['~', '.swp', '.swo', '.bak', '.pyc', '.pyo'];
+
+/**
+ * Whether a file or directory basename is a build/editor artifact rather than skill content.
+ * @param {string} name - Basename of the candidate path
+ * @returns {boolean} True when the entry must not be copied into a skill tree
+ */
+function shouldSkipSkillArtifact(name) {
+  if (SKILL_ARTIFACT_NAMES.has(name)) return true;
+  if (name.startsWith('.') && name !== '.gitkeep') return true;
+  return SKILL_ARTIFACT_SUFFIXES.some((suffix) => name.endsWith(suffix));
+}
+
 /**
  * Config-driven IDE setup handler
  *
@@ -448,17 +465,8 @@ class ConfigDrivenIdeSetup {
       await fs.ensureDir(skillDir);
       this.skillWriteTracker?.add(canonicalId);
 
-      // Copy all skill files, filtering OS/editor artifacts recursively
-      const skipPatterns = new Set(['.DS_Store', 'Thumbs.db', 'desktop.ini']);
-      const skipSuffixes = ['~', '.swp', '.swo', '.bak'];
-      const filter = (src) => {
-        const name = path.basename(src);
-        if (src === sourceDir) return true;
-        if (skipPatterns.has(name)) return false;
-        if (name.startsWith('.') && name !== '.gitkeep') return false;
-        if (skipSuffixes.some((s) => name.endsWith(s))) return false;
-        return true;
-      };
+      // Copy all skill files, filtering OS/editor artifacts and Python caches recursively
+      const filter = (src) => src === sourceDir || !shouldSkipSkillArtifact(path.basename(src));
       await fs.copy(sourceDir, skillDir, { filter });
 
       count++;
@@ -969,4 +977,4 @@ class ConfigDrivenIdeSetup {
   }
 }
 
-module.exports = { ConfigDrivenIdeSetup };
+module.exports = { ConfigDrivenIdeSetup, shouldSkipSkillArtifact };


### PR DESCRIPTION
## What

IDE skill copying now excludes `__pycache__` directories and `.pyc`/`.pyo` files, preventing Python bytecode from the npm package from reaching users' skill trees.

## Why

Fixes #2694. The published package currently contains maintainer-generated Python bytecode, and the IDE skill installer copies it into projects.

## How

- Extended the existing recursive skill-copy filter with Python cache names and suffixes.
- Added observable-behavior assertions to the existing Claude Code installation test for cache directories and root-level bytecode files.
- Kept Python source and tracked skill content behavior unchanged.

## Testing

`HUSKY=0 npm ci && npm run quality`
