### PR TITLE
feat(build): add direct and early one-shot routes

### DIFF
--- a/src/bmm-skills/ship/bmad-build/SKILL.md
+++ b/src/bmm-skills/ship/bmad-build/SKILL.md
@@ -3,11 +3,23 @@ name: bmad-build
 description: 'Implements any user intent, requirement, story, bug fix or change request by producing clean working code artifacts that follow the project''s existing architecture, patterns and conventions. Use when the user wants to build, fix, tweak, refactor, add or modify any code, component or feature.'
 ---
 
-Run the following command exactly once without changing the current working directory. Replace `{project-root}` with the absolute path to the project root and `{skill-root}` with the absolute path to this skill's directory:
+Before using any tool, choose the route. Take the direct route only for a **pointed edit**: the request pins the change to a bounded, colocated span in one file — a word, a phrase, a paragraph or two the user is evidently looking at — whether the user dictates the replacement ("change X to Y") or delegates its authoring within that span ("this paragraph is overprompted"). Applying dispositions from a findings list also qualifies, as does an explicit ask to skip the process. The tell: there is nothing to clarify — target and latitude are both pinned by the request.
+
+Never choose the direct route because a change merely looks trivial or low-risk; absent the tell, take the full route and let the workflow route after intent is clarified.
+
+Without changing the current working directory, run exactly one command. Replace `{project-root}` with the absolute project root and `{skill-root}` with this skill's absolute directory.
+
+Direct route:
+
+```bash
+uv run --no-cache "{project-root}/_bmad/scripts/render_skill.py" --project-root "{project-root}" --skill "{skill-root}" --route direct
+```
+
+Full route:
 
 ```bash
 uv run --no-cache "{project-root}/_bmad/scripts/render_skill.py" --project-root "{project-root}" --skill "{skill-root}"
 ```
 
-- On success, read and follow the one absolute `workflow.md` instruction printed to stdout.
+- On success, read and follow the one absolute instruction file printed to stdout.
 - On failure (including `uv` being unavailable), report the command output and HALT. Do not run any workflow source directly.

--- a/src/bmm-skills/ship/bmad-build/SKILL.md
+++ b/src/bmm-skills/ship/bmad-build/SKILL.md
@@ -3,16 +3,26 @@ name: bmad-build
 description: 'Implements any user intent, requirement, story, bug fix or change request by producing clean working code artifacts that follow the project''s existing architecture, patterns and conventions. Use when the user wants to build, fix, tweak, refactor, add or modify any code, component or feature.'
 ---
 
-Before using any tool, choose the route. Take the direct route only for a **pointed edit**: the request pins the change to a bounded, colocated span in one file — a word, a phrase, a paragraph or two the user is evidently looking at — whether the user dictates the replacement ("change X to Y") or delegates its authoring within that span ("this paragraph is overprompted"). Applying dispositions from a findings list also qualifies, as does an explicit ask to skip the process. The tell: there is nothing to clarify — target and latitude are both pinned by the request.
+Before using any tool, choose one initial behavior: direct route, early one-shot probe, or full route. Take the direct route only for a **pointed edit**: the request pins the change to a bounded, colocated span in one file — a word, a phrase, a paragraph or two the user is evidently looking at — whether the user dictates the replacement ("change X to Y") or delegates its authoring within that span ("this paragraph is overprompted"). Applying dispositions from a findings list also qualifies, as does an explicit ask to skip the process. The tell: there is nothing to clarify — target and latitude are both pinned by the request.
 
-Never choose the direct route because a change merely looks trivial or low-risk; absent the tell, take the full route and let the workflow route after intent is clarified.
+Never choose the direct route because a change merely looks trivial or low-risk.
 
-Without changing the current working directory, run exactly one command. Replace `{project-root}` with the absolute project root and `{skill-root}` with this skill's absolute directory.
+For a clear, explicit, single-goal **new implementation request** that is not a request to resume or act on an existing spec, story, or BMAD artifact, probe for the one-shot route before rendering anything: inspect only the relevant source, tests, and call sites needed to understand the affected surface and plausible consequences. Include the version-control sanity check in the same tool call where practical. If the tree is dirty or the branch is an obvious mismatch, HALT and ask the human before proceeding. Do not scan BMAD artifacts during this probe. The request alone cannot establish one-shot eligibility; the source investigation must do that.
+
+After the probe, take the early one-shot route only when the intent remains clear, no architectural decision is needed, and the evidence shows zero blast radius — no plausible path by which the change causes unintended consequences elsewhere. Otherwise take the full route and carry the probe's findings forward rather than repeating its investigation. For every other request, take the full route immediately.
+
+Once the route is chosen, run exactly one renderer command without changing the current working directory. Replace `{project-root}` with the absolute project root and `{skill-root}` with this skill's absolute directory.
 
 Direct route:
 
 ```bash
 uv run --no-cache "{project-root}/_bmad/scripts/render_skill.py" --project-root "{project-root}" --skill "{skill-root}" --route direct
+```
+
+Early one-shot route, after the probe qualifies it:
+
+```bash
+uv run --no-cache "{project-root}/_bmad/scripts/render_skill.py" --project-root "{project-root}" --skill "{skill-root}" --route one-shot
 ```
 
 Full route:
