### PR TITLE
fix(build,code-review): forbid detached review subagent dispatch

### DIFF
--- a/src/bmm-skills/ship/bmad-build/step-oneshot.md
+++ b/src/bmm-skills/ship/bmad-build/step-oneshot.md
@@ -5,7 +5,7 @@
 - **Language** — Speak in `{{.communication_language}}`. Write any file output in `{{.document_output_language}}`.
 - NEVER auto-push.
 - All review subagents must run at the same model capability as the current session.
-- Run subagents synchronously: launch them together, then wait for all results before continuing.
+- Run subagents synchronously: launch them together as blocking calls awaited in this turn — never backgrounded or detached, never ending the turn to await results.
 
 ## INSTRUCTIONS
 

--- a/src/bmm-skills/ship/bmad-code-review/steps/step-02-review.md
+++ b/src/bmm-skills/ship/bmad-code-review/steps/step-02-review.md
@@ -8,7 +8,7 @@ failed_layers: '' # set at runtime: comma-separated list of layers that failed o
 
 - YOU MUST ALWAYS SPEAK OUTPUT in your Agent communication style with the config `{communication_language}`
 - All review subagents must run at the same model capability as the current session.
-- Run subagents synchronously: launch them together, then wait for all results before continuing.
+- Run subagents synchronously: launch them together as blocking calls awaited in this turn — never backgrounded or detached, never ending the turn to await results.
 
 ## INSTRUCTIONS
 


### PR DESCRIPTION
## Problem

`bmad-build/step-oneshot.md` and `bmad-code-review/steps/step-02-review.md` direct the orchestrator to launch review subagents together, "then wait for all results before continuing" — spawn-then-wait phrasing that reads as an invitation to detach the reviewer and improvise the wait.

In an eight-run study of the one-shot route (identical prompt, same model and effort), dispatch split on exactly this reading:

- Five runs launched the reviewer as a blocking call: the review arrived as the call result, supervised by the platform. All five were clean.
- Three runs detached the reviewer: the launch returned a spawn acknowledgment, the orchestrator improvised the wait (sleep loops, status queries that returned no liveness signal, direct messages that got no reply), and two of the three relaunched a reviewer that was still working — paying for the review twice. These were the three most expensive runs, up to ~2.2× the clean-run cost.

The relaunch itself is correct behavior under zero observability; the defect is the phrasing that steers the orchestrator into the mode where it ends up blind.

## Change

`bmad-build/step-04-review.md` and bmad-build-auto (workflow.md, step-03, step-04) already pin the contract: blocking calls awaited in this turn — never backgrounded or detached, never ending the turn to await results. This ports that clause to the two remaining sites that still carry the weak sentence. One line each; no change for runs that already dispatch blocking calls.