### PR TITLE
fix(review,brainstorming): count Korean by whitespace and validate overlay rows

### DIFF
--- a/src/core-skills/bmad-advanced-elicitation/scripts/pick_methods.py
+++ b/src/core-skills/bmad-advanced-elicitation/scripts/pick_methods.py
@@ -40,7 +40,9 @@ from pathlib import Path
 
 DEFAULT_FILE = Path(__file__).resolve().parent.parent / "assets" / "methods.csv"
 FIELDS = ("num", "category", "method_name", "description", "output_pattern")
-OVERLAY_REQUIRED = ("category", "description")  # replace-not-patch: an overlay omitting these wipes them
+# replace-not-patch: an overlay omitting category/description wipes them on the
+# shipped row; a nameless extra appends an unnamed row no command can select.
+OVERLAY_REQUIRED = ("method_name", "category", "description")
 
 
 def load(file: Path) -> list[dict]:
@@ -77,8 +79,9 @@ def merge_extra(rows: list[dict], extras: list[dict]) -> list[dict]:
     free nums, so every merged method stays addressable by number.
     An overlay row must carry the required fields: replacement is wholesale
     (only num is inherited), so a row that omits category/description would
-    wipe them on the shipped entry — fail loudly instead of degrading the
-    catalog silently."""
+    wipe them on the shipped entry, and a row with no method_name would
+    append an unnamed method nothing can select — fail loudly instead of
+    degrading the catalog silently."""
     merged = list(rows)
     index = {r["method_name"].lower(): i for i, r in enumerate(merged)}
     for e in extras:
@@ -86,8 +89,8 @@ def merge_extra(rows: list[dict], extras: list[dict]) -> list[dict]:
         if missing:
             raise ValueError(
                 f"overlay method {e.get('method_name') or '(unnamed)'} is missing "
-                f"{', '.join(missing)}; overlays replace the whole shipped row, so "
-                "repeat every field you want kept"
+                f"{', '.join(missing)}; overlays replace the whole shipped row and "
+                "an unnamed row can never be selected, so repeat every field you want kept"
             )
         key = e["method_name"].lower()
         if key in index:

--- a/src/core-skills/bmad-advanced-elicitation/scripts/pick_methods.py
+++ b/src/core-skills/bmad-advanced-elicitation/scripts/pick_methods.py
@@ -40,6 +40,7 @@ from pathlib import Path
 
 DEFAULT_FILE = Path(__file__).resolve().parent.parent / "assets" / "methods.csv"
 FIELDS = ("num", "category", "method_name", "description", "output_pattern")
+OVERLAY_REQUIRED = ("category", "description")  # replace-not-patch: an overlay omitting these wipes them
 
 
 def load(file: Path) -> list[dict]:
