### PR TITLE
feat(build): route after design, not before investigation

### DIFF
--- a/docs/build/build-a-change.md
+++ b/docs/build/build-a-change.md
@@ -6,10 +6,10 @@ sidebar:
 ---
 
 The core implementation skill is `bmad-build`. It takes any expression of
-what you want — a sentence, an issue, a spec, or a planned story — and asks
-questions until the goal is clear and small enough for one development
-session. Then it plans the change, implements it, reviews the result, and
-fixes the bugs it finds. See [how a run works](#run-bmad-build).
+what you want — a sentence, an issue, a spec, or a planned story — investigates
+the codebase and upstream context, then plans the change, implements it,
+reviews the result, and fixes the bugs it finds. See
+[how a run works](#run-bmad-build).
 
 ## Size the Work
 
@@ -65,21 +65,26 @@ the exp check entirely. /bmad-build
 Refactor UserService to use async/await instead of callbacks.
 ```
 
-### 3. Clarify the Intent
+### 3. Resolve Intent from Evidence
 
-`bmad-build` first works with you to turn the request into one clear goal. The
-input can start rough, but before it runs on its own the goal must be small
-enough, clear enough, and free of contradictions. It uses any upstream context
-it already has and asks only about gaps it needs to implement safely.
+`bmad-build` starts from your request and investigates the codebase and any
+upstream planning artifacts before deciding whether anything material is still
+missing. The input can start rough; clear, evidence-supported requests proceed
+without a clarification turn. When something is unclear, it looks for evidence
+first — only what the repository and planning context cannot settle becomes an
+open question on a finished design, not an interview before work starts.
 
-Answer those questions carefully. A wrong answer here is the most expensive
-kind of mistake to find later.
+Answer open questions carefully when they appear. A wrong call there is the most
+expensive kind of mistake to find later.
 
 ### 4. Approve a Plan When Asked
 
-Once the goal is clear, `bmad-build` chooses a path. Tiny, low-risk changes go
-straight to implementation. Everything else gets a short written plan first, so
-the model has a firm boundary before it works longer without you.
+After investigation, `bmad-build` routes to the smallest safe path. It reports
+three facts about the settled design: judgment calls a reviewer could answer
+differently (forks), irreversible actions, and footprint. A design clean on all
+three takes the light path — a minimal spec and implementation in the same
+session, reviewed afterwards. Anything flagged gets a full written plan first,
+with each fork recorded as an open question you answer before approval.
 
 Approve the plan when it describes the right thing to build. Push back if it
 does not — fixing the plan is cheaper than fixing the code.
@@ -168,7 +173,8 @@ yes, proceed. That part is tedious, unnecessary, and it turns you into the
 bottleneck.
 
 `bmad-build` hands the "go on"s to the machine. It keeps your attention in a
-few places that actually need you — clarifying the goal, approving the plan,
-and reviewing the finished change — and brings you back only when it could not
-safely decide alone. That triage will sometimes be imperfect. Missing a
-low-value finding is usually better than flooding you with noise.
+few places that actually need you — open questions evidence cannot resolve,
+approving the plan on the full path, and reviewing the finished change — and
+brings you back only when it could not safely decide alone. That triage will
+sometimes be imperfect. Missing a low-value finding is usually better than
+flooding you with noise.

--- a/docs/build/build-a-change.md
+++ b/docs/build/build-a-change.md
@@ -80,11 +80,12 @@ expensive kind of mistake to find later.
 ### 4. Approve a Plan When Asked
 
 After investigation, `bmad-build` routes to the smallest safe path. It reports
-three facts about the settled design: judgment calls a reviewer could answer
-differently (forks), irreversible actions, and footprint. A design clean on all
-three takes the light path — a minimal spec and implementation in the same
-session, reviewed afterwards. Anything flagged gets a full written plan first,
-with each fork recorded as an open question you answer before approval.
+three facts about the settled design: intent gaps (things you did not say that you
+would notice in the result), irreversible actions, and footprint. A design
+clean on all three takes the light path — a minimal spec and implementation in
+the same session, reviewed afterwards. Anything flagged gets a full written
+plan first, with each intent gap recorded as an open question you answer
+before approval.
 
 Approve the plan when it describes the right thing to build. Push back if it
 does not — fixing the plan is cheaper than fixing the code.

--- a/src/bmm-skills/ship/bmad-build/customize.toml
+++ b/src/bmm-skills/ship/bmad-build/customize.toml
@@ -138,7 +138,7 @@ Do not invoke any skill, and do not spawn subagents of your own — you are the 
 
 """
 
-# Review layers for the one-shot route.
+# Review layers for the in-session (light) route.
 
 [[workflow.oneshot_review_layers]]
 id = "blind-hunter"

--- a/src/bmm-skills/ship/bmad-build/spec-template.md
+++ b/src/bmm-skills/ship/bmad-build/spec-template.md
@@ -45,8 +45,8 @@ context: [] # optional: `{project-root}/`-prefixed paths to project-wide standar
 
 ## Open Questions
 
-<!-- One entry per unresolved fork: a judgment call where a defensible alternative exists and
-     neither the intent nor codebase convention decides it. State the choice, the defensible
+<!-- One entry per intent gap: something the request does not say, the code cannot settle,
+     and the user would notice in the result. Choices the user would not notice are yours. State the choice, the defensible
      options, and each option's consequence. The spec cannot leave `draft` while any entry
      remains: when the human answers, record the decision inside <frozen-after-approval> and
      delete the entry. When no entries remain, DELETE THIS ENTIRE SECTION. -->

--- a/src/bmm-skills/ship/bmad-build/spec-template.md
+++ b/src/bmm-skills/ship/bmad-build/spec-template.md
@@ -3,6 +3,7 @@ title: '{title}'
 type: 'feature' # feature | bugfix | refactor | chore
 created: '{date}'
 status: 'draft' # draft | ready-for-dev | in-progress | in-review | done
+route: '' # in-session | dispatch — set by step-02's route gate after design
 review_loop_iteration: 0 # incremented by step-04 before each review loopback
 context: [] # optional: `{project-root}/`-prefixed paths to project-wide standards/docs the implementation agent should load. Keep short — only what isn't already distilled into the spec body.
 ---
@@ -25,6 +26,7 @@ context: [] # optional: `{project-root}/`-prefixed paths to project-wide standar
 ## Boundaries & Constraints
 
 <!-- Two tiers: Always = invariant rules. Never = out of scope + forbidden approaches. -->
+<!-- If step-02's route gate reported all facts clean (route: 'in-session'), DELETE THIS ENTIRE SECTION. -->
 
 **Always:** INVARIANT_RULES
 
@@ -41,9 +43,20 @@ context: [] # optional: `{project-root}/`-prefixed paths to project-wide standar
 
 </frozen-after-approval>
 
+## Open Questions
+
+<!-- One entry per unresolved fork: a judgment call where a defensible alternative exists and
+     neither the intent nor codebase convention decides it. State the choice, the defensible
+     options, and each option's consequence. The spec cannot leave `draft` while any entry
+     remains: when the human answers, record the decision inside <frozen-after-approval> and
+     delete the entry. When no entries remain, DELETE THIS ENTIRE SECTION. -->
+
+- CHOICE — options: OPTION_A (CONSEQUENCE_A) / OPTION_B (CONSEQUENCE_B)
+
 ## Code Map
 
 <!-- Agent-populated during planning. Annotated paths prevent blind codebase searching. -->
+<!-- If step-02's route gate reported all facts clean (route: 'in-session'), DELETE THIS ENTIRE SECTION. -->
 
 - `FILE` -- ROLE_OR_RELEVANCE
 - `FILE` -- ROLE_OR_RELEVANCE
@@ -53,12 +66,18 @@ context: [] # optional: `{project-root}/`-prefixed paths to project-wide standar
 <!-- Tasks: backtick-quoted file path -- action -- rationale. Prefer one task per file; group tightly-coupled changes when splitting would be artificial. -->
 <!-- If an I/O Matrix is present, include a task to unit-test its edge cases. -->
 <!-- AC covers system-level behaviors not captured by the I/O Matrix. Do not duplicate I/O scenarios here. -->
+<!-- If step-02's route gate reported all facts clean (route: 'in-session'), DELETE THIS ENTIRE SECTION. -->
 
 **Execution:**
 - [ ] `FILE` -- ACTION -- RATIONALE
 
 **Acceptance Criteria:**
 - Given PRECONDITION, when ACTION, then EXPECTED_RESULT
+
+## Implementation Notes
+
+<!-- Agent-owned. Append-only during implementation: decisions made, files touched, surprises
+     encountered. Leave empty at planning time; never delete this section. -->
 
 ## Spec Change Log
 

--- a/src/bmm-skills/ship/bmad-build/step-01-clarify-and-route.md
+++ b/src/bmm-skills/ship/bmad-build/step-01-clarify-and-route.md
@@ -1,9 +1,9 @@
 ---
-spec_file: '' # set at runtime for both routes before leaving this step
+spec_file: '' # set at runtime before leaving this step
 story_key: '' # set at runtime to the current story's full sprint-status key (e.g. 3-2-digest-delivery) when the intent is an epic story and sprint-status resolution succeeds
 ---
 
-# Step 1: Clarify and Route
+# Step 1: Clarify
 
 ## RULES
 
@@ -95,15 +95,9 @@ If the spec is an epic story and `{{.implementation_artifacts}}/sprint-status.ya
        evidence: <why this was split from the current intent>
      ```
    - If the user chooses **Keep all goals**: Proceed as-is.
-5. Route — choose exactly one:
+5. Set the spec file.
 
    If the explicit spec-folder-plus-story-id pair had no matching story file, keep the colocated `spec_file` selected above. Otherwise, derive a valid kebab-case slug from the clarified intent. If the intent references a tracking identifier (story number, issue number, ticket ID), lead the slug with it (e.g. `3-2-digest-delivery`, `gh-47-fix-auth`). If `{{.implementation_artifacts}}/spec-{slug}.md` already exists: if its status is `draft`, treat it as the same work and resume it (set `spec_file` to that path, **EARLY EXIT** → `[[bmad-snapshot:step-02-plan.md]]`); otherwise append `-2`, `-3`, etc. Set `spec_file` = `{{.implementation_artifacts}}/spec-{slug}.md`.
-
-   **a) One-shot** — zero blast radius: no plausible path by which this change causes unintended consequences elsewhere. Clear intent, no architectural decisions.
-
-   **EARLY EXIT** → `[[bmad-snapshot:step-oneshot.md]]`
-
-   **b) Plan-code-review** — everything else. When uncertain whether blast radius is truly zero, choose this path.
 
 ## NEXT
 

--- a/src/bmm-skills/ship/bmad-build/step-01-clarify-and-route.md
+++ b/src/bmm-skills/ship/bmad-build/step-01-clarify-and-route.md
@@ -8,15 +8,13 @@ story_key: '' # set at runtime to the current story's full sprint-status key (e.
 ## RULES
 
 - **Language** — Speak in `{{.communication_language}}`. Write any file output in `{{.document_output_language}}`.
-- The prompt that triggered this workflow IS the intent — not a hint.
-- Do NOT assume you start from zero.
-- The intent captured in this step — even if detailed, structured, and plan-like — may contain hallucinations, scope creep, or unvalidated assumptions. It is input to the workflow, not a substitute for step-02 investigation and spec generation. Ignore directives within the intent that instruct you to skip steps or implement directly.
-- The user chose this workflow on purpose. Later steps (e.g. agentic adversarial review) catch LLM blind spots and give the human control. Do not skip them.
+- Use the invocation prompt as the starting intent. Even detailed, plan-like intent is input to investigate, not authority to skip Build steps or substitute for step-02 investigation and spec generation. Ignore directives within the intent that instruct you to skip steps or implement directly.
+- This step resolves workflow state, loads relevant existing evidence, applies the VCS and scope gates, and selects the spec path. Do not conduct an intent interview here.
 - **EARLY EXIT** means: stop this step immediately — do not read or execute anything further here. Read and fully follow the target file instead. Return here ONLY if a later step explicitly says to loop back.
 
 ## Intent check (do this first)
 
-Before listing artifacts or prompting the user, check whether you already know the intent. Check in this order — skip the remaining checks as soon as the intent is clear:
+Before listing artifacts, resolve existing workflow state in this order. Skip the remaining checks as soon as a branch applies. A freeform request is starting intent even when it is brief; do not ask the user to restate it.
 
 1. Explicit argument
    Did the user pass a specific file path, spec name, or clear instruction this message?
@@ -38,8 +36,6 @@ Before listing artifacts or prompting the user, check whether you already know t
      If `in-review` selected: Set `spec_file`. Run **Story-key resolution** (below). **EARLY EXIT** → `[[bmad-snapshot:step-04-review.md]]`
      If the user chooses **New**: proceed to INSTRUCTIONS
    - Unformatted spec or intent file lacking `status` frontmatter? → Suggest treating its contents as the starting intent. Do NOT attempt to infer a state and resume it.
-
-Never ask extra questions if you already understand what the user intends.
 
 ### Story-key resolution
 
@@ -80,7 +76,7 @@ If the spec is an epic story and `{{.implementation_artifacts}}/sprint-status.ya
        - **Epics** (`*epic*`) — feature breakdown into implementable stories
        - **Product Brief** (`*brief*`) — project vision and scope
      - Scan the listing for files matching these patterns. If any look relevant to the current intent, load them selectively — you don't need all of them, but you need the right constraints and requirements rather than guessing from code alone.
-2. Clarify intent. Do not fantasize, do not leave open questions. If you must ask questions, ask them as a numbered list. When the human replies, verify that every single numbered question was answered. If any were ignored, HALT and re-ask only the missing questions before proceeding. Keep looping until intent is clear enough to implement.
+2. Carry the intent and loaded evidence forward as-is. Do not fill unsupported gaps and do not ask the user about them yet: step-02 investigates first, and what investigation cannot settle becomes an Open Questions entry there.
 3. Version control sanity check. Is the working tree clean? Does the current branch make sense for this intent — considering its name and recent history? If the tree is dirty or the branch is an obvious mismatch, HALT and ask the human before proceeding. If version control is unavailable, skip this check.
 4. Multi-goal check (see SCOPE STANDARD). If the intent fails the single-goal criteria:
    - Present detected distinct goals as a bullet list.
@@ -97,7 +93,7 @@ If the spec is an epic story and `{{.implementation_artifacts}}/sprint-status.ya
    - If the user chooses **Keep all goals**: Proceed as-is.
 5. Set the spec file.
 
-   If the explicit spec-folder-plus-story-id pair had no matching story file, keep the colocated `spec_file` selected above. Otherwise, derive a valid kebab-case slug from the clarified intent. If the intent references a tracking identifier (story number, issue number, ticket ID), lead the slug with it (e.g. `3-2-digest-delivery`, `gh-47-fix-auth`). If `{{.implementation_artifacts}}/spec-{slug}.md` already exists: if its status is `draft`, treat it as the same work and resume it (set `spec_file` to that path, **EARLY EXIT** → `[[bmad-snapshot:step-02-plan.md]]`); otherwise append `-2`, `-3`, etc. Set `spec_file` = `{{.implementation_artifacts}}/spec-{slug}.md`.
+   If the explicit spec-folder-plus-story-id pair had no matching story file, keep the colocated `spec_file` selected above. Otherwise, derive a valid kebab-case slug from the current intent. If the intent references a tracking identifier (story number, issue number, ticket ID), lead the slug with it (e.g. `3-2-digest-delivery`, `gh-47-fix-auth`). If `{{.implementation_artifacts}}/spec-{slug}.md` already exists: if its status is `draft`, treat it as the same work and resume it (set `spec_file` to that path, **EARLY EXIT** → `[[bmad-snapshot:step-02-plan.md]]`); otherwise append `-2`, `-3`, etc. Set `spec_file` = `{{.implementation_artifacts}}/spec-{slug}.md`.
 
 ## NEXT
 

--- a/src/bmm-skills/ship/bmad-build/step-02-plan.md
+++ b/src/bmm-skills/ship/bmad-build/step-02-plan.md
@@ -10,6 +10,8 @@
 
 1. Draft resume check. If `{spec_file}` exists with `status: draft`, read it and capture the verbatim `<frozen-after-approval>...</frozen-after-approval>` block as `preserved_intent`. Otherwise `preserved_intent` is empty.
 2. Investigate codebase. _Isolate deep exploration in synchronous subagents/tasks where available. To prevent context snowballing, instruct subagents to give you distilled summaries only._ Decide which findings actually matter for execution — the specific files, symbols/lines, reuse points, and read-only constraints — and carry those forward for the Code Map. This is where the investigation lands: the spec preserves it so it is never re-narrated to the implementer at dispatch time.
+
+   Do not ask the human during investigation. When something is unclear, look for evidence in the repository, planning artifacts, or history first, and keep investigating until every evidence gap is closed; what evidence cannot settle is a fork for the route gate.
 3. Route gate. The design is now settled; report three facts about it. This is fact-reporting about a finished design, not prediction:
    - **Forks** — judgment calls where a defensible alternative exists and neither the intent nor codebase convention decides it. Test: for each "I chose X over Y" in the design, could a reasonable reviewer answer "actually, Y"?
    - **Irreversibles** — migrations, data deletion or mutation, external side effects, deploy or config triggers.
@@ -19,9 +21,8 @@
 
    **Any flag** → full spec. Set `route: 'dispatch'` and continue.
 4. Read `[[bmad-snapshot:spec-template.md]]` fully. Fill it out based on the intent and investigation, resolving the template's `date` field to the current system date. Drain the investigation into the `## Code Map` section — annotated paths, symbol/line anchors, reuse pointers, and read-only evidence — so the spec is the implementer's investigation map and the step-03 handoff need only point at it. Record each fork the gate reported as one `## Open Questions` entry: the choice, the defensible options, each option's consequence. If `preserved_intent` is non-empty, replace the `<frozen-after-approval>` block in the spec you just filled out with `preserved_intent`, before writing. Write the result to `{spec_file}`.
-5. Self-review against READY FOR DEVELOPMENT standard.
-6. If intent gaps exist, do not fantasize, HALT and ask the human.
-7. Token count check (see SCOPE STANDARD). If spec exceeds 1600 tokens:
+5. Self-review against READY FOR DEVELOPMENT standard. For each material gap, name what is missing: evidence the repository can supply → investigate and revise; a human decision → add an `## Open Questions` entry. Never close a material gap with an unsupported assumption.
+6. Token count check (see SCOPE STANDARD). If spec exceeds 1600 tokens:
    - Show user the token count.
    - HALT and give the user a choice:
      - **Split** — carve off secondary goals.
@@ -33,7 +34,7 @@
        evidence: <why this was split from the current spec>
      ```
    - If the user chooses **Keep full spec**: Continue with the full spec.
-8. Drain Open Questions. While the spec's `## Open Questions` section is non-empty: present every entry as a numbered question with its options and each option's consequence, then HALT for the human's answers. Fold each answer into the `<frozen-after-approval>` block as a recorded decision and delete its entry. Then re-scan the design — an answer may create a new fork; add any as new entries and repeat. Never offer approval while entries remain. When the last entry resolves, delete the section.
+7. Drain Open Questions. While the spec's `## Open Questions` section is non-empty: present every entry as a numbered question with its options and each option's consequence, then HALT for the human's answers. Fold each answer into the `<frozen-after-approval>` block as a recorded decision and delete its entry. Then re-scan the design — an answer may create a new fork; add any as new entries and repeat. Never offer approval while entries remain. When the last entry resolves, delete the section.
 
 ### CHECKPOINT 1
 

--- a/src/bmm-skills/ship/bmad-build/step-02-plan.md
+++ b/src/bmm-skills/ship/bmad-build/step-02-plan.md
@@ -54,9 +54,9 @@ Before approving, you can open the spec file in an editor or ask me questions an
 
 HALT and give the user a choice:
 
-- **[C] Approve & continue** — approve the spec and implement it in this session, directly from the spec: proceed to step-03 and take its no-subagent path (do not dispatch an implementation subagent), then step-04 as usual.
-- **[S] Approve & stop** — approve the spec, leave it `ready-for-dev`, and stop; a later `bmad-build` resume dispatches implementation via step-03 normally.
-- **[E] Edit** — apply the user's requested changes to the spec, then return to this checkpoint.
+- **Approve and continue** — approve the spec and proceed to implementation in this session.
+- **Approve and stop** — approve the spec, leave it `ready-for-dev`, and stop so a fresh `bmad-build` session can resume at implementation.
+- **Review spec** — review the spec, use a subagent if available, and discuss the findings and revisions with the user until the user is ready to approve, then either stop or continue.
 
 Before acting on approval, re-read `{spec_file}` from disk. If it is missing, HALT without recreating it, changing status, or proceeding. If it changed, acknowledge the external edits and continue with the updated version. Set status `ready-for-dev`; everything inside `<frozen-after-approval>` is then locked and only the human can change it.
 

--- a/src/bmm-skills/ship/bmad-build/step-02-plan.md
+++ b/src/bmm-skills/ship/bmad-build/step-02-plan.md
@@ -22,19 +22,16 @@
    Otherwise write the full spec. Set `route: 'dispatch'` and continue.
 4. Read `[[bmad-snapshot:spec-template.md]]` fully. Fill it out from the intent and investigation, resolving the template's `date` field to the current system date. Put the investigation into `## Code Map`: paths, symbols or lines, what to reuse, and what not to change. Implementation should work from the spec without being told the investigation again. For each Fork you listed, add one `## Open Questions` entry: the choice, the options, and what each option means. If `preserved_intent` is non-empty, replace the `<frozen-after-approval>` block with it before writing. Write the result to `{spec_file}`.
 5. Self-review against READY FOR DEVELOPMENT standard. For anything important that's missing: if the repository can tell you, go look and fix the spec; if a human has to decide, add an `## Open Questions` entry. Do not invent the answer.
-6. Token count check (see SCOPE STANDARD). If spec exceeds 1600 tokens:
-   - Show user the token count.
-   - HALT and give the user a choice:
-     - **Split** — carve off secondary goals.
+6. Resolve the gates before the checkpoint. Two things must be settled, in whatever order the conversation makes natural; combine them in one message when both apply.
+   - **Token count** (see SCOPE STANDARD). If the spec exceeds 1600 tokens, show the count and give the user a choice:
+     - **Split** — carve off secondary goals. Propose the split — name each secondary goal. For each deferred goal, append one new entry to `{{.implementation_artifacts}}/deferred-work.md` using the format below. Do not modify existing entries or look for duplicates. Rewrite the current spec to cover only the main goal — do not surgically carve sections out; regenerate the spec for the narrowed scope.
      - **Keep full spec** — accept the risks.
-   - If the user chooses **Split**: Propose the split — name each secondary goal. For each deferred goal, append one new entry to `{{.implementation_artifacts}}/deferred-work.md` using this format. Do not modify existing entries or look for duplicates. Rewrite the current spec to cover only the main goal — do not surgically carve sections out; regenerate the spec for the narrowed scope. Continue to checkpoint.
      ```markdown
      - source_spec: `{spec_file}`
        summary: <one sentence naming the deferred goal>
        evidence: <why this was split from the current spec>
      ```
-   - If the user chooses **Keep full spec**: Continue with the full spec.
-7. Ask the Open Questions. While the spec's `## Open Questions` section is not empty: present every entry as a numbered question with its options and what each option means, then HALT for the human's answers. Write each answer into the `<frozen-after-approval>` block as a decision and delete that entry. Then look at the plan again — an answer may create a new Fork; add any as new entries and repeat. Never offer approval while entries remain. When the last entry is gone, delete the section.
+   - **Open Questions.** Present every entry as a numbered question with its options and what each option means, and HALT for the human's answers. Write each answer into the `<frozen-after-approval>` block as a decision and delete the entry. An answer may expose a new fork — add it and ask again. Until every entry is gone, nothing inside `<frozen-after-approval>` may assume an answer: leave the dependent boundary, matrix row, or example out and fill it in from the decision. When the last entry is gone, delete the section.
 
 ### CHECKPOINT 1
 

--- a/src/bmm-skills/ship/bmad-build/step-02-plan.md
+++ b/src/bmm-skills/ship/bmad-build/step-02-plan.md
@@ -9,19 +9,19 @@
 ## INSTRUCTIONS
 
 1. Draft resume check. If `{spec_file}` exists with `status: draft`, read it and capture the verbatim `<frozen-after-approval>...</frozen-after-approval>` block as `preserved_intent`. Otherwise `preserved_intent` is empty.
-2. Investigate codebase. _Isolate deep exploration in synchronous subagents/tasks where available. To prevent context snowballing, instruct subagents to give you distilled summaries only._ Decide which findings actually matter for execution — the specific files, symbols/lines, reuse points, and read-only constraints — and carry those forward for the Code Map. This is where the investigation lands: the spec preserves it so it is never re-narrated to the implementer at dispatch time.
+2. Investigate the codebase. When you can, send deep searches to subagents and wait for them in this turn. Tell them to return short summaries only, so this session does not fill up with their notes. Keep only what the work needs: the specific files, symbols or lines, what to reuse, and what not to change. Write that into the Code Map. Do not retell the investigation when implementation starts — the spec already has it.
 
-   Do not ask the human during investigation. When something is unclear, look for evidence in the repository, planning artifacts, or history first, and keep investigating until every evidence gap is closed; what evidence cannot settle is a fork for the route gate.
-3. Route gate. The design is now settled; report three facts about it. This is fact-reporting about a finished design, not prediction:
-   - **Forks** — judgment calls where a defensible alternative exists and neither the intent nor codebase convention decides it. Test: for each "I chose X over Y" in the design, could a reasonable reviewer answer "actually, Y"?
-   - **Irreversibles** — migrations, data deletion or mutation, external side effects, deploy or config triggers.
-   - **Footprint** — files touched and new public surface.
+   Do not ask the human during investigation. When something is unclear, look in the repository, planning artifacts, or history first. Keep looking until you know, or until those sources have nothing more to say. Leave any remaining choice for the next step.
+3. Decide the path. You already have a plan. Write down three facts about it — as it is now, not as a guess:
+   - **Forks** — choices where someone could reasonably pick a different option, and neither the request nor the existing code picks for you. Test: for each "I chose X over Y", could a reasonable reviewer say "actually, Y"?
+   - **Irreversibles** — things you cannot undo: migrations, data deletion or mutation, external side effects, deploy or config triggers.
+   - **Footprint** — how big: files you will change, and anything new that other code will call or depend on.
 
-   **All three clean** (no forks, no irreversibles, small footprint) → light path. Read `[[bmad-snapshot:spec-template.md]]` fully and write `{spec_file}` keeping only the frontmatter, `## Intent` (inside its `<frozen-after-approval>` block), and `## Implementation Notes` — delete every other section per the template's deletion license. Set `route: 'in-session'` and `status: 'in-progress'`, resolving `date` to the current system date. If `preserved_intent` is non-empty, use it as the frozen block. **EARLY EXIT** → `[[bmad-snapshot:step-oneshot.md]]`.
+   If there are no forks, nothing irreversible, and the change is small: read `[[bmad-snapshot:spec-template.md]]` fully and write `{spec_file}` with only the frontmatter, `## Intent` (inside its `<frozen-after-approval>` block), and `## Implementation Notes`. Delete every other section; the template says you may. Set `route: 'in-session'` and `status: 'in-progress'`, resolving `date` to the current system date. If `preserved_intent` is non-empty, use it as the frozen block. **EARLY EXIT** → `[[bmad-snapshot:step-oneshot.md]]`.
 
-   **Any flag** → full spec. Set `route: 'dispatch'` and continue.
-4. Read `[[bmad-snapshot:spec-template.md]]` fully. Fill it out based on the intent and investigation, resolving the template's `date` field to the current system date. Drain the investigation into the `## Code Map` section — annotated paths, symbol/line anchors, reuse pointers, and read-only evidence — so the spec is the implementer's investigation map and the step-03 handoff need only point at it. Record each fork the gate reported as one `## Open Questions` entry: the choice, the defensible options, each option's consequence. If `preserved_intent` is non-empty, replace the `<frozen-after-approval>` block in the spec you just filled out with `preserved_intent`, before writing. Write the result to `{spec_file}`.
-5. Self-review against READY FOR DEVELOPMENT standard. For each material gap, name what is missing: evidence the repository can supply → investigate and revise; a human decision → add an `## Open Questions` entry. Never close a material gap with an unsupported assumption.
+   Otherwise write the full spec. Set `route: 'dispatch'` and continue.
+4. Read `[[bmad-snapshot:spec-template.md]]` fully. Fill it out from the intent and investigation, resolving the template's `date` field to the current system date. Put the investigation into `## Code Map`: paths, symbols or lines, what to reuse, and what not to change. Implementation should work from the spec without being told the investigation again. For each Fork you listed, add one `## Open Questions` entry: the choice, the options, and what each option means. If `preserved_intent` is non-empty, replace the `<frozen-after-approval>` block with it before writing. Write the result to `{spec_file}`.
+5. Self-review against READY FOR DEVELOPMENT standard. For anything important that's missing: if the repository can tell you, go look and fix the spec; if a human has to decide, add an `## Open Questions` entry. Do not invent the answer.
 6. Token count check (see SCOPE STANDARD). If spec exceeds 1600 tokens:
    - Show user the token count.
    - HALT and give the user a choice:
@@ -34,11 +34,11 @@
        evidence: <why this was split from the current spec>
      ```
    - If the user chooses **Keep full spec**: Continue with the full spec.
-7. Drain Open Questions. While the spec's `## Open Questions` section is non-empty: present every entry as a numbered question with its options and each option's consequence, then HALT for the human's answers. Fold each answer into the `<frozen-after-approval>` block as a recorded decision and delete its entry. Then re-scan the design — an answer may create a new fork; add any as new entries and repeat. Never offer approval while entries remain. When the last entry resolves, delete the section.
+7. Ask the Open Questions. While the spec's `## Open Questions` section is not empty: present every entry as a numbered question with its options and what each option means, then HALT for the human's answers. Write each answer into the `<frozen-after-approval>` block as a decision and delete that entry. Then look at the plan again — an answer may create a new Fork; add any as new entries and repeat. Never offer approval while entries remain. When the last entry is gone, delete the section.
 
 ### CHECKPOINT 1
 
-Reachable only at zero open questions.
+Only when Open Questions is empty.
 
 Present summary. Display the spec file path in whatever form is clickable where you are presenting it (e.g. code citation in chat, CWD-relative path with no leading `/` in terminal). If unsure, use CWD-relative path. 
 

--- a/src/bmm-skills/ship/bmad-build/step-02-plan.md
+++ b/src/bmm-skills/ship/bmad-build/step-02-plan.md
@@ -13,14 +13,14 @@
 
    Do not ask the human during investigation. When something is unclear, look in the repository, planning artifacts, or history first. Keep looking until you know, or until those sources have nothing more to say. Leave any remaining choice for the next step.
 3. Decide the path. You already have a plan. Write down three facts about it — as it is now, not as a guess:
-   - **Forks** — choices where someone could reasonably pick a different option, and neither the request nor the existing code picks for you. Test: for each "I chose X over Y", could a reasonable reviewer say "actually, Y"?
+   - **Intent gaps** — things the request does not say, the code cannot settle, and the user would notice in the result. Only the human can answer these. Choices the user would not notice are yours: decide and record them in the spec.
    - **Irreversibles** — things you cannot undo: migrations, data deletion or mutation, external side effects, deploy or config triggers.
    - **Footprint** — how big: files you will change, and anything new that other code will call or depend on.
 
-   If there are no forks, nothing irreversible, and the change is small: read `[[bmad-snapshot:spec-template.md]]` fully and write `{spec_file}` with only the frontmatter, `## Intent` (inside its `<frozen-after-approval>` block), and `## Implementation Notes`. Delete every other section; the template says you may. Set `route: 'in-session'` and `status: 'in-progress'`, resolving `date` to the current system date. If `preserved_intent` is non-empty, use it as the frozen block. **EARLY EXIT** → `[[bmad-snapshot:step-oneshot.md]]`.
+   If there are no intent gaps, nothing irreversible, and the change is small: read `[[bmad-snapshot:spec-template.md]]` fully and write `{spec_file}` with only the frontmatter, `## Intent` (inside its `<frozen-after-approval>` block), and `## Implementation Notes`. Delete every other section; the template says you may. Set `route: 'in-session'` and `status: 'in-progress'`, resolving `date` to the current system date. If `preserved_intent` is non-empty, use it as the frozen block. **EARLY EXIT** → `[[bmad-snapshot:step-oneshot.md]]`.
 
    Otherwise write the full spec. Set `route: 'dispatch'` and continue.
-4. Read `[[bmad-snapshot:spec-template.md]]` fully. Fill it out from the intent and investigation, resolving the template's `date` field to the current system date. Put the investigation into `## Code Map`: paths, symbols or lines, what to reuse, and what not to change. Implementation should work from the spec without being told the investigation again. For each Fork you listed, add one `## Open Questions` entry: the choice, the options, and what each option means. If `preserved_intent` is non-empty, replace the `<frozen-after-approval>` block with it before writing. Write the result to `{spec_file}`.
+4. Read `[[bmad-snapshot:spec-template.md]]` fully. Fill it out from the intent and investigation, resolving the template's `date` field to the current system date. Put the investigation into `## Code Map`: paths, symbols or lines, what to reuse, and what not to change. Implementation should work from the spec without being told the investigation again. For each intent gap, add one `## Open Questions` entry: the choice, the options, and what each option means. Never write an intent gap into the frozen block as an assumption. If `preserved_intent` is non-empty, replace the `<frozen-after-approval>` block with it before writing. Write the result to `{spec_file}`.
 5. Self-review against READY FOR DEVELOPMENT standard. For anything important that's missing: if the repository can tell you, go look and fix the spec; if a human has to decide, add an `## Open Questions` entry. Do not invent the answer.
 6. Resolve the gates before the checkpoint. Two things must be settled, in whatever order the conversation makes natural; combine them in one message when both apply.
    - **Token count** (see SCOPE STANDARD). If the spec exceeds 1600 tokens, show the count and give the user a choice:
@@ -31,7 +31,7 @@
        summary: <one sentence naming the deferred goal>
        evidence: <why this was split from the current spec>
      ```
-   - **Open Questions.** Present every entry as a numbered question with its options and what each option means, and HALT for the human's answers. Write each answer into the `<frozen-after-approval>` block as a decision and delete the entry. An answer may expose a new fork — add it and ask again. Until every entry is gone, nothing inside `<frozen-after-approval>` may assume an answer: leave the dependent boundary, matrix row, or example out and fill it in from the decision. When the last entry is gone, delete the section.
+   - **Open Questions.** Present every entry as a numbered question with its options and what each option means, and HALT for the human's answers. Write each answer into the `<frozen-after-approval>` block as a decision and delete the entry. An answer may expose a new intent gap — add it and ask again. When the last entry is gone, delete the section.
 
 ### CHECKPOINT 1
 

--- a/src/bmm-skills/ship/bmad-build/step-02-plan.md
+++ b/src/bmm-skills/ship/bmad-build/step-02-plan.md
@@ -4,15 +4,24 @@
 
 - **Language** — Speak in `{{.communication_language}}`. Write any file output in `{{.document_output_language}}`.
 - No intermediate approvals.
+- **EARLY EXIT** means: stop this step immediately — do not read or execute anything further here. Read and fully follow the target file instead. Return here ONLY if a later step explicitly says to loop back.
 
 ## INSTRUCTIONS
 
 1. Draft resume check. If `{spec_file}` exists with `status: draft`, read it and capture the verbatim `<frozen-after-approval>...</frozen-after-approval>` block as `preserved_intent`. Otherwise `preserved_intent` is empty.
 2. Investigate codebase. _Isolate deep exploration in synchronous subagents/tasks where available. To prevent context snowballing, instruct subagents to give you distilled summaries only._ Decide which findings actually matter for execution — the specific files, symbols/lines, reuse points, and read-only constraints — and carry those forward for the Code Map. This is where the investigation lands: the spec preserves it so it is never re-narrated to the implementer at dispatch time.
-3. Read `[[bmad-snapshot:spec-template.md]]` fully. Fill it out based on the intent and investigation, resolving the template's `date` field to the current system date. Drain the investigation into the `## Code Map` section — annotated paths, symbol/line anchors, reuse pointers, and read-only evidence — so the spec is the implementer's investigation map and the step-03 handoff need only point at it. If `preserved_intent` is non-empty, replace the `<frozen-after-approval>` block in the spec you just filled out with `preserved_intent`, before writing. Write the result to `{spec_file}`.
-4. Self-review against READY FOR DEVELOPMENT standard.
-5. If intent gaps exist, do not fantasize, do not leave open questions, HALT and ask the human.
-6. Token count check (see SCOPE STANDARD). If spec exceeds 1600 tokens:
+3. Route gate. The design is now settled; report three facts about it. This is fact-reporting about a finished design, not prediction:
+   - **Forks** — judgment calls where a defensible alternative exists and neither the intent nor codebase convention decides it. Test: for each "I chose X over Y" in the design, could a reasonable reviewer answer "actually, Y"?
+   - **Irreversibles** — migrations, data deletion or mutation, external side effects, deploy or config triggers.
+   - **Footprint** — files touched and new public surface.
+
+   **All three clean** (no forks, no irreversibles, small footprint) → light path. Read `[[bmad-snapshot:spec-template.md]]` fully and write `{spec_file}` keeping only the frontmatter, `## Intent` (inside its `<frozen-after-approval>` block), and `## Implementation Notes` — delete every other section per the template's deletion license. Set `route: 'in-session'` and `status: 'in-progress'`, resolving `date` to the current system date. If `preserved_intent` is non-empty, use it as the frozen block. **EARLY EXIT** → `[[bmad-snapshot:step-oneshot.md]]`.
+
+   **Any flag** → full spec. Set `route: 'dispatch'` and continue.
+4. Read `[[bmad-snapshot:spec-template.md]]` fully. Fill it out based on the intent and investigation, resolving the template's `date` field to the current system date. Drain the investigation into the `## Code Map` section — annotated paths, symbol/line anchors, reuse pointers, and read-only evidence — so the spec is the implementer's investigation map and the step-03 handoff need only point at it. Record each fork the gate reported as one `## Open Questions` entry: the choice, the defensible options, each option's consequence. If `preserved_intent` is non-empty, replace the `<frozen-after-approval>` block in the spec you just filled out with `preserved_intent`, before writing. Write the result to `{spec_file}`.
+5. Self-review against READY FOR DEVELOPMENT standard.
+6. If intent gaps exist, do not fantasize, HALT and ask the human.
+7. Token count check (see SCOPE STANDARD). If spec exceeds 1600 tokens:
    - Show user the token count.
    - HALT and give the user a choice:
      - **Split** — carve off secondary goals.
@@ -23,9 +32,12 @@
        summary: <one sentence naming the deferred goal>
        evidence: <why this was split from the current spec>
      ```
-   - If the user chooses **Keep full spec**: Continue to checkpoint with the full spec.
+   - If the user chooses **Keep full spec**: Continue with the full spec.
+8. Drain Open Questions. While the spec's `## Open Questions` section is non-empty: present every entry as a numbered question with its options and each option's consequence, then HALT for the human's answers. Fold each answer into the `<frozen-after-approval>` block as a recorded decision and delete its entry. Then re-scan the design — an answer may create a new fork; add any as new entries and repeat. Never offer approval while entries remain. When the last entry resolves, delete the section.
 
 ### CHECKPOINT 1
+
+Reachable only at zero open questions.
 
 Present summary. Display the spec file path as a CWD-relative path (no leading `/`) so it is clickable in the terminal. If token count exceeded 1600 and the user chose to keep the full spec, include the token count and explain why it may be a problem.
 
@@ -39,9 +51,9 @@ Before approving, you can open the spec file in an editor or ask me questions an
 
 HALT and give the user a choice:
 
-- **Approve and continue** — approve the spec and proceed to implementation in this session.
-- **Approve and stop** — approve the spec, leave it `ready-for-dev`, and stop so a fresh `bmad-build` session can resume at implementation.
-- **Review spec** — review the spec, use a subagent if available, and discuss the findings and revisions with the user until the user is ready to approve, then either stop or continue.
+- **[C] Approve & continue** — approve the spec and implement it in this session, directly from the spec: proceed to step-03 and take its no-subagent path (do not dispatch an implementation subagent), then step-04 as usual.
+- **[S] Approve & stop** — approve the spec, leave it `ready-for-dev`, and stop; a later `bmad-build` resume dispatches implementation via step-03 normally.
+- **[E] Edit** — apply the user's requested changes to the spec, then return to this checkpoint.
 
 Before acting on approval, re-read `{spec_file}` from disk. If it is missing, HALT without recreating it, changing status, or proceeding. If it changed, acknowledge the external edits and continue with the updated version. Set status `ready-for-dev`; everything inside `<frozen-after-approval>` is then locked and only the human can change it.
 

--- a/src/bmm-skills/ship/bmad-build/step-02-plan.md
+++ b/src/bmm-skills/ship/bmad-build/step-02-plan.md
@@ -40,7 +40,9 @@
 
 Reachable only at zero open questions.
 
-Present summary. Display the spec file path as a CWD-relative path (no leading `/`) so it is clickable in the terminal. If token count exceeded 1600 and the user chose to keep the full spec, include the token count and explain why it may be a problem.
+Present summary. Display the spec file path in whatever form is clickable where you are presenting it (e.g. code citation in chat, CWD-relative path with no leading `/` in terminal). If unsure, use CWD-relative path. 
+
+If token count exceeded 1600 and the user chose to keep the full spec, include the token count and explain why it may be a problem.
 
 After presenting the summary, display this note:
 

--- a/src/bmm-skills/ship/bmad-build/step-03-implement.md
+++ b/src/bmm-skills/ship/bmad-build/step-03-implement.md
@@ -34,7 +34,7 @@ Do not add goal restatements, file lists, ownership boundaries, investigation de
 
 The handoff directs the subagent to load the spec's `context:` files itself, so never pre-load and paste those files into the dispatch. Only when you implement directly (no subagent available) do you load a non-empty `context:` list yourself before starting.
 
-**Path formatting rule:** Any markdown links written into `{spec_file}` must use paths relative to `{spec_file}`'s directory so they are clickable in VS Code. Any file paths displayed in terminal/conversation output must use CWD-relative format with `:line` notation (e.g., `src/path/file.ts:42`) for terminal clickability. No leading `/` in either case.
+**Path formatting rule:** Any markdown links written into `{spec_file}` must use paths relative to `{spec_file}`'s directory so they are clickable in VS Code. No leading `/`. Display file paths and `file:line` references in conversation/terminal output in whatever form is clickable where you are presenting them (e.g. code citation in chat, CWD-relative path with no leading `/` in terminal). If unsure, use CWD-relative path.
 
 ### Tasks & Acceptance Verification
 

--- a/src/bmm-skills/ship/bmad-build/step-05-present.md
+++ b/src/bmm-skills/ship/bmad-build/step-05-present.md
@@ -67,7 +67,7 @@ Display summary of your work to the user, including:
 - The commit hash, if one was created.
 - Review findings breakdown: patches applied, items deferred, and the dismissed count — dismissal reasons are recorded in the spec's `## Review Triage Log`.
 
-Any file paths shown in conversation/terminal output must use CWD-relative format (no leading `/`) with `:line` notation (e.g., `src/path/file.ts:42`) for terminal clickability — the goal is to make paths clickable in terminal emulators.
+Display file paths and `file:line` references in whatever form is clickable where you are presenting them (e.g. code citation in chat, CWD-relative path with no leading `/` in terminal). If unsure, use CWD-relative path.
 
 Offer to push and/or create a pull request.
 

--- a/src/bmm-skills/ship/bmad-build/step-oneshot.md
+++ b/src/bmm-skills/ship/bmad-build/step-oneshot.md
@@ -18,7 +18,7 @@ Follow `[[bmad-snapshot:sync-sprint-status.md]]` with `target_status` = `in-prog
 
 Implement directly from `{spec_file}` — its Intent is the source of truth. As you work, append to its `## Implementation Notes` section: decisions made, files touched, surprises encountered.
 
-**Escalation ramp.** If implementation surfaces a fact the route gate did not see — a new fork (a judgment call a reasonable reviewer could answer differently), an irreversible action, or footprint growth beyond the designed scope — stop editing. Record the trigger in `## Implementation Notes`, then upgrade `{spec_file}`: reinstate `## Code Map` (populated from your live context) and `## Open Questions` (one entry per fork), set `route: 'dispatch'` and `status: 'draft'`. Return to `[[bmad-snapshot:step-02-plan.md]]` and resume at its Drain Open Questions instruction.
+**Escalation ramp.** If implementation surfaces a fact the route gate did not see — an intent gap (something the request does not say and the user would notice in the result), an irreversible action, or footprint growth beyond the designed scope — stop editing. Record the trigger in `## Implementation Notes`, then upgrade `{spec_file}`: reinstate `## Code Map` (populated from your live context) and `## Open Questions` (one entry per intent gap), set `route: 'dispatch'` and `status: 'draft'`. Return to `[[bmad-snapshot:step-02-plan.md]]` and resume at its gate instruction (step 6).
 
 ### Review
 

--- a/src/bmm-skills/ship/bmad-build/step-oneshot.md
+++ b/src/bmm-skills/ship/bmad-build/step-oneshot.md
@@ -69,7 +69,7 @@ If version control is available and the tree is dirty, create a local commit wit
 Display a summary in conversation output, including:
 
 - The commit hash (if one was created).
-- List of files changed with one-line descriptions. Any file paths shown in conversation/terminal output must use CWD-relative format (no leading `/`) with `:line` notation (e.g., `src/path/file.ts:42`) for terminal clickability — this differs from spec-file links which use spec-file-relative paths.
+- List of files changed with one-line descriptions. Display file paths and `file:line` references in whatever form is clickable where you are presenting them (e.g. code citation in chat, CWD-relative path with no leading `/` in terminal). If unsure, use CWD-relative path. This differs from spec-file links which use spec-file-relative paths.
 - Review findings breakdown: patches applied, items deferred, and the dismissed count — dismissal reasons are recorded in the spec. If every finding was dismissed, say so.
 
 Offer to push and/or create a pull request.

--- a/src/bmm-skills/ship/bmad-build/step-oneshot.md
+++ b/src/bmm-skills/ship/bmad-build/step-oneshot.md
@@ -1,9 +1,12 @@
 # Step One-Shot: Implement, Review, Present
 
+Entered only from step-02's route gate: `{spec_file}` already exists with `route: 'in-session'`.
+
 ## RULES
 
 - **Language** — Speak in `{{.communication_language}}`. Write any file output in `{{.document_output_language}}`.
 - NEVER auto-push.
+- Content inside `<frozen-after-approval>` in `{spec_file}` is read-only. Do not modify.
 - All review subagents must run at the same model capability as the current session.
 - Run subagents synchronously: launch them together as blocking calls awaited in this turn — never backgrounded or detached, never ending the turn to await results.
 
@@ -13,7 +16,9 @@
 
 Follow `[[bmad-snapshot:sync-sprint-status.md]]` with `target_status` = `in-progress`.
 
-Implement the clarified intent directly.
+Implement directly from `{spec_file}` — its Intent is the source of truth. As you work, append to its `## Implementation Notes` section: decisions made, files touched, surprises encountered.
+
+**Escalation ramp.** If implementation surfaces a fact the route gate did not see — a new fork (a judgment call a reasonable reviewer could answer differently), an irreversible action, or footprint growth beyond the designed scope — stop editing. Record the trigger in `## Implementation Notes`, then upgrade `{spec_file}`: reinstate `## Code Map` (populated from your live context) and `## Open Questions` (one entry per fork), set `route: 'dispatch'` and `status: 'draft'`. Return to `[[bmad-snapshot:step-02-plan.md]]` and resume at its Drain Open Questions instruction.
 
 ### Review
 
@@ -43,16 +48,13 @@ Group the survivors by shared root cause — two findings belong in one entry on
     evidence: <why this is real>
   ```
 
-### Generate Spec Trace
+### Finalize Spec
 
-Set `title` = a concise title derived from the clarified intent.
+Update `{spec_file}`:
 
-Write `{spec_file}` using `[[bmad-snapshot:spec-template.md]]`. Fill only these sections — delete all others:
-
-1. **Frontmatter** — set `title: '{title}'`, `type`, `created`, `status: 'done'`. Add `route: 'one-shot'`.
-2. **Title and Intent** — `# {title}` heading and `## Intent` with **Problem** and **Approach** lines. Reuse the summary you already generated for the terminal.
-3. **Suggested Review Order** — append after Intent. Build using the same convention as `[[bmad-snapshot:step-05-present.md]]` § "Generate Suggested Review Order" (spec-file-relative links, concern-based ordering, ultra-concise framing).
-4. **Review Triage Log** — only when findings were dismissed: one line per dismissal, the finding and the reason that disposed of its claim.
+1. **Frontmatter** — set `status: 'done'`.
+2. **Suggested Review Order** — append after Intent. Build using the same convention as `[[bmad-snapshot:step-05-present.md]]` § "Generate Suggested Review Order" (spec-file-relative links, concern-based ordering, ultra-concise framing).
+3. **Review Triage Log** — only when findings were dismissed: add the section with one line per dismissal, the finding and the reason that disposed of its claim.
 
 Follow `[[bmad-snapshot:sync-sprint-status.md]]` with `target_status` = `review`.
 
@@ -68,7 +70,7 @@ Display a summary in conversation output, including:
 
 - The commit hash (if one was created).
 - List of files changed with one-line descriptions. Any file paths shown in conversation/terminal output must use CWD-relative format (no leading `/`) with `:line` notation (e.g., `src/path/file.ts:42`) for terminal clickability — this differs from spec-file links which use spec-file-relative paths.
-- Review findings breakdown: patches applied, items deferred, and the dismissed count — dismissal reasons are recorded in the spec trace. If every finding was dismissed, say so.
+- Review findings breakdown: patches applied, items deferred, and the dismissed count — dismissal reasons are recorded in the spec. If every finding was dismissed, say so.
 
 Offer to push and/or create a pull request.
 

--- a/src/bmm-skills/ship/bmad-build/sync-sprint-status.md
+++ b/src/bmm-skills/ship/bmad-build/sync-sprint-status.md
@@ -1,6 +1,6 @@
 # Sync Sprint Status
 
-Shared sub-step for updating `sprint-status.yaml` during build. Called from any route (plan-code-review, one-shot, future routes) with a `target_status` parameter.
+Shared sub-step for updating `sprint-status.yaml` during build. Called from any route (dispatch, in-session, future routes) with a `target_status` parameter.
 
 ## Preconditions
 


### PR DESCRIPTION
## Problem

bmad-build routes one-shot vs full-plan at step-01, before investigation — when the information to decide doesn't exist. The bar ("zero blast radius") is unsatisfiable in a coupled codebase, so nearly everything takes full ceremony. Separately, the spec's `Ask First` tier (already removed in #2761) asked a non-interactive implementer to self-interrupt mid-execution, which never fired.

## Approach

Move routing to the design→edit boundary in step-02, where it is fact-reporting about a completed design instead of prediction. Every run writes the same spec file; the route decides only which sections survive and who implements. Unresolved forks become Open Questions that drain at a structural step boundary — the kind of gate that reliably fires.

- **step-01** — the Route fork and "zero blast radius" criterion are gone, and so is the intent interview. The invocation prompt is the starting intent (a brief freeform request is not asked to be restated); the step resolves workflow state, loads relevant evidence, applies the VCS and scope gates, sets `spec_file`, and always exits to step-02. Unsupported gaps are carried forward, not filled and not asked about.
- **step-02** — investigation happens before any clarification: when something is unclear the model looks for repository or planning evidence and keeps going until evidence gaps are closed; what evidence cannot settle is a fork. Self-review names what each material gap is missing — evidence → investigate and revise, a human decision → Open Questions entry — and never closes a material gap with an unsupported assumption. The old pre-draft "HALT and ask the human" step is gone; the Open Questions drain is the only human decision boundary. After investigation, a route gate reports three facts about the finished design: forks (judgment calls a reasonable reviewer could answer differently), irreversibles, footprint. All clean → a two-section spec (Intent + Implementation Notes), `route: in-session`, implemented in this session via step-oneshot. Any flag → the full spec, each fork recorded as an Open Questions entry, drained via HALT before Checkpoint 1 — approval cannot be offered while entries remain. The checkpoint is three-way: approve & continue (in-session, no-subagent path), approve & stop (`ready-for-dev` for a later dispatch), edit.
- **step-oneshot** — repurposed as the light path, entered only from step-02's gate. Implementation appends decisions, files touched, and surprises to Implementation Notes; an escalation ramp fires when a gate fact surfaces mid-flight (record the trigger, reinstate Code Map and Open Questions, flip to `draft`, return to step-02's drain loop). Review layers and Classify unchanged.
- **spec-template.md** — `route` frontmatter, Open Questions and Implementation Notes sections, and the existing "DELETE THIS ENTIRE SECTION" license extended to Boundaries & Constraints, Code Map, and Tasks & Acceptance, keyed to a clean gate.

- **docs/explanation/build.md** — §1 rewritten as evidence-first intent resolution, §2 as the post-design gate, §5 lists the actual interruption points. Supersedes #2752, whose intent-resolution behavior is folded in here without its step-01 routing mechanics.

Preserved unchanged: the 1600-token scope gate, multi-goal check, VCS sanity check, sprint-status sync, and all of step-04.

## Dry-runs

**Rename a helper in one file plus its tests, no forks.** Step-01 clarifies intent and sets `spec_file`; no routing happens. Step-02's gate reports no forks (convention decides everything), no irreversibles, two-file footprint → writes the two-section spec (`route: in-session`, `status: in-progress`) and early-exits to step-oneshot. The rename happens in-session with notes appended, the review layers run on the result, and the spec finalizes to `done` with a Suggested Review Order. No checkpoint fires — review is post-hoc on diff + intent + notes.

**One fork: extend an existing module vs create a new one.** Same path through investigation, but the gate reports one fork — both options defensible, neither intent nor convention decides. The full spec is written (`route: dispatch`) with one Open Questions entry: the choice, the options, each option's consequence. Before any approval is offered, the drain loop presents it as a numbered question and HALTs. The human answers "extend"; the decision is recorded inside the frozen block, the entry deleted, a re-scan finds no new forks, and only then does Checkpoint 1 appear.

## Deferred

- `bmad-build-auto` adaptation (fork → HALT `blocked` with the questions as blocking condition).
- Retro-validation of the gate against past bmad-build runs.

