### PR TITLE
fix(build): mark stories done in sprint status on completion

### DIFF
--- a/docs/explanation/sprint-planning.md
+++ b/docs/explanation/sprint-planning.md
@@ -9,7 +9,7 @@ Run `bmad-sprint-planning` at the boundary between planning and implementation. 
 
 ## Why one skill
 
-`sprint-status.yaml` is the single tracking artifact the whole dev cycle reads and writes — build syncs story statuses into it, code-review moves stories through review, the retrospective appends action items to it. Everything that *creates* or *summarizes* that artifact now lives in the skill that owns it. Gating, generating, and viewing were previously spread across three skills (`bmad-check-implementation-readiness`, `bmad-sprint-planning`, `bmad-sprint-status`); consolidation means one owner, one status vocabulary, and no drift between what the gate checks and what the tracker builds.
+`sprint-status.yaml` is the single tracking artifact the whole dev cycle reads and writes — build syncs story statuses into it through completion, code-review sends a story back when it finds work left to do, the retrospective appends action items to it. Everything that *creates* or *summarizes* that artifact now lives in the skill that owns it. Gating, generating, and viewing were previously spread across three skills (`bmad-check-implementation-readiness`, `bmad-sprint-planning`, `bmad-sprint-status`); consolidation means one owner, one status vocabulary, and no drift between what the gate checks and what the tracker builds.
 
 ## The readiness gate
 

--- a/src/bmm-skills/ship/bmad-build/step-05-present.md
+++ b/src/bmm-skills/ship/bmad-build/step-05-present.md
@@ -52,7 +52,7 @@ When there is only one concern, omit the bold label — just list the stops dire
 
 Change `{spec_file}` status to `done` in the frontmatter.
 
-Follow `[[bmad-snapshot:sync-sprint-status.md]]` with `target_status` = `review`.
+Follow `[[bmad-snapshot:sync-sprint-status.md]]` with `target_status` = `done`.
 
 ### Commit and Complete
 

--- a/src/bmm-skills/ship/bmad-build/step-oneshot.md
+++ b/src/bmm-skills/ship/bmad-build/step-oneshot.md
@@ -54,7 +54,7 @@ Write `{spec_file}` using `[[bmad-snapshot:spec-template.md]]`. Fill only these 
 3. **Suggested Review Order** — append after Intent. Build using the same convention as `[[bmad-snapshot:step-05-present.md]]` § "Generate Suggested Review Order" (spec-file-relative links, concern-based ordering, ultra-concise framing).
 4. **Review Triage Log** — only when findings were dismissed: one line per dismissal, the finding and the reason that disposed of its claim.
 
-Follow `[[bmad-snapshot:sync-sprint-status.md]]` with `target_status` = `review`.
+Follow `[[bmad-snapshot:sync-sprint-status.md]]` with `target_status` = `done`.
 
 ### Commit
 


### PR DESCRIPTION
## Where the `review` status came from

In v6, implementation and review were two skills. `bmad-dev-story` implemented a story, set it to `review`, and handed off — closing with the tip to "run `code-review` using a **different** LLM than the one that implemented this story" (`src/bmm-skills/v6-shims/bmad-dev-story/SKILL.md:442,481`). The implementing model could not credibly review its own work, so `review` was the seam between the two skills, and `bmad-code-review` was the only thing that could carry a story to `done`.

`bmad-dev-story` is now a deprecated shim. `bmad-build` absorbed the implementation role — and inherited the seam without the reason for it.

Build reviews internally. `step-04-review.md` stages a diff, launches three **context-free** subagents in parallel (blind-hunter, edge-case-hunter, verification-gap), verifies each finding at the site it names, assigns severity itself, triages, and patches. The independence that the v6 tip asked a human to arrange by switching models, build arranges structurally by denying the reviewers its context. So the handoff it announces by writing `review` is a handoff to nobody.

## What that costs today

- `step-05-present.md` sets the **spec frontmatter** to `done`, then two lines later syncs **`sprint-status.yaml`** to `review`. The one-shot route does the same. Two artifacts, two different answers about one story.
- Nothing in build can reach `done` in the tracker, and `sync-sprint-status.md` never regresses a status, so stories park at `review` indefinitely unless the user runs a second review pass they may not want.
- `bmad-retrospective` gates on stories whose status is not `done`, so a fully built epic always opens the retro with an "these stories are unfinished, retro anyway?" prompt — noise that fires every time, because the default path structurally cannot clear it.

Fixing it by demoting the spec is not available: `status: done` on the spec is what `step-01-clarify-and-route.md:71` scans for to load previous-story continuity, and `bmad-build-auto` *halts* when it finds `in-review` there instead. The spec's `done` is pinned; the sprint key is the side that moves.

## Change

Both build routes sync `target_status` = `done` instead of `review` — three lines, plus a doc sentence that described the v6 flow.

`review` stays in the vocabulary and keeps its place in `sprint_plan.py`'s recommended-action ordering. It is now what it should always have been: the state for a story someone deliberately parks for another pair of eyes. `bmad-code-review` keeps its existing ability to send a story back to `in-progress` when it finds unresolved work, so running it on a `done` story still does the right thing.

## Tier 3 detection, deliberately untouched

`bmad-code-review` (Tier 3 of its target cascade) and `bmad-checkpoint-preview` (step 3 of orientation) both auto-detect a target by scanning sprint status for `review` stories — the other half of the same v6 handoff. Neither will match a freshly built story now; both fall through to the git-state tier, which confirms the current branch/HEAD. One extra confirmation instead of a pre-filled suggestion.

I left both alone rather than teaching them to detect `done` stories, which would have them offering up finished work. They also are not dead: `bmad-dev-story` still writes `review` at line 442, so the legacy path still produces exactly the input those tiers were built to consume.

## Verification

`HUSKY=0 npm ci && npm run quality` passes on `HEAD` in this checkout: 0 errors. The 19 warnings are pre-existing sidebar-order drift in the `vi-vn`/`zh-cn`/`cs`/`fr` translations, untouched here.
