### PR TITLE
fix(review): gate routing on explicit review requests

### DIFF
--- a/src/core-skills/bmad-review/SKILL.md
+++ b/src/core-skills/bmad-review/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: bmad-review
-description: 'Review any diff, document, spec, or other artifact with one or more installed review methods (lenses) — shipped ones cover adversarial critique, edge cases, verification gaps, document structure, and prose. Runs whichever fit the content, or exactly the ones asked for. Use when the user says "review this", "critical review", "editorial review", "hunt edge cases", "review the structure", or "review the prose"'
+description: 'Runs one or more installed review lenses — adversarial critique, edge cases, verification gaps, structure, prose — and reports triaged findings. Use when, and only when, the user asks you to review a diff, a pull request, or an artifact — code or documents, one or many — and actually says "review". A request to act on feedback from an earlier review is a change, not a review. Never invoke this uninvited, including on edits you just made.'
 ---
 
 # BMad Review

--- a/src/core-skills/bmad-review/SKILL.md
+++ b/src/core-skills/bmad-review/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: bmad-review
-description: 'Runs one or more installed review lenses — adversarial critique, edge cases, verification gaps, structure, prose — and reports triaged findings. Use when, and only when, the user asks you to review a diff, a pull request, or an artifact — code or documents, one or many — and actually says "review". A request to act on feedback from an earlier review is a change, not a review. Never invoke this uninvited, including on edits you just made.'
+description: 'Runs one or more installed review lenses — adversarial critique, edge cases, verification gaps, structure, prose — and reports triaged findings. Use when, and only when, the user asks you to review a diff, a pull request, or an artifact — code or documents, one or many — and actually says "review"; an explicit skill:bmad-review directive from another skill counts as that ask. A request to act on feedback from an earlier review is a change, not a review. Never invoke this uninvited, including on edits you just made.'
 ---
 
 # BMad Review


### PR DESCRIPTION
## What

Replaces bmad-review's description so routing requires an explicit review request — the user asks to review a concrete target and actually says "review" — instead of matching any review-like phrasing.

## Why

The previous description ("Review any diff, document, spec, or other artifact… Use when the user says 'review this'…") over-triggers, worst on Codex. A week of session logs shows the skill invoked for an install command, a rebase, a PR summary request, worktree setup directions, two build handovers, planning questions, and a question about the review skill itself — and only once for an actual review request. This is the review-side counterpart to #2714 (same failure class as #2708 was for bmad-build).

## How

The new description defines three routing rules:

- Trigger only on an explicit ask: the user requests a review of a diff, a pull request, or an artifact — code or documents, one or many — and actually says "review".
- A request to act on feedback from an earlier review is a change, not a review.
- Never volunteer, including on the agent's own just-made edits.

## Testing

- `npm ci && npm run quality` — 0 errors
- `node tools/validate-skills.js --json src/core-skills/bmad-review` — clean
- 32-case routing eval, each case judged in an isolated agent context (no cross-contamination), on two agent platforms. Ten cases are the real over-trigger transcripts from the week of logs; the rest cover explicit review asks (diff, PR, docs, code), near-miss phrasings ("take a look", "sanity-check"), review-feedback follow-ups, git/PR operations, and agent self-invocation. The final wording scores 30/30 on both platforms; an earlier draft scored 29/30 (a source directory read as outside the target list), which drove the artifact clause to name code explicitly.
