### PR TITLE
Fix Windows renderer staging ACL inheritance

### DIFF
--- a/package.json
+++ b/package.json
@@ -46,7 +46,7 @@
     "test:channels": "node test/test-installer-channels.js",
     "test:install": "node test/test-installation-components.js && node test/test-shim-policy.js",
     "test:refs": "node test/test-file-refs-csv.js",
-    "test:renderer": "uv run --python 3.11 python -m unittest src/scripts/tests/test_config_utils.py src/scripts/tests/test_resolve_config.py src/scripts/tests/test_resolve_customization.py && node test/test-build-auto-renderer.js",
+    "test:renderer": "uv run --python 3.11 python -m unittest src/scripts/tests/test_config_utils.py src/scripts/tests/test_resolve_config.py src/scripts/tests/test_resolve_customization.py src/scripts/tests/test_render_skill.py && node test/test-build-auto-renderer.js",
     "test:retrospective": "uv run --python 3.11 src/bmm-skills/ship/bmad-retrospective/scripts/tests/test_git_evidence.py && uv run --python 3.11 src/bmm-skills/ship/bmad-retrospective/scripts/tests/test_sprint_status.py",
     "test:site-url": "node test/test-site-url.mjs",
     "test:skills": "node test/test-validate-skills.js",

--- a/src/scripts/render_skill.py
+++ b/src/scripts/render_skill.py
@@ -11,6 +11,7 @@ import hashlib
 import json
 import os
 import re
+import secrets
 import shutil
 import sys
 import tempfile
@@ -31,6 +32,7 @@ _CONFIG_TOKEN = re.compile(r"\{\{config\.([A-Za-z0-9_.-]+)\}\}")
 _SHORT_CONFIG_TOKEN = re.compile(r"\{\{\.([A-Za-z0-9_]+)\}\}")
 _CUSTOM_TOKEN = re.compile(r"\{workflow\.([A-Za-z0-9_.-]+)\}")
 _SNAPSHOT_TOKEN = re.compile(r"\[\[bmad-snapshot:([A-Za-z0-9_./-]+\.md)\]\]")
+_WINDOWS_STAGING_ATTEMPTS = 16
 
 
 def _hash_bytes(content: bytes) -> str:
@@ -292,12 +294,30 @@ def _verify_existing(destination: Path, manifest: dict[str, Any]) -> None:
             raise RenderError(f"generation output hash mismatch: {destination / name}")
 
 
+def _create_staging_directory(parent: Path) -> Path:
+    """Create private POSIX staging or inheritable Windows staging."""
+    if sys.platform != "win32":
+        return Path(tempfile.mkdtemp(prefix=".staging-", dir=parent))
+
+    for _ in range(_WINDOWS_STAGING_ATTEMPTS):
+        staging = parent / f".staging-{secrets.token_hex(8)}"
+        try:
+            staging.mkdir()
+        except FileExistsError:
+            continue
+        return staging
+    raise RenderError(
+        "failed to create Windows staging directory after "
+        f"{_WINDOWS_STAGING_ATTEMPTS} name collisions in {parent}"
+    )
+
+
 def _publish(destination: Path, outputs: dict[str, bytes], manifest: dict[str, Any]) -> None:
     destination.parent.mkdir(parents=True, exist_ok=True)
     if destination.exists():
         _verify_existing(destination, manifest)
         return
-    staging = Path(tempfile.mkdtemp(prefix=".staging-", dir=destination.parent))
+    staging = _create_staging_directory(destination.parent)
     try:
         for name, content in outputs.items():
             path = staging / name

