### PR TITLE
fix(project-context): normalize invocation trigger

### DIFF
--- a/src/bmm-skills/plan/bmad-project-context/SKILL.md
+++ b/src/bmm-skills/plan/bmad-project-context/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: bmad-project-context
-description: 'Set up, adopt, refresh, or audit a repository''s agent instructions (the AGENTS.md block) so AI agents work well in that repo. Also records observed agent mistakes as pitfalls. Must be invoked by name'
+description: 'Set up, adopt, refresh, or audit a repository''s agent instructions (the AGENTS.md block) so AI agents work well in that repo. Also records observed agent mistakes as pitfalls. Use when invoked by name'
 ---
 
 # Overview


### PR DESCRIPTION
## Summary

- normalize the project-context description to the established `Use when` trigger form
- preserve invocation-by-name-only routing while satisfying SKILL-06

## Test plan

- `node tools/validate-skills.js --json src/bmm-skills/plan/bmad-project-context`
- `HUSKY=0 npm ci && npm run quality`
