### PR TITLE
docs(project-context): update stale "pitfall line" wording to "pitfall"

### DIFF
--- a/docs/explanation/project-context-theory.md
+++ b/docs/explanation/project-context-theory.md
@@ -73,7 +73,7 @@ The result is small by design. When the evidence supports ten lines, ten lines i
 
 There is one rule that inverts the pruning instinct, and getting it wrong quietly destroys the best content in the file.
 
-**A policy or pitfall line retires only when the thing it guards is gone** — removed, or now mechanically enforced — **or when a human retires it.** Absence of recent failures is never grounds. A working rule erases its own evidence, and much of the value of the block is the failures that no longer happen.
+**A policy or pitfall retires only when the thing it guards is gone** — removed, or now mechanically enforced — **or when a human retires it.** Absence of recent failures is never grounds. A working rule erases its own evidence, and much of the value of the block is the failures that no longer happen.
 
 ## Two altitudes, two artifacts
 

--- a/docs/how-to/project-context.md
+++ b/docs/how-to/project-context.md
@@ -55,7 +55,7 @@ At the end it tells you what went in, what was left out and why, and the reasoni
 ## Keeping it healthy
 
 - **Refresh** after real change — re-checks that the caveats still hold, diffs deletions and renames since the recorded commit, updates what moved, and never re-asks what you already settled
-- **Record** the moment an agent gets something wrong — that's the only admissible source for a pitfall line
+- **Record** the moment an agent gets something wrong — that's the only admissible source for a pitfall
 - **Audit** on demand — re-verifies everything and prunes; the block ends smaller or equal, never larger
 
 A rule stays until the thing it guards is gone or you retire it. Nothing broke lately is never a reason to delete one — a working rule erases its own evidence.


### PR DESCRIPTION
## What

Updates the two remaining docs occurrences of "pitfall line" to "pitfall" — `docs/how-to/project-context.md` (record intent) and `docs/explanation/project-context-theory.md` (retention rule).

## Why

#2709 renamed the term in the skill source; these docs still used the old compound.
