### PR TITLE
docs(bmm): restrict bmad-project-context routing to invocation by name

### DIFF
--- a/src/bmm-skills/plan/bmad-project-context/SKILL.md
+++ b/src/bmm-skills/plan/bmad-project-context/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: bmad-project-context
-description: 'Set up or refresh agent instructions so AI agents work well in it. Use when the user says "project context", "set up AGENTS.md", "document this project", "refresh context", "audit context", wants to apply coding standards or governance to a repo, or wants to record a mistake agents keep making'
+description: 'Set up, refresh, or audit a repository''s agent instructions (the AGENTS.md block) so AI agents work well in that repo. Also records observed agent mistakes as pitfall lines. Must be invoked by name.'
 ---
 
 # Overview


### PR DESCRIPTION
## What

Rewrites the `bmad-project-context` skill description so the skill routes only when invoked by name.

## Why

The old description had two problems:

- "…so AI agents work well in it" — the pronoun had no antecedent; the repository was never named in the sentence.
- Its trigger list mixed verbatim phrases with broad intent paraphrases ("document this project", "wants to apply coding standards or governance to a repo", "wants to record a mistake agents keep making"), which let the router launch this heavyweight interview-style workflow on inferred intent rather than an explicit request.

The new description names the repository and the artifact (the AGENTS.md block), lists all four intents (setup / refresh / audit / record), and ends with "Must be invoked by name." Users who say "project context" in any phrasing still reach the skill — the name itself remains a routing surface; only outcome-descriptions that never name it stop auto-routing.