--- a/src/scripts/tests/test_render_skill.py
+++ b/src/scripts/tests/test_render_skill.py
@@ -1,0 +1,125 @@
+import contextlib
+import importlib.util
+import secrets
+import shutil
+import sys
+import unittest
+from pathlib import Path
+from unittest import mock
+
+
+SCRIPTS_DIR = Path(__file__).resolve().parents[1]
+MODULE_PATH = SCRIPTS_DIR / "render_skill.py"
+ORIGINAL_SYS_PATH = sys.path.copy()
+try:
+    if str(SCRIPTS_DIR) not in sys.path:
+        sys.path.insert(0, str(SCRIPTS_DIR))
+    SPEC = importlib.util.spec_from_file_location("bmad_render_skill", MODULE_PATH)
+    if SPEC is None or SPEC.loader is None:
+        raise RuntimeError(f"failed to load renderer module from {MODULE_PATH}")
+    render_skill = importlib.util.module_from_spec(SPEC)
+    SPEC.loader.exec_module(render_skill)
+finally:
+    sys.path[:] = ORIGINAL_SYS_PATH
+
+
+@contextlib.contextmanager
+def writable_test_directory():
+    """Create a test directory that inherits the checkout's writable Windows ACL."""
+    path = Path(__file__).resolve().parent / f".test-{secrets.token_hex(8)}"
+    path.mkdir()
+    try:
+        yield path
+    finally:
+        shutil.rmtree(path)
+
+
+class CreateStagingDirectoryTests(unittest.TestCase):
+    def test_windows_creates_inheritable_randomized_child(self):
+        with writable_test_directory() as parent:
+            with (
+                mock.patch.object(render_skill.sys, "platform", "win32"),
+                mock.patch.object(
+                    render_skill.secrets, "token_hex", return_value="abc123"
+                ) as token_hex,
+                mock.patch.object(
+                    render_skill.tempfile,
+                    "mkdtemp",
+                    side_effect=AssertionError("Windows must not use tempfile.mkdtemp"),
+                ),
+            ):
+                staging = render_skill._create_staging_directory(parent)
+                probe = staging / "nested" / "probe.txt"
+                probe.parent.mkdir()
+                probe.write_text("writable", encoding="utf-8")
+
+            self.assertEqual(staging, parent / ".staging-abc123")
+            self.assertEqual(probe.read_text(encoding="utf-8"), "writable")
+            token_hex.assert_called_once_with(8)
+
+    def test_non_windows_delegates_to_mkdtemp(self):
+        parent = Path("parent")
+        created = "parent/.staging-created"
+        with (
+            mock.patch.object(render_skill.sys, "platform", "linux"),
+            mock.patch.object(
+                render_skill.tempfile, "mkdtemp", return_value=created
+            ) as mkdtemp,
+        ):
+            staging = render_skill._create_staging_directory(parent)
+
+        self.assertEqual(staging, Path(created))
+        mkdtemp.assert_called_once_with(prefix=".staging-", dir=parent)
+
+    def test_windows_retries_collision_without_altering_existing_path(self):
+        with writable_test_directory() as parent:
+            collision = parent / ".staging-collision"
+            collision.mkdir()
+            marker = collision / "marker.txt"
+            marker.write_text("untouched", encoding="utf-8")
+            with (
+                mock.patch.object(render_skill.sys, "platform", "win32"),
+                mock.patch.object(
+                    render_skill.secrets,
+                    "token_hex",
+                    side_effect=["collision", "available"],
+                ),
+            ):
+                staging = render_skill._create_staging_directory(parent)
+
+            self.assertEqual(staging, parent / ".staging-available")
+            self.assertEqual(marker.read_text(encoding="utf-8"), "untouched")
+
+    def test_windows_reports_collision_exhaustion(self):
+        with writable_test_directory() as parent:
+            collision = parent / ".staging-collision"
+            collision.mkdir()
+            with (
+                mock.patch.object(render_skill.sys, "platform", "win32"),
+                mock.patch.object(
+                    render_skill.secrets, "token_hex", return_value="collision"
+                ) as token_hex,
+            ):
+                with self.assertRaisesRegex(
+                    render_skill.RenderError, "16 name collisions"
+                ):
+                    render_skill._create_staging_directory(parent)
+
+            self.assertEqual(
+                token_hex.call_count, render_skill._WINDOWS_STAGING_ATTEMPTS
+            )
+            self.assertTrue(collision.is_dir())
+
+    def test_windows_propagates_unexpected_creation_error(self):
+        with writable_test_directory() as parent:
+            missing_parent = parent / "missing"
+            with (
+                mock.patch.object(render_skill.sys, "platform", "win32"),
+                mock.patch.object(render_skill.secrets, "token_hex", return_value="x"),
+            ):
+                with self.assertRaises(FileNotFoundError):
+                    render_skill._create_staging_directory(missing_parent)
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Summary

- create renderer staging directories with inherited ACLs on Windows
- preserve `tempfile.mkdtemp()` and private `0700` behavior on non-Windows platforms
- add focused tests for platform selection, entropy, collision retries, exhaustion, and unexpected filesystem errors
- register the new tests in the existing `test:renderer` quality path

## Root cause

Python 3.11.10 and newer specially handle `mkdir(..., 0o700)` on Windows by creating a protected ACL for the owner, SYSTEM, and administrators. `tempfile.mkdtemp()` uses that mode. In a restricted sandbox, the protected ACL drops inherited workspace principals, so the renderer can create its staging directory but is denied when writing the first snapshot file.

## Impact

Sandboxed Windows rendering can publish immutable workflow snapshots without requiring an unsandboxed workaround. Existing atomic rename, concurrent-winner verification, cleanup, destination layout, and POSIX security behavior remain unchanged.

## Validation

- `npm ci`
- `npm run quality` under WSL with Node 22.23.2 and uv 0.12.4 — passed
- renderer suite within quality: 15/15 Python tests and 24/24 integration tests passed
- consumer-project sandbox verification: renderer completed and the emitted `workflow.md` was readable from a separate sandboxed process
