### PR TITLE
fix(build): expose real spec checkpoint choices

### DIFF
--- a/src/bmm-skills/ship/bmad-build/step-02-plan.md
+++ b/src/bmm-skills/ship/bmad-build/step-02-plan.md
@@ -31,16 +31,17 @@ After presenting the summary, display this note:
 
 ---
 
-Before approving, you can open the spec file in an editor or ask me questions and tell me what to change. You can also use `bmad-advanced-elicitation`, `bmad-party-mode`, or `bmad-code-review` skills, ideally in another session to avoid context bloat.
+Before approving, you can open the spec file in an editor or ask me questions and tell me what to change. You can also use `bmad-advanced-elicitation` or `bmad-party-mode`, ideally in another session to avoid context bloat.
 
 ---
 
-HALT and ask human: `[A] Approve` | `[E] Edit`
+HALT and give the user a choice:
 
-- **A**: Re-read `{spec_file}` from disk.
-  - **If the file is missing:** HALT. Tell the user the spec file is gone and STOP — do not write anything to `{spec_file}`, do not set status, do not proceed to Step 3. Nothing below this point runs.
-  - **If the file exists:** Compare the content to what you wrote. If it has changed since you wrote it, acknowledge the external edits — show a brief summary of what changed — and proceed with the updated version. Then set status `ready-for-dev` in `{spec_file}`. Everything inside `<frozen-after-approval>` is now locked — only the human can change it. → Step 3.
-- **E**: Apply changes, then return to CHECKPOINT 1.
+- **Approve and continue** — approve the spec and proceed to implementation in this session.
+- **Approve and stop** — approve the spec, leave it `ready-for-dev`, and stop so a fresh `bmad-build` session can resume at implementation.
+- **Review spec** — review the spec before deciding whether to approve it.
+
+Before acting on approval, re-read `{spec_file}` from disk. If it is missing, HALT without recreating it, changing status, or proceeding. If it changed, acknowledge the external edits and continue with the updated version. Set status `ready-for-dev`; everything inside `<frozen-after-approval>` is then locked and only the human can change it.
 
 ## NEXT
 

--- a/src/bmm-skills/ship/bmad-build/step-02-plan.md
+++ b/src/bmm-skills/ship/bmad-build/step-02-plan.md
@@ -39,7 +39,7 @@ HALT and give the user a choice:
 
 - **Approve and continue** — approve the spec and proceed to implementation in this session.
 - **Approve and stop** — approve the spec, leave it `ready-for-dev`, and stop so a fresh `bmad-build` session can resume at implementation.
-- **Review spec** — review the spec before deciding whether to approve it.
+- **Review spec** — review the spec, use a subagent if available, and discuss the findings and revisions with the user until the user is ready to approve, then either stop or continue.
 
 Before acting on approval, re-read `{spec_file}` from disk. If it is missing, HALT without recreating it, changing status, or proceeding. If it changed, acknowledge the external edits and continue with the updated version. Set status `ready-for-dev`; everything inside `<frozen-after-approval>` is then locked and only the human can change it.
 


### PR DESCRIPTION
## What

Replace the misleading `[A] Approve | [E] Edit` checkpoint with three meaningful choices: approve and continue, approve and stop, or review the spec.

## Why

Edit was not a real workflow branch. The actual decision is whether implementation continues in the current session or the approved `ready-for-dev` spec is handed to a fresh session, with spec review available before approval.

## How

- Present the choices in plain language so the host can use its native interaction UI.
- Preserve the disk re-read, missing-file stop, external-edit handling, status transition, and frozen-intent lock.
- Remove the unrelated code-review suggestion from the pre-approval note.

## Testing

`HUSKY=0 npm ci && npm run quality`