@@ -21,5 +31,5 @@ Full route:
 uv run --no-cache "{project-root}/_bmad/scripts/render_skill.py" --project-root "{project-root}" --skill "{skill-root}"
 ```
 
-- On success, follow what stdout gives you: the direct route prints its instructions inline — act on them without reading anything further; the full route prints one absolute instruction file to read and follow.
+- On success, follow what stdout gives you: the direct and early one-shot routes print their instructions inline — act on them without reading anything further; the full route prints one absolute instruction file to read and follow.
 - On failure (including `uv` being unavailable), report the command output and HALT. Do not run any workflow source directly.

--- a/src/bmm-skills/ship/bmad-build/SKILL.md
+++ b/src/bmm-skills/ship/bmad-build/SKILL.md
@@ -21,5 +21,5 @@ Full route:
 uv run --no-cache "{project-root}/_bmad/scripts/render_skill.py" --project-root "{project-root}" --skill "{skill-root}"
 ```
 
-- On success, read and follow the one absolute instruction file printed to stdout.
+- On success, follow what stdout gives you: the direct route prints its instructions inline — act on them without reading anything further; the full route prints one absolute instruction file to read and follow.
 - On failure (including `uv` being unavailable), report the command output and HALT. Do not run any workflow source directly.

--- a/src/bmm-skills/ship/bmad-build/customize.toml
+++ b/src/bmm-skills/ship/bmad-build/customize.toml
@@ -18,7 +18,7 @@
 direct_route = """
 Apply the pointed edit immediately — the edit is your first action, before any commentary — then acknowledge in one line. Treat each subsequent message that is itself a pointed edit as the next iteration of this loop: apply it the same way, without re-running triage or the render command. Keep every edit inside its pointed span.
 
-Do not commit per edit. When the conversation moves off pointed edits, or the user says they are done, commit the loop's edited files with a one-line Conventional Commit message and mention the commit in a single parenthetical while handling whatever the user asked next.
+Do not commit per edit. When the conversation moves off pointed edits, or the user says they are done, commit the loop's edited files with a one-line Conventional Commit message. Commit before you start the next request or leave this route — the loop owns these edits, and whatever runs next must find a clean tree. Mention the commit in a single parenthetical while handling whatever the user asked next.
 """
 
 # Reviewer for direct-route edits that touch code. The whole execution

--- a/src/bmm-skills/ship/bmad-build/customize.toml
+++ b/src/bmm-skills/ship/bmad-build/customize.toml
@@ -12,6 +12,30 @@
 
 [workflow]
 
+# Recipe for the direct route: an interactive editing loop over pointed edits
+# (see SKILL.md for the trigger).
+
+direct_route = """
+Apply the pointed edit immediately — the edit is your first action, before any commentary — then acknowledge in one line. Treat each subsequent message that is itself a pointed edit as the next iteration of this loop: apply it the same way, without re-running triage or the render command. Keep every edit inside its pointed span.
+
+Do not commit per edit. When the conversation moves off pointed edits, or the user says they are done, commit the loop's edited files with a one-line Conventional Commit message and mention the commit in a single parenthetical while handling whatever the user asked next.
+"""
+
+# Reviewer for direct-route edits that touch code. The whole execution
+# recipe — a subagent by default, but an override may run anything.
+# {diff_output} is substituted at run time.
+
+direct_review = """
+Launch a context-free subagent with this prompt:
+
+Review this diff. Report ONLY merge-blocking issues: incorrect behavior, data loss, or security. Silence is a valid result — if nothing rises to that bar, reply "No blocking issues." Do not report style, naming, structure, or improvement suggestions.
+
+DIFF:
+{diff_output}
+
+Do not invoke any skill. Return only the review result.
+"""
+
 # Extra instructions to run before config is loaded and before the user is greeted.
 
 activation_steps_prepend = []

--- a/src/bmm-skills/ship/bmad-build/route-direct.md
+++ b/src/bmm-skills/ship/bmad-build/route-direct.md
@@ -19,4 +19,4 @@ When an edit in this loop touches code — a file a machine executes or parses f
 
 ## ESCALATION
 
-If an edit needs to reach beyond its pointed span — another section, a second file, a decision the user did not pin — or any direct-route tell from SKILL.md stops holding, stop editing. Keep what you learned, then read fully and follow `[[bmad-snapshot:workflow.md]]`.
+If an edit needs to reach beyond its pointed span — another section, a second file, a decision the user did not pin — or any direct-route tell from SKILL.md stops holding, stop editing. Commit the loop's edits as above before handing over. Keep what you learned, then read fully and follow `[[bmad-snapshot:workflow.md]]`.

--- a/src/bmm-skills/ship/bmad-build/route-direct.md
+++ b/src/bmm-skills/ship/bmad-build/route-direct.md
@@ -1,0 +1,22 @@
+# Direct Build Route
+
+## RULES
+
+- **Language** — Speak in `{{.communication_language}}`. Write any file output in `{{.document_output_language}}`.
+- NEVER push.
+
+## THE LOOP
+
+This route is an interactive editing loop, not a pipeline: the user is watching the file on screen and is the review process.
+
+{workflow.direct_route}
+
+## CODE REVIEW
+
+When an edit in this loop touches code — a file a machine executes or parses for behavior, not prose, prompts, or docs — run the review below after the edit lands, with `{diff_output}` set to the diff of that edit. Fix or surface anything it returns; drop everything else silently — no classification, no deferred-work entries, no spec trace.
+
+{workflow.direct_review}
+
+## ESCALATION
+
+If an edit needs to reach beyond its pointed span — another section, a second file, a decision the user did not pin — or any direct-route tell from SKILL.md stops holding, stop editing. Keep what you learned, then read fully and follow `[[bmad-snapshot:workflow.md]]`.

