### PR TITLE
feat(installer): add Grok as a tool target

### DIFF
--- a/test/test-installation-components.js
+++ b/test/test-installation-components.js
@@ -544,6 +544,45 @@ async function runTests() {
 
   console.log('');
 
+  // ============================================================
+  // Test 11c: Grok Native Skills Install
+  // ============================================================
+  console.log(`${colors.yellow}Test Suite 11c: Grok Native Skills${colors.reset}\n`);
+
+  try {
+    clearCache();
+    const platformCodes11c = await loadPlatformCodes();
+    const grokInstaller = platformCodes11c.platforms.grok?.installer;
+
+    assert(grokInstaller?.target_dir === '.agents/skills', 'Grok target_dir uses native skills path');
+
+    const tempProjectDir11c = await fs.mkdtemp(path.join(os.tmpdir(), 'bmad-grok-test-'));
+    const installedBmadDir11c = await createTestBmadFixture();
+
+    const ideManager11c = new IdeManager();
+    await ideManager11c.ensureInitialized();
+    const result11c = await ideManager11c.setup('grok', tempProjectDir11c, installedBmadDir11c, {
+      silent: true,
+      selectedModules: ['bmm'],
+    });
+
+    assert(result11c.success === true, 'Grok setup succeeds against temp project');
+
+    const skillFile11c = path.join(tempProjectDir11c, '.agents', 'skills', 'bmad-master', 'SKILL.md');
+    assert(await fs.pathExists(skillFile11c), 'Grok install writes SKILL.md directory output');
+
+    const skillContent11c = await fs.readFile(skillFile11c, 'utf8');
+    const nameMatch11c = skillContent11c.match(/^name:\s*(.+)$/m);
+    assert(nameMatch11c && nameMatch11c[1].trim() === 'bmad-master', 'Grok skill name frontmatter matches directory name exactly');
+
+    await fs.remove(tempProjectDir11c);
+    await fs.remove(path.dirname(installedBmadDir11c));
+  } catch (error) {
+    assert(false, 'Grok native skills install test succeeds', error.message);
+  }
+
+  console.log('');
+
   // Test 12: Removed — ancestor conflict check no longer applies (no IDE inherits skills from parent dirs)
 
   // ============================================================

--- a/tools/installer/ide/platform-codes.yaml
+++ b/tools/installer/ide/platform-codes.yaml
@@ -169,6 +169,13 @@ platforms:
       target_dir: .agents/skills
       global_target_dir: ~/.config/agents/skills
 
+  grok:
+    name: "Grok"
+    preferred: false
+    installer:
+      target_dir: .agents/skills
+      global_target_dir: ~/.grok/skills
+
   hermes:
     name: "Hermes Agent"
     preferred: false


### PR DESCRIPTION
## What

Add Grok as a first-class installer tool ID so `--tools grok` is valid.

## Why

Grok already loads the shared `.agents/skills` tree, but the installer had no `grok` target, so it never appeared in `--list-tools` and could not be selected on install or update.

## How

- Register `grok` in `platform-codes.yaml` with project path `.agents/skills` and global path `~/.grok/skills`
- Cover install and SKILL.md output in the existing installer component tests

## Testing

`HUSKY=0 npm ci && npm run quality` passed in this worktree, including the new Grok native-skills suite.
