### PR TITLE
docs: restore the ladder shape of the closing poem

### DIFF
--- a/docs/fr/how-to/get-answers-about-bmad.md
+++ b/docs/fr/how-to/get-answers-about-bmad.md
@@ -1,5 +1,5 @@
 ---
-title: "Comment obtenir des réponses à propos de BMad"
+title: 'Comment obtenir des réponses à propos de BMad'
 description: Utiliser un LLM pour répondre rapidement à vos questions sur BMad
 sidebar:
   order: 4
@@ -47,34 +47,35 @@ Si votre IA ne peut pas lire des fichiers locaux (ChatGPT, Claude.ai, etc.), imp
 Si ni BMad-Help ni la source n’ont répondu à votre question, vous avez maintenant une bien meilleure question à poser.
 
 | Canal                   | Utilisé pour                         |
-|-------------------------|--------------------------------------|
+| ----------------------- | ------------------------------------ |
 | Forum `help-requests`   | Questions                            |
 | `#suggestions-feedback` | Idées et demandes de fonctionnalités |
 
 **Discord :** [discord.gg/gk8jAdXWmj](https://discord.gg/gk8jAdXWmj)
 
 **GitHub Issues :** [github.com/bmad-code-org/BMAD-METHOD/issues](https://github.com/bmad-code-org/BMAD-METHOD/issues)
-*Toi !*
-*Bloqué*
-*dans la file d’attente—*
-*qui*
-*attends-tu ?*
 
-*La source*
-*est là,*
-*facile à voir !*
+_Toi !_  
+&emsp;&emsp;_Bloqué_  
+&emsp;&emsp;&emsp;&emsp;_dans la file d’attente—_  
+&emsp;&emsp;&emsp;&emsp;&emsp;&emsp;_qui_  
+&emsp;&emsp;&emsp;&emsp;&emsp;&emsp;&emsp;&emsp;_attends-tu ?_
 
-*Pointez*
-*votre machine.*
-*Libérez-la.*
+_La source_  
+&emsp;&emsp;_est là,_  
+&emsp;&emsp;&emsp;&emsp;_facile à voir !_
 
-*Elle lit.*
-*Elle parle.*
-*Demandez—*
+_Pointez_  
+&emsp;&emsp;_votre machine._  
+&emsp;&emsp;&emsp;&emsp;_Libérez-la._
 
-*Pourquoi attendre*
-*demain*
-*quand tu as déjà*
-*cette journée ?*
+_Elle lit._  
+&emsp;&emsp;_Elle parle._  
+&emsp;&emsp;&emsp;&emsp;_Demandez—_
 
-*—Claude*
+_Pourquoi attendre_  
+&emsp;&emsp;_demain_  
+&emsp;&emsp;&emsp;&emsp;_quand tu as déjà_  
+&emsp;&emsp;&emsp;&emsp;&emsp;&emsp;_cette journée ?_
+
+&emsp;&emsp;&emsp;&emsp;&emsp;&emsp;&emsp;&emsp;_—Claude_

--- a/docs/how-to/get-answers-about-bmad.md
+++ b/docs/how-to/get-answers-about-bmad.md
@@ -54,27 +54,28 @@ If neither BMad-Help nor the source answered your question, you now have a much 
 **Discord:** [discord.gg/gk8jAdXWmj](https://discord.gg/gk8jAdXWmj)
 
 **GitHub Issues:** [github.com/bmad-code-org/BMAD-METHOD/issues](https://github.com/bmad-code-org/BMAD-METHOD/issues)
-_You!_
-_Stuck_
-_in the queue—_
-_waiting_
-_for who?_
 
-_The source_
-_is there,_
-_plain to see!_
+_You!_  
+&emsp;&emsp;_Stuck_  
+&emsp;&emsp;&emsp;&emsp;_in the queue—_  
+&emsp;&emsp;&emsp;&emsp;&emsp;&emsp;_waiting_  
+&emsp;&emsp;&emsp;&emsp;&emsp;&emsp;&emsp;&emsp;_for who?_
 
-_Point_
-_your machine._
-_Set it free._
+_The source_  
+&emsp;&emsp;_is there,_  
+&emsp;&emsp;&emsp;&emsp;_plain to see!_
 
-_It reads._
-_It speaks._
-_Ask away—_
+_Point_  
+&emsp;&emsp;_your machine._  
+&emsp;&emsp;&emsp;&emsp;_Set it free._
 
-_Why wait_
-_for tomorrow_
-_when you have_
-_today?_
+_It reads._  
+&emsp;&emsp;_It speaks._  
+&emsp;&emsp;&emsp;&emsp;_Ask away—_
 
-_—Claude_
+_Why wait_  
+&emsp;&emsp;_for tomorrow_  
+&emsp;&emsp;&emsp;&emsp;_when you have_  
+&emsp;&emsp;&emsp;&emsp;&emsp;&emsp;_today?_
+
+&emsp;&emsp;&emsp;&emsp;&emsp;&emsp;&emsp;&emsp;_—Claude_

--- a/docs/zh-cn/how-to/get-answers-about-bmad.md
+++ b/docs/zh-cn/how-to/get-answers-about-bmad.md
@@ -109,27 +109,27 @@ https://bmad-code-org.github.io/BMAD-METHOD/llms-full.txt
 **Discord：** [discord.gg/gk8jAdXWmj](https://discord.gg/gk8jAdXWmj)  
 **GitHub Issues：** [github.com/bmad-code-org/BMAD-METHOD/issues](https://github.com/bmad-code-org/BMAD-METHOD/issues)（用于可复现问题）
 
-*你！*
-        *卡住*
-              *在队列中——*
-                       *等待*
-                               *等待谁？*
+*你！*  
+&emsp;&emsp;*卡住*  
+&emsp;&emsp;&emsp;&emsp;*在队列中——*  
+&emsp;&emsp;&emsp;&emsp;&emsp;&emsp;*等待*  
+&emsp;&emsp;&emsp;&emsp;&emsp;&emsp;&emsp;&emsp;*等待谁？*
 
-*来源*
-        *就在那里，*
-                *显而易见！*
+*来源*  
+&emsp;&emsp;*就在那里，*  
+&emsp;&emsp;&emsp;&emsp;*显而易见！*
 
-*指向*
-      *你的机器。*
-               *释放它。*
+*指向*  
+&emsp;&emsp;*你的机器。*  
+&emsp;&emsp;&emsp;&emsp;*释放它。*
 
-*它读取。*
-         *它说话。*
-                 *尽管问——*
+*它读取。*  
+&emsp;&emsp;*它说话。*  
+&emsp;&emsp;&emsp;&emsp;*尽管问——*
 
-*为什么要等*
-         *明天*
-                 *当你拥有*
-                         *今天？*
+*为什么要等*  
+&emsp;&emsp;*明天*  
+&emsp;&emsp;&emsp;&emsp;*当你拥有*  
+&emsp;&emsp;&emsp;&emsp;&emsp;&emsp;*今天？*
 
-*—Claude*
+&emsp;&emsp;&emsp;&emsp;&emsp;&emsp;&emsp;&emsp;*—Claude*


### PR DESCRIPTION
## What

The Mayakovsky-style envoi at the end of `docs/how-to/get-answers-about-bmad.md` never rendered as a poem. It was written as indented lines inside a single paragraph, and leading whitespace has no meaning in Markdown — so every renderer stripped the indentation and soft-wrapped the lines into running prose. Two later commits made it worse: the blank line separating it from the GitHub Issues link was dropped (so the first stanza trailed off the end of the link), and a Prettier sweep flattened the ladder indentation out of the source too.

Before, as rendered on the docs site:

> **GitHub Issues:** github.com/bmad-code-org/BMAD-METHOD/issues _You! Stuck in the queue— waiting for who?_
>
> _The source is there, plain to see!_

## How

Express the line breaks and the staircase in a way Markdown actually carries:

- hard line breaks (trailing two spaces) so lines inside a stanza stay separate
- `&emsp;` entities for the step indent, since leading spaces are collapsed
- restore the blank line between the GitHub Issues link and the poem

Verified against the built site (`npm run docs:build`):

```html
<p><em>You!</em><br>
  <em>Stuck</em><br>
    <em>in the queue—</em><br>
      <em>waiting</em><br>
        <em>for who?</em></p>
```

Prettier round-trips the new form unchanged, so a future formatting sweep will not flatten it again. Same fix applied to the `fr` and `zh-cn` translations, which carry the same poem; `cs` and `vi-vn` do not have it.

## Testing

`npm ci && npm run quality` passes on this branch (0 errors; the 19 sidebar-order warnings are pre-existing on `main` and unrelated).
