### PR TITLE
fix(installer): ask about deprecated shims during Quick Update, and report the outcome

### DIFF
--- a/docs/how-to/install-bmad.md
+++ b/docs/how-to/install-bmad.md
@@ -39,7 +39,7 @@ The interactive flow asks you six things when the selected modules still ship de
 
 Accept the defaults and you land on the latest stable release of every module, configured for your chosen tool.
 
-Existing installations keep their current shim choice during Quick Update. Modify Install lets you change it explicitly. Once a release no longer contains any shims, the installer stops asking and removes previously installed shims through its normal update cleanup.
+Quick Update asks the same question whenever the project still has shims installed, defaulting to keeping them so pressing enter never breaks a skill you are using. Answer No there to remove them. An installation that has already dropped its shims is not asked again. Whenever an install keeps its shims, the installer lists every one of them and what it forwards to, so you can see what is left to migrate. Once a release no longer contains any shims, the installer stops asking and removes previously installed shims through its normal update cleanup.
 
 :::tip[Just want the newest prerelease?]
 

--- a/test/test-shim-policy.js
+++ b/test/test-shim-policy.js
@@ -12,6 +12,8 @@ const {
   formatRemovedShimNotice,
   formatRetainedShimNotice,
   inferShimPreference,
+  readInstalledShims,
+  selectShimOutcome,
 } = require('../tools/installer/core/shim-policy');
 
 async function writeSkill(directory, name, lifecycle) {
@@ -191,6 +193,51 @@ async function run() {
       prompts.confirm = originalConfirm;
       process.stdin.isTTY = originalIsTTY;
     }
+
+    const installedShims = await readInstalledShims(path.join(root, 'legacy', '_bmad'));
+    assert.deepEqual(
+      installedShims.map((shim) => shim.id),
+      ['legacy-name'],
+      'installed shims are recovered from the manifest, independent of what the incoming release ships',
+    );
+    assert.deepEqual(await readInstalledShims(path.join(root, 'nothing-here')), [], 'a missing manifest reports no installed shims');
+
+    // The v7 cut: the release ships no shims at all, so nothing is discoverable
+    // in source, yet the update still deletes what is installed.
+    const v7 = selectShimOutcome({ installedShims, availableShims: [], install: false });
+    assert.equal(v7.retained.length, 0);
+    assert.deepEqual(
+      v7.removed.map((shim) => shim.id),
+      ['legacy-name'],
+      'a shimless release still reports the shims it is deleting',
+    );
+    const v7Notice = formatRemovedShimNotice(v7.removed, { canReinstall: false });
+    assert.match(v7Notice, /legacy-name/, 'the retired shim is named in the notice');
+    assert.match(v7Notice, /--shims cannot bring them back/, 'a retired shim is not advertised as reinstallable');
+    assert.match(formatRemovedShimNotice(v7.removed), /re-run with --shims/, 'a shim the release still ships can be restored');
+
+    // A shim retired from source while the user keeps the rest: retained and
+    // removed are both non-empty in the same run.
+    const partial = selectShimOutcome({
+      installedShims: [{ id: 'still-shipped' }, { id: 'retired' }],
+      availableShims: [{ id: 'still-shipped' }],
+      install: true,
+    });
+    assert.deepEqual(
+      partial.retained.map((shim) => shim.id),
+      ['still-shipped'],
+    );
+    assert.deepEqual(
+      partial.removed.map((shim) => shim.id),
+      ['retired'],
+      'a shim dropped from source is reported as removed even while shims stay enabled',
+    );
+
+    assert.deepEqual(
+      selectShimOutcome({ installedShims, availableShims: [{ id: 'legacy-name' }], install: true }).removed,
+      [],
+      'nothing is reported removed when the shim is reinstalled',
+    );
 
     const manifestDir = path.join(root, 'manifest', '_config');
     await fs.ensureDir(manifestDir);

--- a/test/test-shim-policy.js
+++ b/test/test-shim-policy.js
@@ -7,7 +7,7 @@ const prompts = require('../tools/installer/prompts');
 const { ManifestGenerator } = require('../tools/installer/core/manifest-generator');
 const { OfficialModules } = require('../tools/installer/modules/official-modules');
 const { UI } = require('../tools/installer/ui');
-const { discoverShims, inferShimPreference } = require('../tools/installer/core/shim-policy');
+const { discoverShims, formatRetainedShimNotice, inferShimPreference } = require('../tools/installer/core/shim-policy');
 
 async function writeSkill(directory, name, lifecycle) {
   await fs.ensureDir(directory);
@@ -32,6 +32,11 @@ async function run() {
       discovered.map((entry) => entry.id),
       ['legacy-name'],
       'shim discovery uses lifecycle metadata rather than directory naming',
+    );
+    assert.equal(
+      discovered[0].description,
+      'Deprecated compatibility entry',
+      'discovery carries the description used to name the replacement',
     );
 
     assert.equal(inferShimPreference({ availableShims: discovered, existing: false }), false, 'fresh installations default shims off');
@@ -124,6 +129,45 @@ async function run() {
       });
       assert.equal(offeredDefault, true, 'an existing installation containing shims keeps them enabled by default');
       assert.equal(disabledByUser, false, 'the interactive result records the user explicitly disabling shims');
+
+      // Quick Update is the path most users live on, so it has to ask too —
+      // otherwise shims ride along forever without ever being offered up.
+      let quickUpdatePrompts = 0;
+      let quickUpdateDefault;
+      prompts.confirm = async (question) => {
+        quickUpdatePrompts++;
+        quickUpdateDefault = question.default;
+        return question.default;
+      };
+      const quickUpdateKept = await new UI()._selectShimPreference({
+        selectedModules: ['core'],
+        bmadDir: legacyBmadDir,
+        existing: true,
+        options: {},
+        channelOptions: null,
+        quickUpdate: true,
+      });
+      assert.equal(quickUpdatePrompts, 1, 'quick update asks before carrying shims forward again');
+      assert.equal(quickUpdateDefault, true, 'quick update defaults to keeping shims that are already installed');
+      assert.equal(quickUpdateKept, true, 'accepting the default retains the shims');
+
+      const shimlessBmadDir = path.join(root, 'shimless', '_bmad');
+      await fs.ensureDir(path.join(shimlessBmadDir, '_config'));
+      await fs.writeFile(
+        path.join(shimlessBmadDir, '_config', 'manifest.yaml'),
+        yaml.stringify({ installation: { version: '6.11.0', installShims: false }, modules: [], ides: [] }),
+      );
+      quickUpdatePrompts = 0;
+      const quickUpdateSkipped = await new UI()._selectShimPreference({
+        selectedModules: ['core'],
+        bmadDir: shimlessBmadDir,
+        existing: true,
+        options: {},
+        channelOptions: null,
+        quickUpdate: true,
+      });
+      assert.equal(quickUpdatePrompts, 0, 'quick update stays quiet for an installation that already removed its shims');
+      assert.equal(quickUpdateSkipped, false, 'a shimless installation keeps its standing answer');
     } finally {
       OfficialModules.prototype.discoverShims = originalDiscover;
       prompts.confirm = originalConfirm;
@@ -146,6 +190,18 @@ async function run() {
     await generator.writeMainManifest(manifestDir);
     const availableManifest = yaml.parse(await fs.readFile(path.join(manifestDir, 'manifest.yaml'), 'utf8'));
     assert.equal(availableManifest.installation.installShims, false, 'the active user preference is persisted while shims exist');
+
+    const notice = formatRetainedShimNotice([
+      { id: 'bmad-market-research', description: 'Deprecated — forwards to bmad-deep-recon (market type)', module: 'bmm' },
+      { id: 'bmad-editorial-review', description: 'Deprecated — forwards to bmad-review' },
+      { id: 'no-description' },
+    ]);
+    assert.match(notice, /3 deprecated shim skill\(s\) are still installed/, 'the notice counts what is being kept');
+    assert.match(notice, /bmad-market-research \(bmm\): forwards to bmad-deep-recon \(market type\)/, 'each shim names its replacement');
+    assert.match(notice, /bmad-editorial-review: forwards to bmad-review/, 'the module suffix is omitted when unknown');
+    assert.match(notice, /^ {2}no-description$/m, 'a shim without a description still gets listed');
+    assert.match(notice, /re-run Quick Update/, 'the notice tells the user how to remove them');
+    assert.equal(/Deprecated\s*—\s*forwards/.test(notice), false, 'the redundant "Deprecated" prefix is stripped from each line');
 
     console.log('Shim installation policy tests passed.');
   } finally {

--- a/test/test-shim-policy.js
+++ b/test/test-shim-policy.js
@@ -94,9 +94,7 @@ async function run() {
     const originalIsTTY = process.stdin.isTTY;
     let confirmCalls = 0;
     try {
-      // These cases exercise the interactive branch; the test process itself
-      // has no TTY, which the prompt now treats as "nobody is there to answer".
-      process.stdin.isTTY = true;
+      process.stdin.isTTY = true; // the prompt now skips itself without a TTY
       OfficialModules.prototype.discoverShims = async () => [];
       prompts.confirm = async () => {
         confirmCalls++;
@@ -139,8 +137,6 @@ async function run() {
       assert.equal(offeredDefault, true, 'an existing installation containing shims keeps them enabled by default');
       assert.equal(disabledByUser, false, 'the interactive result records the user explicitly disabling shims');
 
-      // Quick Update is the path most users live on, so it has to ask too —
-      // otherwise shims ride along forever without ever being offered up.
       let quickUpdatePrompts = 0;
       let quickUpdateDefault;
       prompts.confirm = async (question) => {
@@ -178,9 +174,6 @@ async function run() {
       assert.equal(quickUpdatePrompts, 0, 'quick update stays quiet for an installation that already removed its shims');
       assert.equal(quickUpdateSkipped, false, 'a shimless installation keeps its standing answer');
 
-      // A scripted `--action quick-update` has no TTY. Prompting there hangs
-      // clack's confirm forever and the process exits mid-install in silence,
-      // so the standing answer has to win without asking.
       process.stdin.isTTY = undefined;
       quickUpdatePrompts = 0;
       const headless = await new UI()._selectShimPreference({

--- a/test/test-shim-policy.js
+++ b/test/test-shim-policy.js
@@ -7,7 +7,12 @@ const prompts = require('../tools/installer/prompts');
 const { ManifestGenerator } = require('../tools/installer/core/manifest-generator');
 const { OfficialModules } = require('../tools/installer/modules/official-modules');
 const { UI } = require('../tools/installer/ui');
-const { discoverShims, formatRetainedShimNotice, inferShimPreference } = require('../tools/installer/core/shim-policy');
+const {
+  discoverShims,
+  formatRemovedShimNotice,
+  formatRetainedShimNotice,
+  inferShimPreference,
+} = require('../tools/installer/core/shim-policy');
 
 async function writeSkill(directory, name, lifecycle) {
   await fs.ensureDir(directory);
@@ -86,8 +91,12 @@ async function run() {
 
     const originalDiscover = OfficialModules.prototype.discoverShims;
     const originalConfirm = prompts.confirm;
+    const originalIsTTY = process.stdin.isTTY;
     let confirmCalls = 0;
     try {
+      // These cases exercise the interactive branch; the test process itself
+      // has no TTY, which the prompt now treats as "nobody is there to answer".
+      process.stdin.isTTY = true;
       OfficialModules.prototype.discoverShims = async () => [];
       prompts.confirm = async () => {
         confirmCalls++;
@@ -168,9 +177,26 @@ async function run() {
       });
       assert.equal(quickUpdatePrompts, 0, 'quick update stays quiet for an installation that already removed its shims');
       assert.equal(quickUpdateSkipped, false, 'a shimless installation keeps its standing answer');
+
+      // A scripted `--action quick-update` has no TTY. Prompting there hangs
+      // clack's confirm forever and the process exits mid-install in silence,
+      // so the standing answer has to win without asking.
+      process.stdin.isTTY = undefined;
+      quickUpdatePrompts = 0;
+      const headless = await new UI()._selectShimPreference({
+        selectedModules: ['core'],
+        bmadDir: legacyBmadDir,
+        existing: true,
+        options: {},
+        channelOptions: null,
+        quickUpdate: true,
+      });
+      assert.equal(quickUpdatePrompts, 0, 'a run with no TTY never reaches the prompt');
+      assert.equal(headless, true, 'a headless run keeps the shims it already had');
     } finally {
       OfficialModules.prototype.discoverShims = originalDiscover;
       prompts.confirm = originalConfirm;
+      process.stdin.isTTY = originalIsTTY;
     }
 
     const manifestDir = path.join(root, 'manifest', '_config');
@@ -201,6 +227,13 @@ async function run() {
     assert.match(notice, /bmad-editorial-review: forwards to bmad-review/, 'the module suffix is omitted when unknown');
     assert.match(notice, /^ {2}no-description$/m, 'a shim without a description still gets listed');
     assert.match(notice, /re-run Quick Update/, 'the notice tells the user how to remove them');
+
+    const removalNotice = formatRemovedShimNotice([
+      { id: 'bmad-market-research', description: 'Deprecated — forwards to bmad-deep-recon (market type)', module: 'bmm' },
+    ]);
+    assert.match(removalNotice, /1 deprecated shim skill\(s\) are being removed/, 'removal is reported, not silent');
+    assert.match(removalNotice, /bmad-market-research \(bmm\): forwards to bmad-deep-recon/, 'the removal names what is going away');
+    assert.match(removalNotice, /--shims/, 'the removal notice says how to undo it');
     assert.equal(/Deprecated\s*—\s*forwards/.test(notice), false, 'the redundant "Deprecated" prefix is stripped from each line');
 
     console.log('Shim installation policy tests passed.');

--- a/tools/installer/core/installer.js
+++ b/tools/installer/core/installer.js
@@ -59,10 +59,7 @@ class Installer {
         }),
       };
 
-      // Reported here rather than at the prompt so it also reaches the paths
-      // that never prompt: --yes, --shims, and a scripted quick update. Every
-      // run that has shims either way says which way it went, because removal
-      // is otherwise completely silent.
+      // Reported here, not at the prompt, so --yes/--shims/scripted runs get it too.
       const removedShims = shimPolicy.install ? [] : availableShims.filter((shim) => installedSkillIds.has(shim.id));
       if (shimPolicy.available && shimPolicy.install) {
         await prompts.note(formatRetainedShimNotice(availableShims), 'Deprecated shim skills retained');
@@ -70,9 +67,7 @@ class Installer {
         await prompts.note(formatRemovedShimNotice(removedShims), 'Deprecated shim skills removed');
       }
 
-      // The notice above lands before the install tasks run, so a long install
-      // buries it. Carry the outcome down to the final summary too, the same
-      // way the uv warning is repeated there.
+      // The notice above scrolls away on a long install; repeat it in the summary.
       let shimStatus = null;
       if (shimPolicy.available && shimPolicy.install) {
         shimStatus = { kind: 'retained', count: availableShims.length };

--- a/tools/installer/core/installer.js
+++ b/tools/installer/core/installer.js
@@ -13,7 +13,7 @@ const { InstallPaths } = require('./install-paths');
 const { ExternalModuleManager } = require('../modules/external-manager');
 const { resolveModuleVersion } = require('../modules/version-resolver');
 const { MODULE_HELP_CSV_HEADER } = require('../modules/module-help-schema');
-const { formatRetainedShimNotice, inferShimPreference, readInstalledSkillIds } = require('./shim-policy');
+const { formatRemovedShimNotice, formatRetainedShimNotice, inferShimPreference, readInstalledSkillIds } = require('./shim-policy');
 
 const { ExistingInstall } = require('./existing-install');
 const { warnPreNativeSkillsLegacy } = require('./legacy-warnings');
@@ -59,10 +59,17 @@ class Installer {
         }),
       };
 
-      // Resolved here rather than at the prompt so it also reaches the paths
-      // that never prompt: --yes, --shims, and a scripted quick update.
+      // Reported here rather than at the prompt so it also reaches the paths
+      // that never prompt: --yes, --shims, and a scripted quick update. Every
+      // run that has shims either way says which way it went, because removal
+      // is otherwise completely silent.
       if (shimPolicy.available && shimPolicy.install) {
         await prompts.note(formatRetainedShimNotice(availableShims), 'Deprecated shim skills retained');
+      } else {
+        const removedShims = availableShims.filter((shim) => installedSkillIds.has(shim.id));
+        if (removedShims.length > 0) {
+          await prompts.note(formatRemovedShimNotice(removedShims), 'Deprecated shim skills removed');
+        }
       }
 
       try {

--- a/tools/installer/core/installer.js
+++ b/tools/installer/core/installer.js
@@ -13,7 +13,7 @@ const { InstallPaths } = require('./install-paths');
 const { ExternalModuleManager } = require('../modules/external-manager');
 const { resolveModuleVersion } = require('../modules/version-resolver');
 const { MODULE_HELP_CSV_HEADER } = require('../modules/module-help-schema');
-const { inferShimPreference, readInstalledSkillIds } = require('./shim-policy');
+const { formatRetainedShimNotice, inferShimPreference, readInstalledSkillIds } = require('./shim-policy');
 
 const { ExistingInstall } = require('./existing-install');
 const { warnPreNativeSkillsLegacy } = require('./legacy-warnings');
@@ -58,6 +58,12 @@ class Installer {
           existing: existingInstall.installed,
         }),
       };
+
+      // Resolved here rather than at the prompt so it also reaches the paths
+      // that never prompt: --yes, --shims, and a scripted quick update.
+      if (shimPolicy.available && shimPolicy.install) {
+        await prompts.note(formatRetainedShimNotice(availableShims), 'Deprecated shim skills retained');
+      }
 
       try {
         await warnPreNativeSkillsLegacy({

--- a/tools/installer/core/installer.js
+++ b/tools/installer/core/installer.js
@@ -63,13 +63,21 @@ class Installer {
       // that never prompt: --yes, --shims, and a scripted quick update. Every
       // run that has shims either way says which way it went, because removal
       // is otherwise completely silent.
+      const removedShims = shimPolicy.install ? [] : availableShims.filter((shim) => installedSkillIds.has(shim.id));
       if (shimPolicy.available && shimPolicy.install) {
         await prompts.note(formatRetainedShimNotice(availableShims), 'Deprecated shim skills retained');
-      } else {
-        const removedShims = availableShims.filter((shim) => installedSkillIds.has(shim.id));
-        if (removedShims.length > 0) {
-          await prompts.note(formatRemovedShimNotice(removedShims), 'Deprecated shim skills removed');
-        }
+      } else if (removedShims.length > 0) {
+        await prompts.note(formatRemovedShimNotice(removedShims), 'Deprecated shim skills removed');
+      }
+
+      // The notice above lands before the install tasks run, so a long install
+      // buries it. Carry the outcome down to the final summary too, the same
+      // way the uv warning is repeated there.
+      let shimStatus = null;
+      if (shimPolicy.available && shimPolicy.install) {
+        shimStatus = { kind: 'retained', count: availableShims.length };
+      } else if (removedShims.length > 0) {
+        shimStatus = { kind: 'removed', count: removedShims.length };
       }
 
       try {
@@ -145,6 +153,7 @@ class Installer {
         customFiles: restoreResult.customFiles.length > 0 ? restoreResult.customFiles : undefined,
         modifiedFiles: restoreResult.modifiedFiles.length > 0 ? restoreResult.modifiedFiles : undefined,
         preInstallVersions,
+        shimStatus,
       });
 
       return {
@@ -1273,6 +1282,11 @@ class Installer {
     }
     if (context.modifiedFiles && context.modifiedFiles.length > 0) {
       lines.push(`  ${color.yellow(`Modified files backed up (.bak): ${context.modifiedFiles.length}`)}`);
+    }
+    if (context.shimStatus?.kind === 'retained') {
+      lines.push(`  ${color.yellow(`Deprecated shim skills retained: ${context.shimStatus.count}`)} (re-run to remove them)`);
+    } else if (context.shimStatus?.kind === 'removed') {
+      lines.push(`  ${color.green(`Deprecated shim skills removed: ${context.shimStatus.count}`)}`);
     }
 
     // Next steps

--- a/tools/installer/core/installer.js
+++ b/tools/installer/core/installer.js
@@ -13,7 +13,14 @@ const { InstallPaths } = require('./install-paths');
 const { ExternalModuleManager } = require('../modules/external-manager');
 const { resolveModuleVersion } = require('../modules/version-resolver');
 const { MODULE_HELP_CSV_HEADER } = require('../modules/module-help-schema');
-const { formatRemovedShimNotice, formatRetainedShimNotice, inferShimPreference, readInstalledSkillIds } = require('./shim-policy');
+const {
+  formatRemovedShimNotice,
+  formatRetainedShimNotice,
+  inferShimPreference,
+  readInstalledShims,
+  readInstalledSkillIds,
+  selectShimOutcome,
+} = require('./shim-policy');
 
 const { ExistingInstall } = require('./existing-install');
 const { warnPreNativeSkillsLegacy } = require('./legacy-warnings');
@@ -59,21 +66,23 @@ class Installer {
         }),
       };
 
+      const installedShims = existingInstall.installed ? await readInstalledShims(paths.bmadDir) : [];
+      const { retained: retainedShims, removed: removedShims } = selectShimOutcome({
+        installedShims,
+        availableShims,
+        install: shimPolicy.install,
+      });
+
       // Reported here, not at the prompt, so --yes/--shims/scripted runs get it too.
-      const removedShims = shimPolicy.install ? [] : availableShims.filter((shim) => installedSkillIds.has(shim.id));
-      if (shimPolicy.available && shimPolicy.install) {
-        await prompts.note(formatRetainedShimNotice(availableShims), 'Deprecated shim skills retained');
-      } else if (removedShims.length > 0) {
-        await prompts.note(formatRemovedShimNotice(removedShims), 'Deprecated shim skills removed');
+      if (retainedShims.length > 0) {
+        await prompts.note(formatRetainedShimNotice(retainedShims), 'Deprecated shim skills retained');
+      }
+      if (removedShims.length > 0) {
+        await prompts.note(formatRemovedShimNotice(removedShims, { canReinstall: shimPolicy.available }), 'Deprecated shim skills removed');
       }
 
-      // The notice above scrolls away on a long install; repeat it in the summary.
-      let shimStatus = null;
-      if (shimPolicy.available && shimPolicy.install) {
-        shimStatus = { kind: 'retained', count: availableShims.length };
-      } else if (removedShims.length > 0) {
-        shimStatus = { kind: 'removed', count: removedShims.length };
-      }
+      // The notices above scroll away on a long install; repeat them in the summary.
+      const shimStatus = { retained: retainedShims.length, removed: removedShims.length };
 
       try {
         await warnPreNativeSkillsLegacy({
@@ -1278,10 +1287,11 @@ class Installer {
     if (context.modifiedFiles && context.modifiedFiles.length > 0) {
       lines.push(`  ${color.yellow(`Modified files backed up (.bak): ${context.modifiedFiles.length}`)}`);
     }
-    if (context.shimStatus?.kind === 'retained') {
-      lines.push(`  ${color.yellow(`Deprecated shim skills retained: ${context.shimStatus.count}`)} (re-run to remove them)`);
-    } else if (context.shimStatus?.kind === 'removed') {
-      lines.push(`  ${color.green(`Deprecated shim skills removed: ${context.shimStatus.count}`)}`);
+    if (context.shimStatus?.retained > 0) {
+      lines.push(`  ${color.yellow(`Deprecated shim skills retained: ${context.shimStatus.retained}`)} (re-run to remove them)`);
+    }
+    if (context.shimStatus?.removed > 0) {
+      lines.push(`  ${color.green(`Deprecated shim skills removed: ${context.shimStatus.removed}`)}`);
     }
 
     // Next steps

--- a/tools/installer/core/shim-policy.js
+++ b/tools/installer/core/shim-policy.js
@@ -113,8 +113,28 @@ function formatRetainedShimNotice(availableShims = []) {
   ].join('\n');
 }
 
+/**
+ * Counterpart to the retained notice, for the run that takes shims away.
+ * Removal is silent everywhere else in the installer, so without this a
+ * headless run gives no sign that a skill the user may still be invoking
+ * just disappeared.
+ */
+function formatRemovedShimNotice(removedShims = []) {
+  const lines = removedShims.map((shim) => describeShim(shim)).sort();
+
+  return [
+    `${removedShims.length} deprecated shim skill(s) are being removed. Invoking these names will no longer work:`,
+    '',
+    ...lines,
+    '',
+    'Each replacement named above is installed and ready. If you still had a customization on one of',
+    'these shims, move it to the replacement, or re-run with --shims to put the shims back.',
+  ].join('\n');
+}
+
 module.exports = {
   describeShim,
+  formatRemovedShimNotice,
   discoverShims,
   formatRetainedShimNotice,
   inferShimPreference,

--- a/tools/installer/core/shim-policy.js
+++ b/tools/installer/core/shim-policy.js
@@ -55,23 +55,38 @@ async function discoverShims(modulePath) {
   return shims;
 }
 
-async function readInstalledSkillIds(bmadDir) {
-  const ids = new Set();
+async function readSkillManifest(bmadDir) {
   const manifestPath = path.join(bmadDir, '_config', 'skill-manifest.csv');
-  if (!(await fs.pathExists(manifestPath))) return ids;
+  if (!(await fs.pathExists(manifestPath))) return [];
 
   try {
     const content = await fs.readFile(manifestPath, 'utf8');
-    const records = csv.parse(content, { columns: true, skip_empty_lines: true });
-    for (const record of records) {
-      if (record.canonicalId) ids.add(record.canonicalId);
-    }
+    return csv.parse(content, { columns: true, skip_empty_lines: true });
   } catch {
     // A missing or unreadable legacy manifest means there is no reliable
     // evidence that compatibility shims were installed.
+    return [];
   }
+}
 
+async function readInstalledSkillIds(bmadDir) {
+  const ids = new Set();
+  for (const record of await readSkillManifest(bmadDir)) {
+    if (record.canonicalId) ids.add(record.canonicalId);
+  }
   return ids;
+}
+
+// The installed manifest carries no lifecycle column, so the description
+// prefix every shim ships with is the only record of what was a shim. This
+// is the same signal validate-skills.js uses to exempt them.
+async function readInstalledShims(bmadDir) {
+  const shims = [];
+  for (const record of await readSkillManifest(bmadDir)) {
+    if (!record.canonicalId || !/^\s*deprecated\b/i.test(record.description || '')) continue;
+    shims.push({ id: record.canonicalId, description: record.description || '', module: record.module || '' });
+  }
+  return shims;
 }
 
 function inferShimPreference({ requested, persisted, availableShims = [], installedSkillIds = new Set(), existing = false }) {
@@ -81,6 +96,16 @@ function inferShimPreference({ requested, persisted, availableShims = [], instal
   if (!existing) return false;
 
   return availableShims.some((shim) => installedSkillIds.has(shim.id));
+}
+
+// Removal is driven by what is installed, not by what this release ships: a
+// shim retired from source is still deleted by the update cleanup.
+function selectShimOutcome({ installedShims = [], availableShims = [], install = false }) {
+  const availableShimIds = new Set(availableShims.map((shim) => shim.id));
+  return {
+    retained: install ? availableShims : [],
+    removed: installedShims.filter((shim) => !(install && availableShimIds.has(shim.id))),
+  };
 }
 
 // Shim descriptions all open with "Deprecated — "; the notice heading says it once.
@@ -104,8 +129,11 @@ function formatRetainedShimNotice(availableShims = []) {
   ].join('\n');
 }
 
-function formatRemovedShimNotice(removedShims = []) {
+function formatRemovedShimNotice(removedShims = [], { canReinstall = true } = {}) {
   const lines = removedShims.map((shim) => describeShim(shim)).sort();
+  const recovery = canReinstall
+    ? 'these shims, move it to the replacement, or re-run with --shims to put the shims back.'
+    : 'these shims, move it to the replacement. This release no longer ships them, so --shims cannot bring them back.';
 
   return [
     `${removedShims.length} deprecated shim skill(s) are being removed. Invoking these names will no longer work:`,
@@ -113,7 +141,7 @@ function formatRemovedShimNotice(removedShims = []) {
     ...lines,
     '',
     'Each replacement named above is installed and ready. If you still had a customization on one of',
-    'these shims, move it to the replacement, or re-run with --shims to put the shims back.',
+    recovery,
   ].join('\n');
 }
 
@@ -125,5 +153,7 @@ module.exports = {
   inferShimPreference,
   isShimSkill,
   parseSkillMetadata,
+  readInstalledShims,
   readInstalledSkillIds,
+  selectShimOutcome,
 };

--- a/tools/installer/core/shim-policy.js
+++ b/tools/installer/core/shim-policy.js
@@ -37,6 +37,7 @@ async function discoverShims(modulePath) {
       if (isShimSkill(metadata)) {
         shims.push({
           id: metadata.name || path.basename(dir),
+          description: typeof metadata.description === 'string' ? metadata.description : '',
           directory: dir,
           relativeDirectory: path.relative(modulePath, dir),
         });
@@ -82,8 +83,40 @@ function inferShimPreference({ requested, persisted, availableShims = [], instal
   return availableShims.some((shim) => installedSkillIds.has(shim.id));
 }
 
+/**
+ * Every shim description already opens with "Deprecated — forwards to X".
+ * The heading of the notice says that once, so strip the prefix rather than
+ * repeating it on all twenty lines.
+ */
+function describeShim(shim) {
+  const cleaned = (shim.description || '').replace(/^\s*deprecated\s*[-–—:]*\s*/i, '').trim();
+  const source = shim.module ? ` (${shim.module})` : '';
+  return cleaned ? `  ${shim.id}${source}: ${cleaned}` : `  ${shim.id}${source}`;
+}
+
+/**
+ * Body of the notice shown whenever an install keeps its compatibility shims.
+ * Names every shim so the user can see what is still forwarding, and what it
+ * forwards to, without going digging.
+ */
+function formatRetainedShimNotice(availableShims = []) {
+  const lines = availableShims.map((shim) => describeShim(shim)).sort();
+
+  return [
+    `${availableShims.length} deprecated shim skill(s) are still installed. Each one only forwards to the skill that replaced it:`,
+    '',
+    ...lines,
+    '',
+    'Shims will be removed with v7, and anything still calling the old name stops working then.',
+    'Only keep a shim if you customized it and still need to move that customization to the replacement.',
+    'Once you have, re-run Quick Update and answer No to this question so the shims come off.',
+  ].join('\n');
+}
+
 module.exports = {
+  describeShim,
   discoverShims,
+  formatRetainedShimNotice,
   inferShimPreference,
   isShimSkill,
   parseSkillMetadata,

--- a/tools/installer/core/shim-policy.js
+++ b/tools/installer/core/shim-policy.js
@@ -83,22 +83,13 @@ function inferShimPreference({ requested, persisted, availableShims = [], instal
   return availableShims.some((shim) => installedSkillIds.has(shim.id));
 }
 
-/**
- * Every shim description already opens with "Deprecated — forwards to X".
- * The heading of the notice says that once, so strip the prefix rather than
- * repeating it on all twenty lines.
- */
+// Shim descriptions all open with "Deprecated — "; the notice heading says it once.
 function describeShim(shim) {
   const cleaned = (shim.description || '').replace(/^\s*deprecated\s*[-–—:]*\s*/i, '').trim();
   const source = shim.module ? ` (${shim.module})` : '';
   return cleaned ? `  ${shim.id}${source}: ${cleaned}` : `  ${shim.id}${source}`;
 }
 
-/**
- * Body of the notice shown whenever an install keeps its compatibility shims.
- * Names every shim so the user can see what is still forwarding, and what it
- * forwards to, without going digging.
- */
 function formatRetainedShimNotice(availableShims = []) {
   const lines = availableShims.map((shim) => describeShim(shim)).sort();
 
@@ -113,12 +104,6 @@ function formatRetainedShimNotice(availableShims = []) {
   ].join('\n');
 }
 
-/**
- * Counterpart to the retained notice, for the run that takes shims away.
- * Removal is silent everywhere else in the installer, so without this a
- * headless run gives no sign that a skill the user may still be invoking
- * just disappeared.
- */
 function formatRemovedShimNotice(removedShims = []) {
   const lines = removedShims.map((shim) => describeShim(shim)).sort();
 

--- a/tools/installer/prompts.js
+++ b/tools/installer/prompts.js
@@ -317,9 +317,6 @@ async function autocompleteMultiselect(options) {
       switch (this.state) {
         case 'submit': {
           const count = this.selectedValues.length;
-          // An empty selection is legitimate for some pickers (core is always
-          // installed, so no rows checked still installs something). Say what
-          // it means, otherwise "0 items selected" reads as a no-op.
           const emptyHint = count === 0 && options.emptyLabel ? ` (${options.emptyLabel})` : '';
           return `${title}${color.gray(clack.S_BAR)}  ${color.dim(`${count} item${count === 1 ? '' : 's'} selected${emptyHint}`)}`;
         }
@@ -336,7 +333,6 @@ async function autocompleteMultiselect(options) {
 
           const errorLine = this.state === 'error' ? [`${bar}  ${color.yellow(this.error)}`] : [];
 
-          // Same reasoning as the submit state, shown before they commit.
           const emptyLine =
             this.selectedValues.length === 0 && options.emptyLabel
               ? [`${bar}  ${color.dim(`Nothing selected: installs ${options.emptyLabel}`)}`]

--- a/tools/installer/prompts.js
+++ b/tools/installer/prompts.js
@@ -316,7 +316,12 @@ async function autocompleteMultiselect(options) {
 
       switch (this.state) {
         case 'submit': {
-          return `${title}${color.gray(clack.S_BAR)}  ${color.dim(`${this.selectedValues.length} items selected`)}`;
+          const count = this.selectedValues.length;
+          // An empty selection is legitimate for some pickers (core is always
+          // installed, so no rows checked still installs something). Say what
+          // it means, otherwise "0 items selected" reads as a no-op.
+          const emptyHint = count === 0 && options.emptyLabel ? ` (${options.emptyLabel})` : '';
+          return `${title}${color.gray(clack.S_BAR)}  ${color.dim(`${count} item${count === 1 ? '' : 's'} selected${emptyHint}`)}`;
         }
 
         case 'cancel': {
@@ -331,7 +336,19 @@ async function autocompleteMultiselect(options) {
 
           const errorLine = this.state === 'error' ? [`${bar}  ${color.yellow(this.error)}`] : [];
 
-          const headerLines = [...`${title}${bar}`.split('\n'), `${bar}  ${searchDisplay}${matchCount}`, ...noMatchesLine, ...errorLine];
+          // Same reasoning as the submit state, shown before they commit.
+          const emptyLine =
+            this.selectedValues.length === 0 && options.emptyLabel
+              ? [`${bar}  ${color.dim(`Nothing selected: installs ${options.emptyLabel}`)}`]
+              : [];
+
+          const headerLines = [
+            ...`${title}${bar}`.split('\n'),
+            `${bar}  ${searchDisplay}${matchCount}`,
+            ...noMatchesLine,
+            ...errorLine,
+            ...emptyLine,
+          ];
 
           const footerLines = [`${bar}  ${color.dim(hints.join(' • '))}`, `${barEnd}`];
 

--- a/tools/installer/ui.js
+++ b/tools/installer/ui.js
@@ -132,6 +132,12 @@ class UI {
 
     if (typeof options.shims === 'boolean' || options.yes) return currentValue;
 
+    // A scripted run (`--action quick-update` with no `--yes`) has nobody to
+    // answer this. clack's confirm never resolves without a TTY, so asking
+    // would drain the event loop and exit mid-install without a word. Keep the
+    // standing answer; `--shims`/`--no-shims` remain the way to change it.
+    if (!process.stdin.isTTY) return currentValue;
+
     // Quick Update asks only when the project actually has shims to give up.
     // Someone who already dropped them has nothing to decide, and re-asking on
     // every update would train them to skip past the question.

--- a/tools/installer/ui.js
+++ b/tools/installer/ui.js
@@ -111,7 +111,7 @@ async function getModuleVersion(moduleCode, { repoUrl = null, registryDefault = 
  * UI utilities for the installer
  */
 class UI {
-  async _selectShimPreference({ selectedModules, bmadDir, existing, options, channelOptions }) {
+  async _selectShimPreference({ selectedModules, bmadDir, existing, options, channelOptions, quickUpdate = false }) {
     const { OfficialModules } = require('./modules/official-modules');
     const officialModules = new OfficialModules({ channelOptions });
     const availableShims = await officialModules.discoverShims(selectedModules, { channelOptions });
@@ -132,10 +132,22 @@ class UI {
 
     if (typeof options.shims === 'boolean' || options.yes) return currentValue;
 
-    return prompts.confirm({
-      message: `Install ${availableShims.length} deprecated compatibility shim skill(s)?`,
-      default: currentValue,
-    });
+    // Quick Update asks only when the project actually has shims to give up.
+    // Someone who already dropped them has nothing to decide, and re-asking on
+    // every update would train them to skip past the question.
+    if (quickUpdate && !currentValue) return currentValue;
+
+    // Keeping shims is the safe answer, so it stays the default: nobody loses a
+    // working skill by pressing enter. The wording carries the recommendation
+    // instead, and names the one case that justifies a yes.
+    const verb = currentValue ? 'Keep' : 'Install';
+    const message =
+      `${verb} ${availableShims.length} deprecated compatibility shim skill(s)? Recommended: No. ` +
+      `If you say yes, the deprecated skills will exist as a skill that forwards to its replacement skill. ` +
+      `Shims will be removed with v7. You should only retain if you customized a shimmed skill and need to ` +
+      `still transition it to the replacement.`;
+
+    return prompts.confirm({ message, default: currentValue });
   }
 
   /**
@@ -346,11 +358,24 @@ class UI {
         // Quick update never shows the module picker, so this is the only
         // place an existing install of a deprecated module hears about it.
         await this._warnDeprecatedModules(existingInstall.moduleIds || []);
+
+        // Same reasoning for shims: without this, someone who only ever runs
+        // Quick Update carries their shims forward release after release and is
+        // never once offered the chance to drop them.
+        const installShims = await this._selectShimPreference({
+          selectedModules: existingInstall.moduleIds || [],
+          bmadDir,
+          existing: true,
+          options,
+          channelOptions,
+          quickUpdate: true,
+        });
+
         return {
           actionType: 'quick-update',
           directory: confirmedDirectory,
           skipPrompts: options.yes || false,
-          installShims: options.shims,
+          installShims: installShims === undefined ? options.shims : installShims,
         };
       }
 

--- a/tools/installer/ui.js
+++ b/tools/installer/ui.js
@@ -132,20 +132,12 @@ class UI {
 
     if (typeof options.shims === 'boolean' || options.yes) return currentValue;
 
-    // A scripted run (`--action quick-update` with no `--yes`) has nobody to
-    // answer this. clack's confirm never resolves without a TTY, so asking
-    // would drain the event loop and exit mid-install without a word. Keep the
-    // standing answer; `--shims`/`--no-shims` remain the way to change it.
+    // clack's confirm never resolves without a TTY: a scripted run would exit mid-install.
     if (!process.stdin.isTTY) return currentValue;
 
-    // Quick Update asks only when the project actually has shims to give up.
-    // Someone who already dropped them has nothing to decide, and re-asking on
-    // every update would train them to skip past the question.
+    // Nothing to give up, so nothing to ask on every single update.
     if (quickUpdate && !currentValue) return currentValue;
 
-    // Keeping shims is the safe answer, so it stays the default: nobody loses a
-    // working skill by pressing enter. The wording carries the recommendation
-    // instead, and names the one case that justifies a yes.
     const verb = currentValue ? 'Keep' : 'Install';
     const message =
       `${verb} ${availableShims.length} deprecated compatibility shim skill(s)? Recommended: No. ` +
@@ -365,9 +357,6 @@ class UI {
         // place an existing install of a deprecated module hears about it.
         await this._warnDeprecatedModules(existingInstall.moduleIds || []);
 
-        // Same reasoning for shims: without this, someone who only ever runs
-        // Quick Update carries their shims forward release after release and is
-        // never once offered the chance to drop them.
         const installShims = await this._selectShimPreference({
           selectedModules: existingInstall.moduleIds || [],
           bmadDir,
@@ -1147,10 +1136,7 @@ class UI {
       message: 'Select official modules to install:',
       options: allOptions,
       initialValues: initialValues.length > 0 ? initialValues : undefined,
-      // Not required: core is installed either way, so an empty selection is a
-      // legitimate "core only" install rather than a mistake to block on. It
-      // does need saying, though: core is not a row here, so an empty picker
-      // otherwise looks like it is about to install nothing at all.
+      // Core installs either way and is not a row here, so empty is a valid core-only install.
       required: false,
       emptyLabel: 'core only',
       maxItems: allOptions.length,

--- a/tools/installer/ui.js
+++ b/tools/installer/ui.js
@@ -1148,8 +1148,11 @@ class UI {
       options: allOptions,
       initialValues: initialValues.length > 0 ? initialValues : undefined,
       // Not required: core is installed either way, so an empty selection is a
-      // legitimate "core only" install rather than a mistake to block on.
+      // legitimate "core only" install rather than a mistake to block on. It
+      // does need saying, though: core is not a row here, so an empty picker
+      // otherwise looks like it is about to install nothing at all.
       required: false,
+      emptyLabel: 'core only',
       maxItems: allOptions.length,
     });
 


### PR DESCRIPTION
## Why

Quick Update never asked about deprecated compatibility shims. It returned before the prompt, so anyone who lives on Quick Update carried their shims forward release after release and was never once offered the chance to drop them. Removal was silent too, and an empty module picker looked like it was about to install nothing.

## What changed

**Quick Update asks.** The prompt now runs on that path, defaulting to keeping the shims so pressing enter never removes a skill in active use. It stays quiet for an install that already dropped its shims rather than re-asking every update. The wording carries the recommendation and names the one case that justifies keeping them:

> Keep 20 deprecated compatibility shim skill(s)? Recommended: No. If you say yes, the deprecated skills will exist as a skill that forwards to its replacement skill. Shims will be removed with v7. You should only retain if you customized a shimmed skill and need to still transition it to the replacement.

**Never prompts without a TTY.** `--action quick-update` is a documented scripting flag and is not tied to `--yes`, so a scripted run reached the new confirm. clack's confirm never resolves without a TTY: the process drained its event loop and exited silently, mid-install, with status 0. It now keeps the standing answer whenever stdin is not a TTY, leaving `--shims` / `--no-shims` as the way to change it from a script.

**Both outcomes are reported.** Retaining shims lists every one and what it forwards to. Removal was previously silent everywhere — source filtering just skips the directories and the IDE cleanup suppresses its logging on purpose — so it now lists what went away and how to put it back. The notices are emitted where the policy is resolved, so they also reach `--yes`, `--shims`, and scripted quick updates. Both land before the install tasks run, so the outcome is repeated as a single line in the final summary box, the same way the uv warning already is.

**Empty module picker says what it does.** Core is always installed and is not a row in the list, so an empty selection is a valid core-only install. It now reads `Nothing selected: installs core only` while selecting and `0 items selected (core only)` on submit, via a new optional `emptyLabel`. Pickers that pass no `emptyLabel` are unchanged.

## Notes

Shims are found by `metadata.lifecycle: shim` frontmatter, and each line in the notices is built from the shim's own `description`, so the lists stay accurate as shims are added or retired without anything to maintain by hand.

## Testing

`test/test-shim-policy.js` extended: the Quick Update prompt and its default, the skip for an already-shimless install, the no-TTY guard, and both notice formatters. Full `npm test` passes via the pre-commit hook.

One thing not verified: the module picker wording is confirmed by inspection only. Interactive prompts need a real terminal, so the live render was not eyeballed.