### PR TITLE
fix(bmad-help): avoid advancing from draft artifacts

### DIFF
--- a/src/core-skills/bmad-help/SKILL.md
+++ b/src/core-skills/bmad-help/SKILL.md
@@ -50,9 +50,11 @@ module,skill,display-name,menu-code,description,action,args,phase,preceded-by,fo
 - A phase with no required items is entirely optional — recommend it but be clear about what's actually required next
 
 **Completion detection**:
-- Search resolved output paths for `outputs` patterns
-- Fuzzy-match found files to catalog rows
-- User may also state completion explicitly, or it may be evident from the current conversation
+- Search resolved output paths for `outputs` patterns and fuzzy-match found files to catalog rows
+- Treat a matching output as evidence that the skill started, not that it completed
+- Inspect matched artifacts for explicit completion evidence, such as final status or finalization markers; a draft or incomplete marker means the skill is still in progress
+- Honor completion stated by the user or established in the current conversation
+- When completion cannot be determined reliably, say so and ask the user; do not recommend advancing based on file presence alone
 
 **Descriptions carry routing context** — some contain cycle info and alternate paths (e.g., "back to DS if fixes needed"). Read them as navigation hints, not just display text.
 


### PR DESCRIPTION
## What

Treat matching output artifacts as evidence that a skill started, not proof that it completed. Require explicit completion evidence before recommending the next phase, and ask the user when completion is uncertain.

## Why

File presence alone can make `bmad-help` advance past an active draft. Fixes #2706.

Inspired by #2711, which identified the failure mode and catalogued producer-specific completion signals. This alternative keeps `bmad-help` compact and producer-agnostic instead of duplicating every skill's artifact contract in its prompt.

## How

- Inspect matched artifacts for explicit final, draft, or incomplete markers.
- Treat drafts as in progress.
- Never advance from ambiguous file presence alone.

## Testing

`HUSKY=0 npm ci && npm run quality`
