### PR TITLE
docs: route the landing page by task

### DIFF
--- a/docs/index.md
+++ b/docs/index.md
@@ -1,68 +1,45 @@
 ---
 title: Build Software with BMad
-description: See how BMad turns short requests and shared specifications into reviewed software changes while you keep control of important decisions.
+description: BMad turns a request into reviewed, working code. Start here to install it, make your first change, or find the path that fits the work in front of you.
 hero:
-  title: Turn intent into working software
-  tagline: BMad clarifies what matters, gives you a plan to approve, implements the change, reviews its work, and shows you the result.
+  title: Turn a request into working software
+  tagline: BMad works inside your AI coding tool. You describe the result you want, approve the plan, and get code that has been written, reviewed, and left ready for you to run.
   actions:
-    - text: Start with a small build
-      link: ./tutorials/getting-started/
+    - text: Install BMad
+      link: ./how-to/install-bmad/
       variant: primary
-    - text: Try it in Django
-      link: ./tutorials/getting-deeper/
+    - text: Build your first change
+      link: ./tutorials/getting-started/
       variant: secondary
 ---
 
-BMad works with supported AI coding tools to carry a software request through
-clarification, an approved plan, implementation, and review. You keep control
-of the decisions that shape the result, and Build returns working code you can
-run and inspect.
+BMad adds a set of named commands, called skills, to AI coding tools such as
+Claude Code and Cursor. The main one is `bmad-build`: you give it a change to
+make, and it does the work and reviews it.
 
-## Start with Working Software
+## Find Your Starting Point
 
-[Getting Started](./tutorials/getting-started.md) begins in an empty directory
-with one short request:
+**You know exactly what needs to change, and it is small.**
+Run `bmad-build` and describe the change. See [Quick Fixes](./how-to/quick-fixes.md).
 
-```text
-/bmad-build write an implementation of mars rover kata
-```
+**You are building a larger feature or a whole product.**
+Plan it first, write a short specification, then build from that specification
+one piece at a time. See the [Workflow Map](./reference/workflow-map.md).
 
-Build asks for the choices it needs, then gives you a plan to approve or change.
-It writes and reviews the program before you run the finished Mars Rover in your
-terminal. The request stays small; you decide what the program should become.
+**You are working in a codebase that already exists.**
+Give BMad a written description of the project before you ask it to change
+anything. See [Established Projects](./how-to/established-projects.md) and
+[Manage Project Context](./how-to/project-context.md).
 
-**[Build Mars Rover with BMad](./tutorials/getting-started.md)**
+**Your idea is still vague, or you are not sure it is a good one.**
+Generate options with [Brainstorming](./explanation/brainstorming.md), gather
+evidence with [Deep Recon](./explanation/deep-recon.md), or have the idea argued
+against in [Pressure-Test an Idea](./how-to/pressure-test-an-idea.md).
 
-## Continue in a Mature Codebase
+**You want BMad to follow your team's own rules and practices.**
+See [Customize BMad](./how-to/customize-bmad.md) and
+[Expand BMad for Your Organization](./how-to/expand-bmad-for-your-org.md).
 
-[Getting Deeper](./tutorials/getting-deeper.md) moves the same direct workflow
-into Django 5.2.4. You ask Build to add JSON output to `django-admin
-diffsettings`, make the decisions that define that output, run the focused
-tests, and inspect the JSON produced by the command.
+---
 
-The second Django exercise shows what changes when the work spans several
-stories. BMad Spec records one shared contract for filtering, redaction, and CI
-status. Three Build runs implement it in order, and one final command shows the
-features working together: filtering selects the setting, redaction hides its
-value, and the exit status still reports the remaining difference.
-
-**[Try the Django playground](./tutorials/getting-deeper.md)**
-
-## Find a Specific Answer
-
-Use the search box or sidebar when you already know what you need. These common
-tasks lead directly to the relevant documentation:
-
-- [Install or update BMad](./how-to/install-bmad.md)
-- [Use BMad in an established project](./how-to/established-projects.md)
-- [Understand how Build works](./explanation/build.md)
-- [Look up installed skills](./reference/commands.md)
-
-## Build in Your Repository
-
-Choose a real change in a repository you already use. Install BMad in that
-repository, run the installed `bmad-build` skill, and describe the result you
-want. You can settle the important choices, approve or revise the plan, and
-inspect the finished change in its real context.
-
-**[Use BMad in your repository](./how-to/install-bmad.md)**
+Unsure where to start? Run `bmad-help`.

--- a/docs/index.md
+++ b/docs/index.md
@@ -1,45 +1,56 @@
 ---
 title: Build Software with BMad
-description: BMad turns a request into reviewed, working code. Start here to install it, make your first change, or find the path that fits the work in front of you.
+description: BMad helps you decide what to build and then build it. Start here to install it, make your first change, or find the path that fits the work in front of you.
 hero:
-  title: Turn a request into working software
-  tagline: BMad works inside your AI coding tool. You describe the result you want, approve the plan, and get code that has been written, reviewed, and left ready for you to run.
+  title: 'Turn ideas into software.<br>At any scale.'
+  tagline: Think it through, then build it. You make the calls, so you understand what you ship.
   actions:
-    - text: Install BMad
-      link: ./how-to/install-bmad/
-      variant: primary
     - text: Build your first change
       link: ./tutorials/getting-started/
+      variant: primary
+    - text: Install BMad
+      link: ./how-to/install-bmad/
       variant: secondary
 ---
 
 BMad adds a set of named commands, called skills, to AI coding tools such as
-Claude Code and Cursor. The main one is `bmad-build`: you give it a change to
-make, and it does the work and reviews it.
+Claude Code and Cursor. Some of them help you think: explore an idea, research
+it, argue against it, and write down what you have settled on. Others help you
+build: give `bmad-build` a change you want made, and it writes the code and
+reviews it.
+
+You can use either group on its own. Many people run the thinking skills and
+never ask BMad to write a line of code, and a small fix can go straight to
+building with no planning at all.
 
 ## Find Your Starting Point
+
+**You want to see it work.**
+[Getting Started](./tutorials/getting-started.md) walks through one build in an
+empty project.
 
 **You know exactly what needs to change, and it is small.**
 Run `bmad-build` and describe the change. See [Quick Fixes](./how-to/quick-fixes.md).
 
-**You are building a larger feature or a whole product.**
-Plan it first, write a short specification, then build from that specification
-one piece at a time. See the [Workflow Map](./reference/workflow-map.md).
-
-**You are working in a codebase that already exists.**
-Give BMad a written description of the project before you ask it to change
-anything. See [Established Projects](./how-to/established-projects.md) and
+**You are working in an existing codebase.**
+Run `bmad-project-context`, then build as usual. See
+[Established Projects](./how-to/established-projects.md) and
 [Manage Project Context](./how-to/project-context.md).
+
+**You are building a larger feature or a whole product.**
+If you can give `bmad-spec` a complete intent, start there. If you need to
+go through the ideation/planning paces first, choose a path in the
+[Workflow Map](./reference/workflow-map.md).
 
 **Your idea is still vague, or you are not sure it is a good one.**
 Generate options with [Brainstorming](./explanation/brainstorming.md), gather
-evidence with [Deep Recon](./explanation/deep-recon.md), or have the idea argued
-against in [Pressure-Test an Idea](./how-to/pressure-test-an-idea.md).
+evidence with [Deep Recon](./explanation/deep-recon.md), or
+[pressure-test the idea](./how-to/pressure-test-an-idea.md).
 
 **You want BMad to follow your team's own rules and practices.**
 See [Customize BMad](./how-to/customize-bmad.md) and
 [Expand BMad for Your Organization](./how-to/expand-bmad-for-your-org.md).
 
----
-
-Unsure where to start? Run `bmad-help`.
+:::tip[Unsure where to start?]
+Run `bmad-help`.
+:::

--- a/docs/index.md
+++ b/docs/index.md
@@ -33,7 +33,7 @@ empty project.
 Run `bmad-build` and describe the change. See [Quick Fixes](./how-to/quick-fixes.md).
 
 **You are working in an existing codebase.**
-Run `bmad-project-context`, then build as usual. See
+Consider running `bmad-project-context`, then build as usual. See
 [Established Projects](./how-to/established-projects.md) and
 [Manage Project Context](./how-to/project-context.md).
 

--- a/website/src/styles/custom.css
+++ b/website/src/styles/custom.css
@@ -83,6 +83,19 @@
    TYPOGRAPHY
    ============================================ */
 
+/* Hero: left-align at all widths (Starlight centers below 50rem) */
+.hero .stack {
+  text-align: start;
+}
+
+.hero .copy {
+  align-items: flex-start;
+}
+
+.hero .actions {
+  justify-content: flex-start;
+}
+
 /* Space Grotesk for all headings - match Ghost blog */
 .sl-markdown-content h1,
 .sl-markdown-content h2,


### PR DESCRIPTION
## Summary
- Replace the tutorial-pitch landing page with a task-based map: think skills and build skills as equal paths, then send the reader to the matching how-to.
- Hero leads with Getting Started; install stays as the secondary action. Spec work with complete intent goes to `bmad-spec`; a larger effort that still needs planning goes to the Workflow Map.
- Left-align the hero at all widths so the two-phrase title does not wrap as a centered stack.

## Test plan
- [ ] Open the docs landing page and confirm the hero title breaks after “software.” and stays left-aligned at desktop and mobile widths
- [ ] Click both hero buttons: Getting Started (primary) and Install BMad (secondary)
- [ ] Follow each “Find Your Starting Point” route and confirm the destination matches the situation
- [ ] Confirm `bmad-help` still appears as the fallback tip
- [ ] Spot-check that translated index pages (no hero) are unchanged