### PR TITLE
fix(build): remove Ask First / Block If from spec-template

### DIFF
--- a/src/bmm-skills/ship/bmad-build-auto/spec-template.md
+++ b/src/bmm-skills/ship/bmad-build-auto/spec-template.md
@@ -27,12 +27,9 @@ deferred: [] # append-only machine-readable deferred review findings; each item 
 
 ## Boundaries & Constraints
 
-<!-- Three tiers: Always = invariant rules. Block If = decisions that cannot be made unattended. Never = out of scope + forbidden approaches. -->
+<!-- Two tiers: Always = invariant rules. Never = out of scope + forbidden approaches. -->
 
 **Always:** INVARIANT_RULES
-
-**Block If:** DECISIONS_REQUIRING_HUMAN_INPUT
-<!-- Agent: if any of these trigger during execution, HALT with status blocked and the blocking condition. -->
 
 **Never:** NON_GOALS_AND_FORBIDDEN_APPROACHES
 

--- a/src/bmm-skills/ship/bmad-build/spec-template.md
+++ b/src/bmm-skills/ship/bmad-build/spec-template.md
@@ -24,12 +24,9 @@ context: [] # optional: `{project-root}/`-prefixed paths to project-wide standar
 
 ## Boundaries & Constraints
 
-<!-- Three tiers: Always = invariant rules. Ask First = human-gated decisions. Never = out of scope + forbidden approaches. -->
+<!-- Two tiers: Always = invariant rules. Never = out of scope + forbidden approaches. -->
 
 **Always:** INVARIANT_RULES
-
-**Ask First:** DECISIONS_REQUIRING_HUMAN_APPROVAL
-<!-- Agent: if any of these trigger during execution, HALT and ask the user before proceeding. -->
 
 **Never:** NON_GOALS_AND_FORBIDDEN_APPROACHES
 


### PR DESCRIPTION
## Summary
- Confirmed against real session logs — including a session built specifically to test it — that Ask First (bmad-build) and its renamed variant Block If / `status: blocked` (bmad-build-auto) never fired. The tier only produced boilerplate at spec-authoring time and got silently fantasized past at execution time.
- Boundaries & Constraints in both `spec-template.md` files drops from three tiers to two: Always, Never. No replacement mechanism — a real judgment call that turns out to matter surfaces at step-04 review like everything else does.
- The general `blocked` status used elsewhere in bmad-build-auto for unrelated hard-failure halts (missing spec file, verification failures, dirty tree, intent gaps, etc.) is untouched — that is a separate, working mechanism.
- Supersedes the earlier `fix/build-ask-first` (#2740, closed), which tried to strengthen enforcement instead of removing the dead mechanism.

## Test plan
- [x] `HUSKY=0 npm ci && npm run quality` passed (0 errors, all tests green)
- [x] Repo-wide grep confirmed no other files reference "Ask First" or "Block If"