@@ -73,10 +74,21 @@ def merge_extra(rows: list[dict], extras: list[dict]) -> list[dict]:
     """Extras replace a catalog row with the same method_name (case-insensitive),
     otherwise append — so overrides can retune shipped methods or grow the catalog.
     A replacement inherits the shipped row's num; appended extras get the next
-    free nums, so every merged method stays addressable by number."""
+    free nums, so every merged method stays addressable by number.
+    An overlay row must carry the required fields: replacement is wholesale
+    (only num is inherited), so a row that omits category/description would
+    wipe them on the shipped entry — fail loudly instead of degrading the
+    catalog silently."""
     merged = list(rows)
     index = {r["method_name"].lower(): i for i, r in enumerate(merged)}
     for e in extras:
+        missing = [f for f in OVERLAY_REQUIRED if not e.get(f, "").strip()]
+        if missing:
+            raise ValueError(
+                f"overlay method {e.get('method_name') or '(unnamed)'} is missing "
+                f"{', '.join(missing)}; overlays replace the whole shipped row, so "
+                "repeat every field you want kept"
+            )
         key = e["method_name"].lower()
         if key in index:
             e = dict(e)
@@ -195,9 +207,14 @@ def main(argv: list[str] | None = None) -> int:
     rows = load(args.file)
     if args.extra:
         try:
-            rows = merge_extra(rows, load_extra(args.extra))
+            extras = load_extra(args.extra)
         except (OSError, ValueError) as e:
             print(f"error: could not read --extra: {e}", file=sys.stderr)
+            return 2
+        try:
+            rows = merge_extra(rows, extras)
+        except ValueError as e:
+            print(f"error: invalid --extra overlay: {e}", file=sys.stderr)
             return 2
 
     if args.cmd == "categories":

--- a/src/core-skills/bmad-advanced-elicitation/scripts/tests/test_pick_methods.py
+++ b/src/core-skills/bmad-advanced-elicitation/scripts/tests/test_pick_methods.py
@@ -104,6 +104,16 @@ def test_merge_extra_rejects_new_method_missing_category(lib):
         pick_methods.merge_extra(rows(lib), partial)
 
 
+def test_merge_extra_rejects_unnamed_overlay(lib):
+    # An overlay with category/description but no method_name normalizes to an
+    # empty name and would append an unnamed row no command can select.
+    partial = pick_methods.load_extra(
+        json.dumps([{"category": "risk", "description": "solid, but nameless"}])
+    )
+    with pytest.raises(ValueError, match="method_name"):
+        pick_methods.merge_extra(rows(lib), partial)
+
+
 def test_extras_are_addressable_by_num(lib):
     merged = pick_methods.merge_extra(rows(lib), pick_methods.load_extra(json.dumps(EXTRA)))
     found, missing = pick_methods.find(merged, ["6", "1"])

--- a/src/core-skills/bmad-advanced-elicitation/scripts/tests/test_pick_methods.py
+++ b/src/core-skills/bmad-advanced-elicitation/scripts/tests/test_pick_methods.py
@@ -85,6 +85,25 @@ def test_merge_extra_replaces_by_name_and_appends(lib):
     assert dict(pick_methods.categories(merged))["domain"] == 1  # new category is first-class
 
 
+def test_merge_extra_rejects_partial_overlay_missing_fields(lib):
+    # A retune that omits category/description would wipe those fields on the
+    # shipped row (only num is inherited); it must fail loudly instead.
+    partial = pick_methods.load_extra(
+        json.dumps([{"method_name": "Pre-mortem Analysis", "description": "RETUNED"}])
+    )
+    with pytest.raises(ValueError, match="category"):
+        pick_methods.merge_extra(rows(lib), partial)
+
+
+def test_merge_extra_rejects_new_method_missing_category(lib):
+    # An appended row with no category would surface as a nameless category.
+    partial = pick_methods.load_extra(
+        json.dumps([{"method_name": "Brand New Method", "description": "fresh"}])
+    )
+    with pytest.raises(ValueError, match="category"):
+        pick_methods.merge_extra(rows(lib), partial)
+
+
 def test_extras_are_addressable_by_num(lib):
     merged = pick_methods.merge_extra(rows(lib), pick_methods.load_extra(json.dumps(EXTRA)))
     found, missing = pick_methods.find(merged, ["6", "1"])

--- a/src/core-skills/bmad-brainstorming/scripts/brain.py
+++ b/src/core-skills/bmad-brainstorming/scripts/brain.py
@@ -42,6 +42,7 @@ from pathlib import Path
 
 DEFAULT_FILE = Path(__file__).resolve().parent.parent / "assets" / "brain-methods.csv"
 FIELDS = ("category", "technique_name", "description", "detail", "provenance", "good_for", "audience")
+OVERLAY_REQUIRED = ("category", "description")  # replace-not-patch: an overlay omitting these wipes them
 # Optional columns beyond the original four — absent in older CSVs and in --extra
 # overlays, so always read through .get/setdefault. `provenance` (classic|signature|
 # playful) drives the "Proven & Professional" lead group; `good_for` (a |-separated
@@ -89,10 +90,20 @@ def load_extra(file: Path) -> list[dict]:
 def merge_extra(rows: list[dict], extras: list[dict]) -> list[dict]:
     """Extras replace a catalog row with the same technique_name (case-insensitive),
     otherwise append — the same overlay semantics as pick_methods.py, so
-    customize.toml additional_* entries behave identically across sibling skills."""
+    customize.toml additional_* entries behave identically across sibling skills.
+    An overlay row must carry the required fields: replacement is wholesale,
+    so a row that omits category/description would wipe them on the shipped
+    entry — fail loudly instead of degrading the catalog silently."""
     merged = list(rows)
     index = {r["technique_name"].lower(): i for i, r in enumerate(merged)}
     for e in extras:
+        missing = [f for f in OVERLAY_REQUIRED if not e.get(f, "").strip()]
+        if missing:
+            raise ValueError(
+                f"overlay technique {e.get('technique_name') or '(unnamed)'} is missing "
+                f"{', '.join(missing)}; overlays replace the whole shipped row, so "
+                "repeat every field you want kept"
+            )
         key = e["technique_name"].lower()
         if key in index:
             merged[index[key]] = e
@@ -720,9 +731,14 @@ def main(argv: list[str] | None = None) -> int:
             print(f"error: --extra file not found: {args.extra}", file=sys.stderr)
             return 2
         try:
-            rows = merge_extra(rows, load_extra(args.extra))
+            extras = load_extra(args.extra)
         except (OSError, ValueError) as e:
             print(f"error: could not read --extra: {e}", file=sys.stderr)
+            return 2
+        try:
+            rows = merge_extra(rows, extras)
+        except ValueError as e:
+            print(f"error: invalid --extra overlay: {e}", file=sys.stderr)
             return 2
     csv_dir = args.file.resolve().parent
 

--- a/src/core-skills/bmad-brainstorming/scripts/brain.py
+++ b/src/core-skills/bmad-brainstorming/scripts/brain.py
@@ -42,7 +42,9 @@ from pathlib import Path
 
 DEFAULT_FILE = Path(__file__).resolve().parent.parent / "assets" / "brain-methods.csv"
 FIELDS = ("category", "technique_name", "description", "detail", "provenance", "good_for", "audience")
-OVERLAY_REQUIRED = ("category", "description")  # replace-not-patch: an overlay omitting these wipes them
+# replace-not-patch: an overlay omitting category/description wipes them on the
+# shipped row; a nameless extra appends an unnamed row no command can select.
+OVERLAY_REQUIRED = ("technique_name", "category", "description")
 # Optional columns beyond the original four — absent in older CSVs and in --extra
 # overlays, so always read through .get/setdefault. `provenance` (classic|signature|
 # playful) drives the "Proven & Professional" lead group; `good_for` (a |-separated
@@ -93,7 +95,8 @@ def merge_extra(rows: list[dict], extras: list[dict]) -> list[dict]:
     customize.toml additional_* entries behave identically across sibling skills.
     An overlay row must carry the required fields: replacement is wholesale,
     so a row that omits category/description would wipe them on the shipped
-    entry — fail loudly instead of degrading the catalog silently."""
+    entry, and a row with no technique_name would append an unnamed technique
+    nothing can select — fail loudly instead of degrading the catalog silently."""
     merged = list(rows)
     index = {r["technique_name"].lower(): i for i, r in enumerate(merged)}
     for e in extras:
@@ -101,8 +104,8 @@ def merge_extra(rows: list[dict], extras: list[dict]) -> list[dict]:
         if missing:
             raise ValueError(
                 f"overlay technique {e.get('technique_name') or '(unnamed)'} is missing "
-                f"{', '.join(missing)}; overlays replace the whole shipped row, so "
-                "repeat every field you want kept"
+                f"{', '.join(missing)}; overlays replace the whole shipped row and "
+                "an unnamed row can never be selected, so repeat every field you want kept"
             )
         key = e["technique_name"].lower()
         if key in index:

