### PR TITLE
fix(build): resolve Ask First questions before implementation

### DIFF
--- a/src/bmm-skills/ship/bmad-build/spec-template.md
+++ b/src/bmm-skills/ship/bmad-build/spec-template.md
@@ -24,12 +24,13 @@ context: [] # optional: `{project-root}/`-prefixed paths to project-wide standar
 
 ## Boundaries & Constraints
 
-<!-- Three tiers: Always = invariant rules. Ask First = human-gated decisions. Never = out of scope + forbidden approaches. -->
+<!-- Three tiers: Always = invariant rules. Ask First = unresolved planning questions only the human can answer. Never = out of scope + forbidden approaches. -->
 
 **Always:** INVARIANT_RULES
 
-**Ask First:** DECISIONS_REQUIRING_HUMAN_APPROVAL
-<!-- Agent: if any of these trigger during execution, HALT and ask the user before proceeding. -->
+**Ask First:**
+- UNRESOLVED_QUESTION_FOR_THE_HUMAN
+<!-- Agent: this is a planning checklist, not execution guidance. Delete the entire section when no questions remain. -->
 
 **Never:** NON_GOALS_AND_FORBIDDEN_APPROACHES
 

--- a/src/bmm-skills/ship/bmad-build/step-01-clarify-and-route.md
+++ b/src/bmm-skills/ship/bmad-build/step-01-clarify-and-route.md
@@ -80,7 +80,7 @@ If the spec is an epic story and `{{.implementation_artifacts}}/sprint-status.ya
        - **Epics** (`*epic*`) — feature breakdown into implementable stories
        - **Product Brief** (`*brief*`) — project vision and scope
      - Scan the listing for files matching these patterns. If any look relevant to the current intent, load them selectively — you don't need all of them, but you need the right constraints and requirements rather than guessing from code alone.
-2. Clarify intent. Do not fantasize, do not leave open questions. If you must ask questions, ask them as a numbered list. When the human replies, verify that every single numbered question was answered. If any were ignored, HALT and re-ask only the missing questions before proceeding. Keep looping until intent is clear enough to implement.
+2. Clarify only enough to identify the goal and choose a route. If the intent is clear enough to investigate, carry planning questions into step-02 rather than asking them here.
 3. Version control sanity check. Is the working tree clean? Does the current branch make sense for this intent — considering its name and recent history? If the tree is dirty or the branch is an obvious mismatch, HALT and ask the human before proceeding. If version control is unavailable, skip this check.
 4. Multi-goal check (see SCOPE STANDARD). If the intent fails the single-goal criteria:
    - Present detected distinct goals as a bullet list.

--- a/src/bmm-skills/ship/bmad-build/step-02-plan.md
+++ b/src/bmm-skills/ship/bmad-build/step-02-plan.md
@@ -10,14 +10,14 @@
 1. Draft resume check. If `{spec_file}` exists with `status: draft`, read it and capture the verbatim `<frozen-after-approval>...</frozen-after-approval>` block as `preserved_intent`. Otherwise `preserved_intent` is empty.
 2. Investigate codebase. _Isolate deep exploration in synchronous subagents/tasks where available. To prevent context snowballing, instruct subagents to give you distilled summaries only._ Decide which findings actually matter for execution — the specific files, symbols/lines, reuse points, and read-only constraints — and carry those forward for the Code Map. This is where the investigation lands: the spec preserves it so it is never re-narrated to the implementer at dispatch time.
 3. Read `[[bmad-snapshot:spec-template.md]]` fully. Fill it out based on the intent and investigation, resolving the template's `date` field to the current system date. Drain the investigation into the `## Code Map` section — annotated paths, symbol/line anchors, reuse pointers, and read-only evidence — so the spec is the implementer's investigation map and the step-03 handoff need only point at it. If `preserved_intent` is non-empty, replace the `<frozen-after-approval>` block in the spec you just filled out with `preserved_intent`, before writing. Write the result to `{spec_file}`.
-4. Self-review against READY FOR DEVELOPMENT standard.
-5. If intent gaps exist, do not fantasize, do not leave open questions, HALT and ask the human.
+4. Self-review against the READY FOR DEVELOPMENT standard. Resolve implementation choices yourself. For each material decision with multiple defensible answers that would change the observable outcome and that only the human can make, add one question to `Ask First`. Delete the entire `Ask First` section when there are no such questions.
+5. If `Ask First` contains questions, present all of them as a numbered list and HALT. Remove a question only after an explicit human answer or explicit delegation in the conversation; your inference, recommendation, assumed default, or preferred implementation does not count. Incorporate each answer into the spec. If an answer exposes another human-owned decision, add it to `Ask First` and ask again. Continue only when the section is empty, then delete it.
 6. Token count check (see SCOPE STANDARD). If spec exceeds 1600 tokens:
    - Show user the token count.
    - HALT and give the user a choice:
      - **Split** — carve off secondary goals.
      - **Keep full spec** — accept the risks.