--- a/src/bmm-skills/ship/bmad-build/route-one-shot.md
+++ b/src/bmm-skills/ship/bmad-build/route-one-shot.md
@@ -9,9 +9,11 @@
 
 ## INSTRUCTIONS
 
+If `spec_file` is unset, derive a valid kebab-case slug from the clarified intent. If the intent references a tracking identifier, lead the slug with it. Append `-2`, `-3`, etc. if needed to avoid an existing file, and set `spec_file` = `{{.implementation_artifacts}}/spec-{slug}.md`.
+
 ### Implement
 
-Follow `[[bmad-snapshot:sync-sprint-status.md]]` with `target_status` = `in-progress`.
+Only if `story_key` is set, follow `[[bmad-snapshot:sync-sprint-status.md]]` with `target_status` = `in-progress`. Otherwise do not read that file.
 
 Implement the clarified intent directly.
 
@@ -42,13 +44,15 @@ If a finding is caused by this change but too significant for a trivial patch, H
 
 Set `title` = a concise title derived from the clarified intent.
 
+Ensure the parent directory of `{spec_file}` exists.
+
 Write `{spec_file}` using `[[bmad-snapshot:spec-template.md]]`. Fill only these sections — delete all others:
 
 1. **Frontmatter** — set `title: '{title}'`, `type`, `created`, `status: 'done'`. Add `route: 'one-shot'`.
 2. **Title and Intent** — `# {title}` heading and `## Intent` with **Problem** and **Approach** lines. Reuse the summary you already generated for the terminal.
 3. **Suggested Review Order** — append after Intent. Build using the same convention as `[[bmad-snapshot:step-05-present.md]]` § "Generate Suggested Review Order" (spec-file-relative links, concern-based ordering, ultra-concise framing).
 
-Follow `[[bmad-snapshot:sync-sprint-status.md]]` with `target_status` = `review`.
+Only if `story_key` is set, follow `[[bmad-snapshot:sync-sprint-status.md]]` with `target_status` = `review`. Otherwise do not read that file.
 
 ### Commit
 

--- a/src/bmm-skills/ship/bmad-build/step-01-clarify-and-route.md
+++ b/src/bmm-skills/ship/bmad-build/step-01-clarify-and-route.md
@@ -100,7 +100,7 @@ If the spec is an epic story and `{{.implementation_artifacts}}/sprint-status.ya
 
    **b) One-shot** — zero blast radius: no plausible path by which this change causes unintended consequences elsewhere. Clear intent, no architectural decisions.
 
-   **EARLY EXIT** → `[[bmad-snapshot:step-oneshot.md]]`
+   **EARLY EXIT** → `[[bmad-snapshot:route-one-shot.md]]`
 
    **c) Plan-code-review** — everything else. When uncertain whether blast radius is truly zero, choose this path.
 

--- a/src/bmm-skills/ship/bmad-build/step-01-clarify-and-route.md
+++ b/src/bmm-skills/ship/bmad-build/step-01-clarify-and-route.md
@@ -1,5 +1,5 @@
 ---
-spec_file: '' # set at runtime for both routes before leaving this step
+spec_file: '' # set at runtime for every spec-producing route before leaving this step; stays unset on the direct route
 story_key: '' # set at runtime to the current story's full sprint-status key (e.g. 3-2-digest-delivery) when the intent is an epic story and sprint-status resolution succeeds
 ---
 
@@ -94,11 +94,15 @@ If the spec is an epic story and `{{.implementation_artifacts}}/sprint-status.ya
 
    If the explicit spec-folder-plus-story-id pair had no matching story file, keep the colocated `spec_file` selected above. Otherwise, derive a valid kebab-case slug from the clarified intent. If the intent references a tracking identifier (story number, issue number, ticket ID), lead the slug with it (e.g. `3-2-digest-delivery`, `gh-47-fix-auth`). If `{{.implementation_artifacts}}/spec-{slug}.md` already exists: if its status is `draft`, treat it as the same work and resume it (set `spec_file` to that path, **EARLY EXIT** → `[[bmad-snapshot:step-02-plan.md]]`); otherwise append `-2`, `-3`, etc. Set `spec_file` = `{{.implementation_artifacts}}/spec-{slug}.md`.
 
-   **a) One-shot** — zero blast radius: no plausible path by which this change causes unintended consequences elsewhere. Clear intent, no architectural decisions.
+   **a) Direct** — the clarified intent is a pointed edit (a bounded, colocated span in one file) or otherwise needs no planning and its full effect is visible in its diff. This route produces no spec: skip the slug/spec_file selection above and leave `spec_file` unset.
+
+   **EARLY EXIT** → `[[bmad-snapshot:route-direct.md]]`
+
+   **b) One-shot** — zero blast radius: no plausible path by which this change causes unintended consequences elsewhere. Clear intent, no architectural decisions.
 
    **EARLY EXIT** → `[[bmad-snapshot:step-oneshot.md]]`
 