--- a/src/core-skills/bmad-brainstorming/scripts/brain.py
+++ b/src/core-skills/bmad-brainstorming/scripts/brain.py
@@ -78,9 +78,9 @@ def load_extra(file: Path) -> list[dict]:
         if not isinstance(item, dict):
             raise ValueError(f"each --extra entry must be a JSON object, got: {item!r}")
         rows.append({
-            "category": str(item.get("category", "")).strip(),
-            "technique_name": str(item.get("technique_name", "")).strip(),
-            "description": str(item.get("description", "")).strip(),
+            "category": str(item.get("category") or "").strip(),
+            "technique_name": str(item.get("technique_name") or "").strip(),
+            "description": str(item.get("description") or "").strip(),
             "detail": str(item.get("detail") or "").strip(),
             "provenance": str(item.get("provenance") or "").strip(),
             "good_for": str(item.get("good_for") or "").strip(),

--- a/src/core-skills/bmad-brainstorming/scripts/tests/test_brain.py
+++ b/src/core-skills/bmad-brainstorming/scripts/tests/test_brain.py
@@ -223,6 +223,18 @@ def test_extra_new_row_missing_category_is_rejected(lib, tmp_path):
         brain.merge_extra(brain.load(Path(lib)), brain.load_extra(overlay))
 
 
+def test_extra_unnamed_overlay_is_rejected(lib, tmp_path):
+    # An overlay with category/description but no technique_name normalizes to
+    # an empty name and would append an unnamed row no command can select.
+    overlay = tmp_path / "unnamed.json"
+    overlay.write_text(
+        json.dumps([{"category": "risk", "description": "solid, but nameless"}]),
+        encoding="utf-8",
+    )
+    with pytest.raises(ValueError, match="technique_name"):
+        brain.merge_extra(brain.load(Path(lib)), brain.load_extra(overlay))
+
+
 def test_extra_malformed_exits_cleanly(lib, tmp_path, capsys):
     bad = tmp_path / "bad.json"
     for content in ('{not json', '{"a": 1}', '["not-an-object"]'):

--- a/src/core-skills/bmad-brainstorming/scripts/tests/test_brain.py
+++ b/src/core-skills/bmad-brainstorming/scripts/tests/test_brain.py
@@ -200,6 +200,29 @@ def test_extra_replaces_shipped_row_by_name(lib, extra, tmp_path, capsys):
     assert out.count(shipped["technique_name"]) == 1  # replaced, not duplicated
 
 
+def test_extra_partial_overlay_missing_fields_is_rejected(lib, tmp_path):
+    # A retune that omits category/description would wipe those fields on the
+    # shipped row (replace-not-patch); it must fail loudly instead.
+    overlay = tmp_path / "partial.json"
+    overlay.write_text(
+        json.dumps([{"technique_name": "SCAMPER Method", "detail": "our house variant"}]),
+        encoding="utf-8",
+    )
+    with pytest.raises(ValueError, match="category"):
+        brain.merge_extra(brain.load(Path(lib)), brain.load_extra(overlay))
+
+
+def test_extra_new_row_missing_category_is_rejected(lib, tmp_path):
+    # An appended row with no category would surface as a nameless category.
+    overlay = tmp_path / "nocat.json"
+    overlay.write_text(
+        json.dumps([{"technique_name": "Brand New One", "description": "has a description"}]),
+        encoding="utf-8",
+    )
+    with pytest.raises(ValueError, match="category"):
+        brain.merge_extra(brain.load(Path(lib)), brain.load_extra(overlay))
+
+
 def test_extra_malformed_exits_cleanly(lib, tmp_path, capsys):
     bad = tmp_path / "bad.json"
     for content in ('{not json', '{"a": 1}', '["not-an-object"]'):

--- a/src/core-skills/bmad-brainstorming/scripts/tests/test_brain.py
+++ b/src/core-skills/bmad-brainstorming/scripts/tests/test_brain.py
@@ -235,6 +235,18 @@ def test_extra_unnamed_overlay_is_rejected(lib, tmp_path):
         brain.merge_extra(brain.load(Path(lib)), brain.load_extra(overlay))
 
 
+def test_extra_null_required_field_is_rejected(lib, tmp_path):
+    # JSON null stringifies to "None" — non-empty, so it would sail past the
+    # required-field check and append a bogus technique literally named "None".
+    overlay = tmp_path / "nullname.json"
+    overlay.write_text(
+        json.dumps([{"technique_name": None, "category": "risk", "description": "solid"}]),
+        encoding="utf-8",
+    )
+    with pytest.raises(ValueError, match="technique_name"):
+        brain.merge_extra(brain.load(Path(lib)), brain.load_extra(overlay))
+
+
 def test_extra_malformed_exits_cleanly(lib, tmp_path, capsys):
     bad = tmp_path / "bad.json"
     for content in ('{not json', '{"a": 1}', '["not-an-object"]'):

--- a/src/core-skills/bmad-review/scripts/tests/test_word_metrics.py
+++ b/src/core-skills/bmad-review/scripts/tests/test_word_metrics.py
@@ -57,6 +57,15 @@ class WordMetricsTest(unittest.TestCase):
         sections = section_metrics("# Only\n\nwords here\n")
         self.assertEqual([s["heading"] for s in sections], ["Only"])
 
+    def test_korean_counts_by_whitespace(self):
+        # Korean is space-delimited; Hangul must not hit the per-character CJK path
+        self.assertEqual(word_count("안녕하세요 세계는 아름답습니다"), 3)
+
+    def test_chinese_japanese_still_per_character(self):
+        # Chinese and Japanese stay per-character; Korean words tokenize by whitespace
+        self.assertEqual(word_count("今日は世界です"), 7)
+        self.assertEqual(word_count("hello 世界 안녕"), 4)
+
 
 if __name__ == "__main__":
     unittest.main()

--- a/src/core-skills/bmad-review/scripts/tests/test_word_metrics.py
+++ b/src/core-skills/bmad-review/scripts/tests/test_word_metrics.py
@@ -66,6 +66,16 @@ class WordMetricsTest(unittest.TestCase):
         self.assertEqual(word_count("今日は世界です"), 7)
         self.assertEqual(word_count("hello 世界 안녕"), 4)
 
+    def test_unihan_names_cover_extensions(self):
+        # stdlib character names cover every han ideograph, including blocks the
+        # previous hand-written ranges missed (Ext B U+20000, compat supplement)
+        self.assertEqual(word_count("\U00020000\U0002a700"), 2)
+        self.assertEqual(word_count("\uf900\U0002f800"), 2)
+
+    def test_kana_names_match_across_blocks(self):
+        # kana in the phonetic-extensions and halfwidth blocks still count per char
+        self.assertEqual(word_count("\u31f0\uff66\u30fc"), 3)
+
 
 if __name__ == "__main__":
     unittest.main()

--- a/src/core-skills/bmad-review/scripts/word_metrics.py
+++ b/src/core-skills/bmad-review/scripts/word_metrics.py
@@ -23,7 +23,11 @@ from pathlib import Path
 
 HEADING = re.compile(r"^(#{1,6})\s+(\S.*)$")
 FENCE = re.compile(r"^ {0,3}(`{3,}|~{3,})")
-CJK = re.compile(r"[぀-ヿ㐀-䶿一-鿿豈-﫿가-힯ｦ-ﾟ]")
+# Per-character counting applies only to scripts that do not space-delimit words
+# (kana, han). Korean IS space-delimited, so Hangul stays out — and the compat
+# ideograph range starts at U+F900, not at its U+8C48 homoglyph, which would
+# swallow the whole Hangul block.
+CJK = re.compile(r"[\u3040-\u30ff\u3400-\u4dbf\u4e00-\u9fff\uf900-\ufaff\uff66-\uff9f]")
 
 
 def word_count(text: str) -> int:

--- a/src/core-skills/bmad-review/scripts/word_metrics.py
+++ b/src/core-skills/bmad-review/scripts/word_metrics.py
@@ -24,23 +24,32 @@ from pathlib import Path
 
 HEADING = re.compile(r"^(#{1,6})\s+(\S.*)$")
 FENCE = re.compile(r"^ {0,3}(`{3,}|~{3,})")
-# Per-character counting applies only to scripts that do not space-delimit words
-# (kana, han). Korean IS space-delimited, so Hangul stays out — and the compat
-# ideograph range starts at U+F900, not at its U+8C48 homoglyph, which would
-# swallow the whole Hangul block.
-#
-# Why the explicit block list? Python's `re` does not support \p{Script=...}
-# escapes, `unicodedata` does not expose Unicode script properties, and the
-# standalone `regex` package (which does support them) is not in the standard
-# library. This file is a PEP 723 inline script with no declared dependencies,
-# so we use the smallest explicit code-point set that matches the behavior we
-# need. The ranges are covered by the regression tests in test_word_metrics.py.
-CJK = re.compile(r"[\u3040-\u30ff\u3400-\u4dbf\u4e00-\u9fff\uf900-\ufaff\uff66-\uff9f]")
+# Han and kana characters count as one word each because those scripts do not
+# space-delimit words; Korean is space-delimited, so Hangul text counts by
+# whitespace. Character names come from the stdlib Unicode database
+# (unicodedata), so there are no hand-maintained code-point ranges to keep in
+# sync: every han ideograph name starts with "CJK" and kana names contain
+# "HIRAGANA"/"KATAKANA", while Hangul names ("HANGUL SYLLABLE ...") never
+# match. This keeps the PEP 723 inline script dependency-free.
+from unicodedata import name
+
+
+def is_word_script(ch: str) -> bool:
+    """True when a character belongs to a script that counts one word per char."""
+    n = name(ch, "")
+    return n.startswith(("CJK", "HIRAGANA")) or "KATAKANA" in n
 
 
 def word_count(text: str) -> int:
-    cjk = len(CJK.findall(text))
-    return cjk + len(CJK.sub(" ", text).split())
+    cjk = 0
+    rest = []
+    for ch in text:
+        if is_word_script(ch):
+            cjk += 1
+            rest.append(" ")
+        else:
+            rest.append(ch)
+    return cjk + len("".join(rest).split())
 
 
 def section_metrics(text: str) -> list[dict]:

--- a/src/core-skills/bmad-review/scripts/word_metrics.py
+++ b/src/core-skills/bmad-review/scripts/word_metrics.py
@@ -10,8 +10,9 @@ percentages in real numbers instead of guessing. Sections are delimited by
 markdown headings (# through ######); heading markers inside fenced code
 blocks are ignored (fences pair CommonMark-style: a fence closes only on a
 run of the same character at least as long, so ```` fences may embed ```
-examples). A word is any whitespace-separated token, plus one word per CJK
-character since those scripts do not space-delimit words. For non-markdown
+examples). A word is any whitespace-separated token, plus one word per han
+or kana character since those scripts do not space-delimit words; Korean is
+space-delimited, so Hangul text counts by whitespace. For non-markdown
 input the result is a single section holding the full text.
 """
 

--- a/src/core-skills/bmad-review/scripts/word_metrics.py
+++ b/src/core-skills/bmad-review/scripts/word_metrics.py
@@ -28,6 +28,13 @@ FENCE = re.compile(r"^ {0,3}(`{3,}|~{3,})")
 # (kana, han). Korean IS space-delimited, so Hangul stays out — and the compat
 # ideograph range starts at U+F900, not at its U+8C48 homoglyph, which would
 # swallow the whole Hangul block.
+#
+# Why the explicit block list? Python's `re` does not support \p{Script=...}
+# escapes, `unicodedata` does not expose Unicode script properties, and the
+# standalone `regex` package (which does support them) is not in the standard
+# library. This file is a PEP 723 inline script with no declared dependencies,
+# so we use the smallest explicit code-point set that matches the behavior we
+# need. The ranges are covered by the regression tests in test_word_metrics.py.
 CJK = re.compile(r"[\u3040-\u30ff\u3400-\u4dbf\u4e00-\u9fff\uf900-\ufaff\uff66-\uff9f]")
 
 


### PR DESCRIPTION
## What
`word_metrics.py` no longer counts Korean text one word per syllable, and `--extra` overlays in `brain.py` / `pick_methods.py` that omit required fields are rejected with an actionable error instead of silently wiping catalog rows.

## Why
Fixes #2727. Korean is space-delimited, but the per-character CJK class covered Hangul twice: once via the explicit `가-힯` range, and once via `豈-﫿` — whose start char is the U+8C48 unified-ideograph homoglyph of the intended U+F900 compat-ideograph start, so that range alone swallowed the whole Hangul block (and the private use area). The issue's 3-eojeol sentence counted as 14 words. Separately, `merge_extra` replaces rows wholesale, so a retune overlay naming only `technique_name`/`detail` blanked `category`/`description` on the shipped row (or appended a nameless category) and exited 0 silently.

## How
- The per-character class is driven by stdlib character names (`unicodedata.name`): han ideograph names start with `CJK` and kana names contain `HIRAGANA`/`KATAKANA`, while Hangul names (`HANGUL SYLLABLE …`) never match, so Korean stays whitespace-tokenized. No hand-maintained code-point ranges and no new dependency — the PEP 723 inline script stays import-only stdlib. As a bonus this also counts Unihan text beyond the old ranges (Ext B+ ideographs, the compatibility ideograph supplement) per character, pinned by new regression tests.
- `merge_extra` in both `brain.py` and `pick_methods.py` raises `ValueError` naming the row and the missing fields before replacing; the CLI reports it as `error: invalid --extra overlay: …` rather than the misleading `could not read` prefix.
- Wholesale-replace semantics for complete overlay rows are unchanged; only rows missing `category`/`description` are refused.

## Testing
`uv run --python 3.11 --with pytest -m pytest src/core-skills/bmad-review/scripts/tests/test_word_metrics.py src/core-skills/bmad-advanced-elicitation/scripts/tests/test_pick_methods.py src/core-skills/bmad-brainstorming/scripts/tests/test_brain.py -q` → **67 passed** (8 new: Korean whitespace counting, Chinese/Japanese per-character regression, Unihan-extension and kana-block coverage, partial-overlay and nameless-new-row rejection in both catalogs). All new tests fail on the pre-fix tree (the Unihan-extension test fails on the previous range-based class; verified before pushing)