-   - If the user chooses **Split**: Propose the split — name each secondary goal. For each deferred goal, append one new entry to `{{.implementation_artifacts}}/deferred-work.md` using this format. Do not modify existing entries or look for duplicates. Rewrite the current spec to cover only the main goal — do not surgically carve sections out; regenerate the spec for the narrowed scope. Continue to checkpoint.
+   - If the user chooses **Split**: Propose the split — name each secondary goal. For each deferred goal, append one new entry to `{{.implementation_artifacts}}/deferred-work.md` using this format. Do not modify existing entries or look for duplicates. Rewrite the current spec to cover only the main goal — do not surgically carve sections out; regenerate the spec for the narrowed scope. Repeat instructions 4–5 before continuing to checkpoint.
      ```markdown
      - source_spec: `{spec_file}`
        summary: <one sentence naming the deferred goal>
@@ -43,7 +43,7 @@ HALT and give the user a choice:
 - **Approve and stop** — approve the spec, leave it `ready-for-dev`, and stop so a fresh `bmad-build` session can resume at implementation.
 - **Review spec** — review the spec, use a subagent if available, and discuss the findings and revisions with the user until the user is ready to approve, then either stop or continue.
 
-Before acting on approval, re-read `{spec_file}` from disk. If it is missing, HALT without recreating it, changing status, or proceeding. If it changed, acknowledge the external edits and continue with the updated version. Set status `ready-for-dev`; everything inside `<frozen-after-approval>` is then locked and only the human can change it.
+Before acting on approval, re-read `{spec_file}` from disk. If it is missing, HALT without recreating it, changing status, or proceeding. If it changed, acknowledge the external edits and continue with the updated version. If it contains `Ask First` questions, keep status `draft` and return to instruction 5. Otherwise set status `ready-for-dev`; everything inside `<frozen-after-approval>` is then locked and only the human can change it.
 
 ## NEXT
 

--- a/src/bmm-skills/ship/bmad-build/step-03-implement.md
+++ b/src/bmm-skills/ship/bmad-build/step-03-implement.md
@@ -8,11 +8,13 @@
 - **Language** — Speak in `{{.communication_language}}`. Write any file output in `{{.document_output_language}}`.
 - No push. No remote ops.
 - Sequential execution only.
-- Content inside `<frozen-after-approval>` in `{spec_file}` is read-only. Do not modify.
+- Content inside `<frozen-after-approval>` in `{spec_file}` is read-only except for incorporating an explicit human answer to `Ask First` and removing the answered question.
 
 ## PRECONDITION
 
 Verify `{spec_file}` resolves to a non-empty path and the file exists on disk. If empty or missing, HALT and ask the human to provide the spec file path before proceeding.
+
+Before launching the implementation handoff, inspect `{spec_file}` for `Ask First` questions. If any remain, present them as a numbered list and HALT; the implementation session must never answer them. Remove a question only after an explicit human answer or explicit delegation, incorporate the answer throughout the spec, and ask any human-owned follow-up it exposes. Continue only when no questions remain, then delete the entire `Ask First` section.
 
 ## INSTRUCTIONS
 

--- a/src/bmm-skills/ship/bmad-build/workflow.md
+++ b/src/bmm-skills/ship/bmad-build/workflow.md
@@ -17,6 +17,7 @@ A specification is "Ready for Development" when:
 - **Complete**: No placeholders or TBDs.
 - **Sufficient**: No known requirement, acceptance, dependency, or implementation gaps remain unresolved.
 - **Coherent**: No unresolved ambiguities or internal contradictions.
+- **Human-resolved**: `Ask First` is absent; every human-owned planning question received an explicit human answer or delegation, and the result is incorporated into the spec.
 
 ## SCOPE STANDARD
 


### PR DESCRIPTION
## What

Treat `Ask First` as a planning checklist for material questions only the human can answer. A spec cannot become ready for development or reach implementation while any questions remain.

## Why

Planning models tend to select plausible defaults rather than interrupt the workflow. That can hand an invented product decision to the non-interactive implementation session as if the human had approved it.

## How

- After investigation and draft review, record only material human-owned decisions under `Ask First`.
- Present the questions and halt. Remove one only after an explicit human answer or delegation, incorporate the result into the spec, and ask any follow-up it exposes.
- Remove the section before approval and check again before the implementation handoff.

`Ask First` is planning-only; execution-time conditional approval gates are outside this change.

## Testing

- Commit-time `npm test`
- `HUSKY=0 npm ci && npm run quality`
