### PR TITLE
fix(build): gate implicit routing on delegated outcomes

### DIFF
--- a/src/bmm-skills/ship/bmad-build/SKILL.md
+++ b/src/bmm-skills/ship/bmad-build/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: bmad-build
-description: 'Implement any requirement, story, bug fix, or change request as working code that follows the project''s existing architecture, patterns, and conventions. Use when the user wants to build, fix, tweak, refactor, add, or modify any code, component, or feature'
+description: 'Turns a work item — feature, story, bug fix, change request — into working code, reviewed and verified. Use when the user hands over an outcome and leaves the edits to you; a bare story or issue link counts. Also use whenever the user asks BMAD by name — then any change qualifies, even a tiny fully-specified edit. Do not volunteer for interactive edits the user directs and reviews themselves, or for version-control operations that record existing work without changing it.'
 ---
 
 Run the following command exactly once without changing the current working directory. Replace `{project-root}` with the absolute path to the project root and `{skill-root}` with the absolute path to this skill's directory:


### PR DESCRIPTION
## What

Replaces bmad-build's description so implicit routing keys on *who owns the edits*, not on whether the request mentions a code change.

## Why

The previous description matched any code change, so coding agents entered the build workflow for requests that never asked for it — including git operations that only record existing content. Fixes #2708.

An earlier fix (#2713) gated routing on the user explicitly invoking BMAD. That closes #2708 but also disables wanted auto-triggering: a bare story or issue link should still enter the build workflow without BMAD being named.

## How

The new description defines three routing rules:

- Auto-trigger when the user hands over an outcome and leaves the edits to the agent; a bare story or issue link counts.
- Always trigger on an explicit BMAD request — no size floor, even a fully-specified one-line edit.
- Never volunteer for interactive edits the user directs and reviews themselves, or for version-control operations that record existing work.

## Testing

- `npm ci && npm run quality`
- `node tools/validate-skills.js --json src/bmm-skills/ship/bmad-build` — clean
- 26-case routing eval, each case judged in an isolated agent context (no cross-contamination), on two agent platforms. Cases cover: the #2708 commit scenario, story/issue links, explicit BMAD asks for tiny edits, dictated edits (constant change, typo, version bump), mid-session interactive directives, outcome-shaped feature/bug requests, and six git-operation variants. Both platforms score 25/25 on the final wording; earlier drafts scored 22–24/25 and drove two wording revisions (scoping the tiny-edit clause to the explicit ask; requiring the outcome to leave the edits open).
