### PR TITLE
fix(build): narrow implicit skill routing

### DIFF
--- a/src/bmm-skills/ship/bmad-build/SKILL.md
+++ b/src/bmm-skills/ship/bmad-build/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: bmad-build
-description: 'Implement any requirement, story, bug fix, or change request as working code that follows the project''s existing architecture, patterns, and conventions. Use when the user wants to build, fix, tweak, refactor, add, or modify any code, component, or feature'
+description: 'Implement a software change through BMAD''s build workflow, from intent clarification through review and verification. Use when the user explicitly invokes bmad-build or asks BMAD to build, fix, refactor, add, or modify code'
 ---
 
 Run the following command exactly once without changing the current working directory. Replace `{project-root}` with the absolute path to the project root and `{skill-root}` with the absolute path to this skill's directory:


### PR DESCRIPTION
## What

Narrows the `bmad-build` description so implicit routing requires an explicit BMAD request or the skill name.

## Why

Generic Git operations that only record existing content should not enter the build workflow. Fixes #2708.

## How

- Frame the skill as BMAD's build workflow.
- Replace the broad any-code trigger with explicit BMAD intent.

## Testing

- `npm ci && npm run quality`
- `node tools/validate-skills.js --json src/bmm-skills/ship/bmad-build`