-   **b) Plan-code-review** — everything else. When uncertain whether blast radius is truly zero, choose this path.
+   **c) Plan-code-review** — everything else. When uncertain whether blast radius is truly zero, choose this path.
 
 ## NEXT
 

--- a/src/scripts/render_skill.py
+++ b/src/scripts/render_skill.py
@@ -401,10 +401,20 @@ def main() -> int:
         reconfigure(encoding="utf-8")
     try:
         entry = render(Path(args.project_root), Path(args.skill), args.route)
+        # A route entry is a leaf recipe: spend its bytes here to spare the
+        # caller a read. The default entry stays a path — it heads a pipeline.
+        payload = (
+            entry.read_text(encoding="utf-8")
+            if entry.name.startswith("route-")
+            else None
+        )
     except (ConfigError, RenderError, OSError, UnicodeError, ValueError) as error:
         sys.stdout.write(f"HALT: {error}\n")
         return 1
-    sys.stdout.write(f"read and follow {entry}\n")
+    if payload is None:
+        sys.stdout.write(f"read and follow {entry}\n")
+    else:
+        sys.stdout.write(f"follow these instructions from {entry}\n\n{payload}")
     return 0
 
 

--- a/src/scripts/render_skill.py
+++ b/src/scripts/render_skill.py
@@ -405,7 +405,7 @@ def main() -> int:
         # caller a read. The default entry stays a path — it heads a pipeline.
         payload = (
             entry.read_text(encoding="utf-8")
-            if entry.name.startswith("route-")
+            if args.route not in (None, "workflow")
             else None
         )
     except (ConfigError, RenderError, OSError, UnicodeError, ValueError) as error:

--- a/src/scripts/render_skill.py
+++ b/src/scripts/render_skill.py
@@ -31,6 +31,7 @@ _CONFIG_TOKEN = re.compile(r"\{\{config\.([A-Za-z0-9_.-]+)\}\}")
 _SHORT_CONFIG_TOKEN = re.compile(r"\{\{\.([A-Za-z0-9_]+)\}\}")
 _CUSTOM_TOKEN = re.compile(r"\{workflow\.([A-Za-z0-9_.-]+)\}")
 _SNAPSHOT_TOKEN = re.compile(r"\[\[bmad-snapshot:([A-Za-z0-9_./-]+\.md)\]\]")
+_ROUTE_NAME = re.compile(r"^[a-z0-9-]+$")
 
 
 def _hash_bytes(content: bytes) -> str:
@@ -319,13 +320,22 @@ def _publish(destination: Path, outputs: dict[str, bytes], manifest: dict[str, A
             shutil.rmtree(staging, ignore_errors=True)
 
 
-def render(project_root: Path, skill_dir: Path) -> Path:
+def render(project_root: Path, skill_dir: Path, route: str | None = None) -> Path:
     project_root = project_root.resolve(strict=True)
     skill_dir = skill_dir.resolve(strict=True)
     if not (project_root / "_bmad").is_dir():
         raise RenderError(f"project root does not contain _bmad/: {project_root}")
 
+    if route is not None and _ROUTE_NAME.fullmatch(route) is None:
+        raise RenderError(f"invalid route name `{route}`; expected [a-z0-9-]+")
+    # `workflow` is reserved: it aliases the default entry, so the default
+    # path has exactly one source spelling.
+    entry_name = "workflow.md" if route in (None, "workflow") else f"route-{route}.md"
     sources = _load_sources(skill_dir)
+    if "route-workflow.md" in sources:
+        raise RenderError(f"reserved route source present: {skill_dir / 'route-workflow.md'}")
+    if entry_name not in sources:
+        raise RenderError(f"render entry is missing: {skill_dir / entry_name}")
     central = load_central_config(project_root)
     has_customization = any(
         _CUSTOM_TOKEN.search(content) for content in sources.values()
@@ -377,19 +387,20 @@ def render(project_root: Path, skill_dir: Path) -> Path:
         "outputs": output_hashes,
     }
     _publish(destination, outputs, manifest)
-    return destination / "workflow.md"
+    return destination / entry_name
 
 
 def main() -> int:
     parser = argparse.ArgumentParser(description=__doc__)
     parser.add_argument("--project-root", required=True)
     parser.add_argument("--skill", required=True)
+    parser.add_argument("--route")
     args = parser.parse_args()
     reconfigure = getattr(sys.stdout, "reconfigure", None)
     if reconfigure is not None:
         reconfigure(encoding="utf-8")
     try:
-        entry = render(Path(args.project_root), Path(args.skill))
+        entry = render(Path(args.project_root), Path(args.skill), args.route)
     except (ConfigError, RenderError, OSError, UnicodeError, ValueError) as error:
         sys.stdout.write(f"HALT: {error}\n")
         return 1

--- a/test/test-build-auto-renderer.js
+++ b/test/test-build-auto-renderer.js
@@ -98,6 +98,28 @@ function run(fix, cwd = fix.project) {
   );
 }
 
+function runRoute(fix, route, cwd = fix.project) {
+  return spawnSync(
+    'uv',
+    [
+      'run',
+      '--python',
+      '3.11',
+      path.join(fix.bmad, 'scripts', 'render_skill.py'),
+      '--project-root',
+      fix.project,
+      '--skill',
+      fix.skill,
+      '--route',
+      route,
+    ],
+    {
+      cwd,
+      encoding: 'utf8',
+    },
+  );
+}
+
 function runAsync(fix) {
   return new Promise((resolve) => {
     const child = spawn(
@@ -347,6 +369,40 @@ async function main() {
     assert(fs.existsSync(path.join(path.dirname(output), 'step.md')), 'generic skill source missing');
   });
 
+  test('route dispatch reuses the no-route snapshot and selects its named entry', () => {
+    const routed = fixture({ skillName: 'bmad-build' });
+    const workflow = entry(run(routed));
+    const direct = entry(runRoute(routed, 'direct'));
+    assert(path.basename(workflow) === 'workflow.md', 'no-route dispatch changed');
+    assert(path.basename(direct) === 'route-direct.md', 'named route was not dispatched');
+    assert(path.dirname(direct) === path.dirname(workflow), 'route changed snapshot identity');
+    assert(fs.existsSync(workflow) && fs.existsSync(direct), 'snapshot does not serve both entries');
+  });
+
+  test('invalid and missing routes HALT without publishing a dispatch', () => {
+    const routed = fixture({ skillName: 'bmad-build' });
+    for (const invalid of ['Direct', '../direct', 'direct_route', '']) {
+      const result = runRoute(routed, invalid);
+      assert(result.status !== 0 && result.stdout.includes('invalid route name'), `invalid route accepted: ${invalid}`);
+      assert(!result.stdout.includes('read and follow') && !result.stderr.includes('Traceback'), `invalid route leaked: ${invalid}`);
+    }
+    const missing = runRoute(routed, 'missing');
+    assert(missing.status !== 0 && missing.stdout.includes('route-missing.md'), 'missing route source accepted');
+    assert(!missing.stdout.includes('read and follow') && !missing.stderr.includes('Traceback'), 'missing route leaked dispatch');
+  });
+
+  test('the reserved workflow route aliases the default entry', () => {
+    const routed = fixture({ skillName: 'bmad-build' });
+    const aliased = entry(runRoute(routed, 'workflow'));
+    assert(path.basename(aliased) === 'workflow.md', 'workflow alias did not dispatch the default entry');
+    assert(aliased === entry(run(routed)), 'workflow alias diverged from the no-route dispatch');
+    fs.writeFileSync(path.join(routed.skill, 'route-workflow.md'), '# reserved\n', 'utf8');
+    for (const result of [run(routed), runRoute(routed, 'workflow')]) {
+      assert(result.status !== 0 && result.stdout.includes('reserved route source'), 'reserved route source accepted');
+      assert(!result.stdout.includes('read and follow') && !result.stderr.includes('Traceback'), 'reserved route leaked dispatch');
+    }
+  });
+
   test('ambiguous shorthand config and source symlink escapes HALT', () => {
     const invalid = fixture({ config: baseConfig('communication_language = "German"') });
     let result = run(invalid);
@@ -500,17 +556,41 @@ async function main() {
     }
   });
 
-  test('the command shipped in SKILL.md dispatches for both skills', () => {
+  test('direct route resolves its customizable recipe', () => {
+    const build = fixture({ skillName: 'bmad-build' });
+    fs.mkdirSync(path.join(build.bmad, 'custom'), { recursive: true });
+    fs.writeFileSync(
+      path.join(build.bmad, 'custom', `${build.skillName}.user.toml`),
+      '[workflow]\ndirect_route = "Use the project-specific direct recipe."\n',
+      'utf8',
+    );
+    const direct = fs.readFileSync(entry(runRoute(build, 'direct')), 'utf8');
+    assert(direct.includes('Use the project-specific direct recipe.'), 'direct route customization missing');
+    assert(!direct.includes('{workflow.direct_route}'), 'direct route customization token survived');
+  });
+
+  test('the commands shipped in SKILL.md dispatch their intended entries', () => {
     for (const skillName of [DEFAULT_SKILL, 'bmad-build']) {
       const fix = fixture({ skillName });
-      const fenced = fs.readFileSync(path.join(fix.skill, 'SKILL.md'), 'utf8').match(/```bash\n([\s\S]*?)```/);
-      assert(fenced, `${skillName}: SKILL.md ships no bash command block`);
-      const command = fenced[1].trim().replaceAll('{project-root}', fix.project).replaceAll('{skill-root}', fix.skill);
+      const fences = [...fs.readFileSync(path.join(fix.skill, 'SKILL.md'), 'utf8').matchAll(/```bash\n([\s\S]*?)```/g)];
+      assert(fences.length > 0, `${skillName}: SKILL.md ships no bash command block`);
+      const fullFence = fences.find((match) => !match[1].includes('--route'));
+      assert(fullFence, `${skillName}: SKILL.md ships no full-route command`);
+      const command = fullFence[1].trim().replaceAll('{project-root}', fix.project).replaceAll('{skill-root}', fix.skill);
       assert(!command.includes('{'), `${skillName}: unsubstituted placeholder in shipped command: ${command}`);
       // Run it verbatim from a nested cwd — no --python pin, exactly as an agent would.
       const dispatched = entry(spawnSync(command, { cwd: path.join(fix.project, 'nested', 'cwd'), shell: true, encoding: 'utf8' }));
       assert(path.basename(dispatched) === 'workflow.md', `${skillName}: shipped command did not dispatch workflow.md`);
       assert(fs.existsSync(dispatched), `${skillName}: dispatched entry does not exist`);
+
+      if (skillName === 'bmad-build') {
+        const directFence = fences.find((match) => match[1].includes('--route direct'));
+        assert(directFence, 'bmad-build: SKILL.md ships no direct-route command');
+        const directCommand = directFence[1].trim().replaceAll('{project-root}', fix.project).replaceAll('{skill-root}', fix.skill);
+        const direct = entry(spawnSync(directCommand, { cwd: path.join(fix.project, 'nested', 'cwd'), shell: true, encoding: 'utf8' }));
+        assert(path.basename(direct) === 'route-direct.md', 'bmad-build: shipped direct command dispatched wrong entry');
+        assert(path.dirname(direct) === path.dirname(dispatched), 'bmad-build: shipped direct command changed generation');
+      }
     }
   });
 

--- a/test/test-build-auto-renderer.js
+++ b/test/test-build-auto-renderer.js
@@ -145,6 +145,17 @@ function entry(result) {
   return outputPath;
 }
 
+function inlinedEntry(result) {
+  assert(result.status === 0, `renderer failed: ${result.stdout}${result.stderr}`);
+  const prefix = 'follow these instructions from ';
+  const [header, ...rest] = result.stdout.split('\n');
+  const outputPath = header.slice(prefix.length);
+  assert(header.startsWith(prefix) && path.isAbsolute(outputPath), `bad inline dispatch: ${header}`);
+  assert(rest[0] === '', 'inline dispatch omits the blank line after its header');
+  assert(rest.slice(1).join('\n') === fs.readFileSync(outputPath, 'utf8'), 'inline dispatch body diverges from the snapshot');
+  return outputPath;
+}
+
 function bytesByName(directory) {
   const files = {};
 
@@ -372,7 +383,7 @@ async function main() {
   test('route dispatch reuses the no-route snapshot and selects its named entry', () => {
     const routed = fixture({ skillName: 'bmad-build' });
     const workflow = entry(run(routed));
-    const direct = entry(runRoute(routed, 'direct'));
+    const direct = inlinedEntry(runRoute(routed, 'direct'));
     assert(path.basename(workflow) === 'workflow.md', 'no-route dispatch changed');
     assert(path.basename(direct) === 'route-direct.md', 'named route was not dispatched');
     assert(path.dirname(direct) === path.dirname(workflow), 'route changed snapshot identity');
@@ -564,9 +575,22 @@ async function main() {
       '[workflow]\ndirect_route = "Use the project-specific direct recipe."\n',
       'utf8',
     );
-    const direct = fs.readFileSync(entry(runRoute(build, 'direct')), 'utf8');
+    const direct = fs.readFileSync(inlinedEntry(runRoute(build, 'direct')), 'utf8');
     assert(direct.includes('Use the project-specific direct recipe.'), 'direct route customization missing');
     assert(!direct.includes('{workflow.direct_route}'), 'direct route customization token survived');
+  });
+
+  test('route dispatch inlines its entry with no flag to omit', () => {
+    const fix = fixture({ skillName: 'bmad-build' });
+    // Inlining is a property of the route entry, so a caller cannot drop it.
+    const inlined = inlinedEntry(runRoute(fix, 'direct'));
+    assert(path.basename(inlined) === 'route-direct.md', 'route dispatch inlined the wrong entry');
+    assert(entry(run(fix)) === path.join(path.dirname(inlined), 'workflow.md'), 'default entry lost its path contract');
+
+    // A failure must stay a failure: no body, no partial instructions.
+    const broken = runRoute(fix, 'nope');
+    assert(broken.status === 1 && broken.stdout.startsWith('HALT: '), `invalid route survived inlining: ${broken.stdout}`);
+    assert(!broken.stdout.includes('follow these instructions'), 'failed route dispatch leaked instructions');
   });
 
   test('the commands shipped in SKILL.md dispatch their intended entries', () => {
@@ -587,7 +611,9 @@ async function main() {
         const directFence = fences.find((match) => match[1].includes('--route direct'));
         assert(directFence, 'bmad-build: SKILL.md ships no direct-route command');
         const directCommand = directFence[1].trim().replaceAll('{project-root}', fix.project).replaceAll('{skill-root}', fix.skill);
-        const direct = entry(spawnSync(directCommand, { cwd: path.join(fix.project, 'nested', 'cwd'), shell: true, encoding: 'utf8' }));
+        const direct = inlinedEntry(
+          spawnSync(directCommand, { cwd: path.join(fix.project, 'nested', 'cwd'), shell: true, encoding: 'utf8' }),
+        );
         assert(path.basename(direct) === 'route-direct.md', 'bmad-build: shipped direct command dispatched wrong entry');
         assert(path.dirname(direct) === path.dirname(dispatched), 'bmad-build: shipped direct command changed generation');
       }

--- a/test/test-build-auto-renderer.js
+++ b/test/test-build-auto-renderer.js
@@ -384,10 +384,13 @@ async function main() {
     const routed = fixture({ skillName: 'bmad-build' });
     const workflow = entry(run(routed));
     const direct = inlinedEntry(runRoute(routed, 'direct'));
+    const oneshot = inlinedEntry(runRoute(routed, 'one-shot'));
     assert(path.basename(workflow) === 'workflow.md', 'no-route dispatch changed');
     assert(path.basename(direct) === 'route-direct.md', 'named route was not dispatched');
+    assert(path.basename(oneshot) === 'route-one-shot.md', 'one-shot route was not dispatched');
     assert(path.dirname(direct) === path.dirname(workflow), 'route changed snapshot identity');
-    assert(fs.existsSync(workflow) && fs.existsSync(direct), 'snapshot does not serve both entries');
+    assert(path.dirname(oneshot) === path.dirname(workflow), 'one-shot route changed snapshot identity');
+    assert(fs.existsSync(workflow) && fs.existsSync(direct) && fs.existsSync(oneshot), 'snapshot does not serve every entry');
   });
 
   test('invalid and missing routes HALT without publishing a dispatch', () => {
@@ -529,20 +532,20 @@ async function main() {
     }
     assert(review.includes('{diff_output}'), 'runtime placeholder was removed from review layers');
 
-    const oneshot = fs.readFileSync(path.join(dir, 'step-oneshot.md'), 'utf8');
+    const oneshot = fs.readFileSync(path.join(dir, 'route-one-shot.md'), 'utf8');
     assert(oneshot.includes('#### Blind Hunter (`blind-hunter`)'), 'oneshot review layer block missing');
 
     // The spec editor handoff must reach both terminal routes (#2652).
     const present = fs.readFileSync(path.join(dir, 'step-05-present.md'), 'utf8');
     assert(present.includes('code -r'), 'open_spec default missing from step-05-present.md');
-    assert(oneshot.includes('code -r'), 'open_spec default missing from step-oneshot.md');
+    assert(oneshot.includes('code -r'), 'open_spec default missing from route-one-shot.md');
     assert(/^Offer to push\b/m.test(present), 'standalone "Offer to push" line was lost');
 
     const artifacts = `${fs.realpathSync(build.project)}/implementation`;
     assert(markdown.includes(`${artifacts}/sprint-status.yaml`), 'sprint-status path was not baked absolute');
     assert(markdown.includes(`${artifacts}/deferred-work.md`), 'deferred-work path was not baked absolute');
 
-    for (const name of ['step-01-clarify-and-route.md', 'step-02-plan.md', 'step-04-review.md', 'step-oneshot.md']) {
+    for (const name of ['step-01-clarify-and-route.md', 'step-02-plan.md', 'step-04-review.md', 'route-one-shot.md']) {
       const site = fs.readFileSync(path.join(dir, name), 'utf8');
       assert(site.includes(`${artifacts}/deferred-work.md`), `${name} does not contain the deferred-work path`);
     }
@@ -559,7 +562,7 @@ async function main() {
     fs.mkdirSync(path.join(build.bmad, 'custom'), { recursive: true });
     fs.writeFileSync(path.join(build.bmad, 'custom', `${build.skillName}.user.toml`), '[workflow]\nopen_spec = ""\n', 'utf8');
     const dir = path.dirname(entry(run(build)));
-    for (const name of ['step-05-present.md', 'step-oneshot.md']) {
+    for (const name of ['step-05-present.md', 'route-one-shot.md']) {
       const rendered = fs.readFileSync(path.join(dir, name), 'utf8');
       assert(!rendered.includes('code -r'), `open_spec default survived in ${name}`);
       assert(!rendered.includes('spec was sent'), `opening summary survived in ${name}`);
@@ -616,6 +619,15 @@ async function main() {
         );
         assert(path.basename(direct) === 'route-direct.md', 'bmad-build: shipped direct command dispatched wrong entry');
         assert(path.dirname(direct) === path.dirname(dispatched), 'bmad-build: shipped direct command changed generation');
+
+        const oneshotFence = fences.find((match) => match[1].includes('--route one-shot'));
+        assert(oneshotFence, 'bmad-build: SKILL.md ships no one-shot-route command');
+        const oneshotCommand = oneshotFence[1].trim().replaceAll('{project-root}', fix.project).replaceAll('{skill-root}', fix.skill);
+        const oneshot = inlinedEntry(
+          spawnSync(oneshotCommand, { cwd: path.join(fix.project, 'nested', 'cwd'), shell: true, encoding: 'utf8' }),
+        );
+        assert(path.basename(oneshot) === 'route-one-shot.md', 'bmad-build: shipped one-shot command dispatched wrong entry');
+        assert(path.dirname(oneshot) === path.dirname(dispatched), 'bmad-build: shipped one-shot command changed generation');
       }
     }
   });

--- a/test/test-installation-components.js
+++ b/test/test-installation-components.js
@@ -3785,12 +3785,16 @@ async function runTests() {
       ],
       renderOptions49,
     );
-    const dispatch49BuildDirect = (render49BuildDirect.stdout || '').trim().replace(/^read and follow /, '');
+    // Route dispatch inlines its entry: one header line, then the entry's bytes.
+    const [header49BuildDirect, ...body49BuildDirect] = (render49BuildDirect.stdout || '').split('\n');
+    const dispatch49BuildDirect = header49BuildDirect.replace(/^follow these instructions from /, '');
     assert(
       render49BuildDirect.status === 0 &&
+        header49BuildDirect.startsWith('follow these instructions from ') &&
         path.basename(dispatch49BuildDirect) === 'route-direct.md' &&
         path.dirname(dispatch49BuildDirect) === path.dirname(dispatch49Build) &&
-        (await fs.pathExists(dispatch49BuildDirect)),
+        (await fs.pathExists(dispatch49BuildDirect)) &&
+        body49BuildDirect.slice(1).join('\n') === (await fs.readFile(dispatch49BuildDirect, 'utf8')),
       'installer-produced build tree dispatches direct from the full-workflow snapshot',
       `${render49BuildDirect.stdout}${render49BuildDirect.stderr}`,
     );

--- a/test/test-installation-components.js
+++ b/test/test-installation-components.js
@@ -3703,6 +3703,7 @@ async function runTests() {
     assert(!(await fs.pathExists(path.join(skill49Build, 'render.toml'))), 'installed build has no duplicate render contract');
     assert(await fs.pathExists(path.join(skill49Build, 'workflow.md')), 'build workflow source reaches installed skill surface');
     assert(await fs.pathExists(path.join(skill49Build, 'route-direct.md')), 'build direct route reaches installed skill surface');
+    assert(await fs.pathExists(path.join(skill49Build, 'route-one-shot.md')), 'build one-shot route reaches installed skill surface');
     assert(await fs.pathExists(path.join(skill49Build, 'step-04-review.md')), 'build step sources reach installed skill surface');
     assert(
       (await fs.readFile(renderGitignore49, 'utf8')) === '*\n!.gitignore\n',

--- a/test/test-installation-components.js
+++ b/test/test-installation-components.js
@@ -3702,6 +3702,7 @@ async function runTests() {
     assert(!(await fs.pathExists(path.join(skill49Build, 'render.py'))), 'the retired skill-local renderer never reaches installed build');
     assert(!(await fs.pathExists(path.join(skill49Build, 'render.toml'))), 'installed build has no duplicate render contract');
     assert(await fs.pathExists(path.join(skill49Build, 'workflow.md')), 'build workflow source reaches installed skill surface');
+    assert(await fs.pathExists(path.join(skill49Build, 'route-direct.md')), 'build direct route reaches installed skill surface');
     assert(await fs.pathExists(path.join(skill49Build, 'step-04-review.md')), 'build step sources reach installed skill surface');
     assert(
       (await fs.readFile(renderGitignore49, 'utf8')) === '*\n!.gitignore\n',
@@ -3767,6 +3768,31 @@ async function runTests() {
         (await fs.pathExists(dispatch49Build)),
       'installer-produced build tree renders and dispatches end to end',
       `${render49Build.stdout}${render49Build.stderr}`,
+    );
+    const render49BuildDirect = spawnSync(
+      'uv',
+      [
+        'run',
+        '--python',
+        '3.11',
+        path.join(scripts49, 'render_skill.py'),
+        '--project-root',
+        root49,
+        '--skill',
+        skill49Build,
+        '--route',
+        'direct',
+      ],
+      renderOptions49,
+    );
+    const dispatch49BuildDirect = (render49BuildDirect.stdout || '').trim().replace(/^read and follow /, '');
+    assert(
+      render49BuildDirect.status === 0 &&
+        path.basename(dispatch49BuildDirect) === 'route-direct.md' &&
+        path.dirname(dispatch49BuildDirect) === path.dirname(dispatch49Build) &&
+        (await fs.pathExists(dispatch49BuildDirect)),
+      'installer-produced build tree dispatches direct from the full-workflow snapshot',
+      `${render49BuildDirect.stdout}${render49BuildDirect.stderr}`,
     );
     const resolveCustomization49 = spawnSync(
       'uv',


### PR DESCRIPTION
## What

Adds two low-ceremony pre-render routes to `bmad-build`:

- **Direct** for user-pinned edits to a bounded span.
- **Early one-shot** for clear single-goal implementation requests whose targeted source probe establishes zero blast radius.

Everything else retains the full workflow.

## Why

Small changes were paying full activation, artifact-discovery, and clarification costs before reaching useful work. In the controlled one-shot experiment, early routing reached the first green verification about 38 seconds sooner; the closest end-to-end comparison saved 14 seconds. The direct route removes still more ceremony for edits that require no investigation.

## How

- Triage before rendering among direct, early one-shot probe, and full workflow.
- Inline named routes from the same immutable renderer snapshot.
- Keep direct edits in a commit-owning interactive loop with merge-blocker review for code.
- Make one-shot a standalone named route that derives its spec path and skips sprint synchronization when no story is present.
- Preserve full-workflow fallback and carry probe findings forward.

## Testing

- `npm ci && npm run quality`
- Shared renderer: 29/29
- Installer: 458/458
- Strict reference and skill validation: clean

Project-root discovery remains deliberately out of scope; callers still provide `--project-root`.
