### PR TITLE
chore(quality): add a gate that prints output only on failure

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -5,8 +5,10 @@ Open source framework for structured, agent-assisted software delivery.
 ## Rules
 
 - Use Conventional Commits for every commit.
-- Before pushing, run `npm ci && npm run quality` on `HEAD` in the exact checkout you are about to push.
-  `quality` mirrors the checks in `.github/workflows/quality.yaml`.
+- Before pushing, run `HUSKY=0 npm ci --silent && npm run -s quality:gate` on
+  `HEAD` in the exact checkout you are about to push; push only on exit 0.
+  It mirrors the checks in `.github/workflows/quality.yaml` and prints
+  output only on failure.
 
 - Skill validation rules are in `tools/skill-validator.md`.
 - Deterministic skill checks run via `npm run validate:skills` (included in `quality`).

--- a/package.json
+++ b/package.json
@@ -41,6 +41,7 @@
     "lint:md": "markdownlint-cli2 \"**/*.md\"",
     "prepare": "command -v husky >/dev/null 2>&1 && husky || exit 0",
     "quality": "npm run format:check && npm run lint && npm run lint:md && npm run docs:build && npm run test:site-url && npm run test:install && npm run test:urls && npm run test:renderer && npm run test:retrospective && npm run test:sprint-planning && npm run validate:refs && npm run validate:skills && npm run docs:validate-sidebar",
+    "quality:gate": "node tools/quality-gate.mjs",
     "rebundle": "node tools/installer/bundlers/bundle-web.js rebundle",
     "test": "npm run test:refs && npm run test:install && npm run test:urls && npm run test:site-url && npm run test:channels && npm run test:renderer && npm run test:retrospective && npm run test:sprint-planning && npm run test:skills && npm run lint && npm run lint:md && npm run format:check",
     "test:channels": "node test/test-installer-channels.js",

--- a/tools/quality-gate.mjs
+++ b/tools/quality-gate.mjs
@@ -1,0 +1,15 @@
+// Runs the quality chain silently; prints its output only when it fails.
+import { spawnSync } from 'node:child_process';
+
+const result = spawnSync('npm run -s quality', {
+  shell: true,
+  encoding: 'utf8',
+  maxBuffer: 64 * 1024 * 1024,
+});
+if (result.status === 0) {
+  console.log('quality: all checks passed');
+} else {
+  process.stdout.write(result.stdout ?? '');
+  process.stderr.write(result.stderr ?? '');
+  process.exit(result.status ?? 1);
+}


### PR DESCRIPTION
`npm run quality:gate` runs the quality chain and prints its output only on failure; AGENTS.md tells agents to gate pushes on `HUSKY=0 npm ci --silent && npm run -s quality:gate`.