### PR TITLE
docs: add Review a Change page

### DIFF
--- a/docs/build/build-a-change.md
+++ b/docs/build/build-a-change.md
@@ -103,6 +103,9 @@ code is wrong because the plan was weak, or the plan is wrong because the goal
 was wrong, it goes back to that layer and regenerates from there instead of
 patching only the diff.
 
+For a standalone review — a PR, someone else's change, an extra pass, or a
+review bot — see [Review a Change](review-a-change.md).
+
 ### 6. Review the Result
 
 When it finishes, `bmad-build` shows you the completed change and its review

--- a/docs/build/review-a-change.md
+++ b/docs/build/review-a-change.md
@@ -1,0 +1,119 @@
+---
+title: 'Review a Change'
+description: Use bmad-code-review for a standalone agentic review of a PR, someone else's change, an extra pass, or a review bot.
+sidebar:
+  order: 2
+---
+
+`bmad-code-review` reviews a code change with independent reviewers in
+parallel, then triages the findings. See
+[how a run works](#run-bmad-code-review).
+
+`bmad-build` already reviewed its own change during implementation. Use
+this skill when the review is not part of that run.
+
+## When to Use It
+
+Use `bmad-code-review` for a standalone agentic review:
+
+- **Someone else's change** — a branch or commit you did not just
+  implement
+- **A pull request** — including one that never went through `bmad-build`
+- **An extra pass** — another review after `bmad-build` already reviewed
+  the implementation
+- **A review bot** — this skill as the prompt behind an automated
+  review. The run is still attended: it confirms the target and presents
+  findings to a human.
+
+Implementation-time review stays on [Build a Change](build-a-change.md).
+`bmad-build` reviews the change it just made, inside that same run.
+
+Invoke it by saying "run code review" or "review this code."
+
+## Run `bmad-code-review`
+
+Start a fresh chat and name the skill. Pass a PR, commit, branch, spec,
+or the current git state. You can describe the target before, with, or
+after the command.
+
+```text
+run code review
+```
+
+```text
+/bmad-code-review Review https://github.com/org/repo/pull/42
+```
+
+The skill writes a unified diff to a file, confirms the target and spec
+context with you, then launches the reviewers. This works best on a
+platform that can spawn subagents, or at least call another model from
+the command line and wait for a result.
+
+## What a Run Does
+
+Active layers review the same diff independently and in parallel. Once
+every layer has reported, triage judges each finding on its own:
+
+- **Verify** the claimed consequence at the named location, reading past
+  the diff hunk far enough to tell whether that consequence actually
+  occurs
+- **Assign severity** from the verified consequence (`low`, `medium`,
+  `high`)
+- **Dismiss** noise, refuted claims, and unsubstantiated claims, with a
+  recorded reason — never silently
+- **Route** survivors to **patch**, **defer**, or **decision needed**
+
+Patch is an unambiguous code fix. Defer is a real pre-existing issue that
+is not this change. Decision needed is an ambiguous choice that requires
+you. Without a spec, decision needed is not used — those findings go to
+patch or defer.
+
+You get a findings summary. Without a spec, that listing stays in the
+chat. You choose whether to apply patches.
+
+## Why Pay for Triage
+
+Reviewer layers and triage cost tokens and minutes. A defect that
+escapes costs a report, a reproduction, a context switch, a fix, and a
+re-review — orders of magnitude more.
+
+Without triage you pay for every note a layer emitted, including noise.
+Triage is what makes you pay for verified findings instead.
+
+## Customize the Layers
+
+Fewer layers is cheaper and catches less. You choose the price for your
+situation.
+
+Override `[[workflow.review_layers]]` in
+`_bmad/custom/bmad-code-review.toml`. The skill ships four layers:
+`blind-hunter`, `edge-case-hunter`, `verification-gap`, and
+`acceptance-auditor`. Empty `instruction` on an existing `id` disables
+that layer. A `when` field gates a layer. A new `id` appends.
+`instruction` may be bash.
+
+```toml
+# _bmad/custom/bmad-code-review.toml
+[[workflow.review_layers]]
+id = "blind-hunter"
+instruction = ""
+[[workflow.review_layers]]
+id = "acceptance-auditor"
+when = 'Only when {review_mode} = "full".'
+[[workflow.review_layers]]
+id = "security-bot"
+name = "Security bot"
+instruction = """
+Run the team reviewer via bash on {diff_file} and return its findings as a Markdown list.
+"""
+```
+
+For how overrides merge, see [Customize BMad](../how-to/customize-bmad.md).
+
+## What It Is Not
+
+`bmad-code-review` is not a human walkthrough — that is
+[Walk Through a Change](walk-through-a-change.md). It is not generated
+test coverage — that is [Test Completed Work](test-completed-work.md).
+Party Mode's Code Review Crew is a debate among lenses, not a triaged
+review; see [Party Mode](../explanation/party-mode.md#the-code-review-crew).

--- a/docs/build/review-a-change.md
+++ b/docs/build/review-a-change.md
@@ -4,37 +4,44 @@ description: Use bmad-code-review for a standalone agentic review of a PR, someo
 sidebar:
   order: 2
 ---
+Ten seconds of your attention costs more than ten minutes of inference.
+A bug that escapes to production costs at least a hundred times more
+than one caught in development.
 
-`bmad-code-review` reviews a code change with independent reviewers in
-parallel, then triages the findings. See
+Code an agent just wrote can — and should — be reviewed and cleaned up
+by an agent before any human looks at it.
+
+If you came from [Build a Change](build-a-change.md), you have already
+seen this happen. `bmad-build` has a review and triage stage baked in.
+By the time it finishes, a round of review and fixing has already
+happened.
+
+If you still suspect there is more to find, run `bmad-build` again and
+hand it the spec from that run — the one already marked `status: done`.
+That skips straight to review and triage, and you can repeat it as many
+times as you want. Stop when the findings are mostly low-value notes
+about exotic corner cases. That is accidental complexity, not quality.
+Non-trivial findings on a third pass of agentic review usually mean
+something is wrong upstream of this change: a weak spec, a
+contradiction, or ambiguity in the rules. Fix that instead of running
+another pass.
+
+To review a change that is not a single `bmad-build` run, use
+`bmad-code-review`. It is the same kind of review and triage, but you
+can point it at any code artifact: a diff, a pull request, a file, a
+namespace, someone else's branch. See
 [how a run works](#run-bmad-code-review).
-
-`bmad-build` already reviewed its own change during implementation. Use
-this skill when the review is not part of that run.
-
-## When to Use It
-
-Use `bmad-code-review` for a standalone agentic review:
-
-- **Someone else's change** — a branch or commit you did not just
-  implement
-- **A pull request** — including one that never went through `bmad-build`
-- **An extra pass** — another review after `bmad-build` already reviewed
-  the implementation
-- **A review bot** — this skill as the prompt behind an automated
-  review. The run is still attended: it confirms the target and presents
-  findings to a human.
-
-Implementation-time review stays on [Build a Change](build-a-change.md).
-`bmad-build` reviews the change it just made, inside that same run.
-
-Invoke it by saying "run code review" or "review this code."
 
 ## Run `bmad-code-review`
 
-Start a fresh chat and name the skill. Pass a PR, commit, branch, spec,
-or the current git state. You can describe the target before, with, or
-after the command.
+Start a fresh chat and name the skill. Pass the change to review: a PR,
+commit, branch, file, or the current git state. You can describe the
+target before, with, or after the command.
+
+If you have a spec, requirements, or even a stream of consciousness
+for what this change is supposed to implement, feed that in too. Review
+quality depends on it — without intent, the reviewers can only judge
+the diff against itself.
 
 ```text
 run code review
@@ -71,19 +78,10 @@ patch or defer.
 You get a findings summary. Without a spec, that listing stays in the
 chat. You choose whether to apply patches.
 
-## Why Pay for Triage
-
-Reviewer layers and triage cost tokens and minutes. A defect that
-escapes costs a report, a reproduction, a context switch, a fix, and a
-re-review — orders of magnitude more.
-
-Without triage you pay for every note a layer emitted, including noise.
-Triage is what makes you pay for verified findings instead.
-
 ## Customize the Layers
 
-Fewer layers is cheaper and catches less. You choose the price for your
-situation.
+The shipped lenses are a starting point. Start `bmad-customize` and
+ask what you can change.
 
 Override `[[workflow.review_layers]]` in
 `_bmad/custom/bmad-code-review.toml`. The skill ships four layers:
@@ -110,10 +108,69 @@ Run the team reviewer via bash on {diff_file} and return its findings as a Markd
 
 For how overrides merge, see [Customize BMad](../how-to/customize-bmad.md).
 
-## What It Is Not
+## Why Does Review Take Forever?
 
-`bmad-code-review` is not a human walkthrough — that is
-[Walk Through a Change](walk-through-a-change.md). It is not generated
-test coverage — that is [Test Completed Work](test-completed-work.md).
-Party Mode's Code Review Crew is a debate among lenses, not a triaged
-review; see [Party Mode](../explanation/party-mode.md#the-code-review-crew).
+Three explanations:
+
+- [Exhaustive on purpose](#exhaustive-on-purpose)
+- [Too many rules, or huge files](#too-many-rules-or-huge-files)
+- [Your platform](#your-platform)
+
+### Exhaustive on purpose
+
+The default assumes an average bug escaping into production is worth
+more than an hour of inference. You can turn that down, or off — see
+[Customize the Layers](#customize-the-layers). Turning review off is
+reasonable for a throwaway prototype. A long review can also run
+offline.
+
+It is a bad idea to let teammates look at unreviewed LLM-generated
+code. It is a worse idea to put that code into production without the
+full battery of review lenses. If you care about the quality of the
+product, think about more lenses, not fewer.
+
+Do not take anyone's word for it. Pick a handful of interesting
+changes, run the full battery, look at one or two of the most
+interesting findings, and ask which is better: extra token burn, or
+living with those issues in production.
+
+Your custom lenses can run on other models. That is worth doing. Run
+several `blind-hunter` lenses with the same prompt, one on every LLM
+you have access to.
+
+### Too many rules, or huge files
+
+There are too many rules in `AGENTS.md` and the other instruction files
+the agent reads every run. Or the codebase is shaped so a reviewing
+agent has to read huge files. Those files blow the context window, or
+the agent wastes the run figuring out how to avoid them without losing
+review quality.
+
+### Your platform
+
+Some runtimes have no subagents. Vendors, including Anthropic and
+OpenAI, have also shipped changes that alter how subagents run. Until
+BMad catches up, the lenses execute one after another instead of in
+parallel — or they fall back to the main session, which is far worse
+for review quality than it sounds.
+
+If a review that usually runs for ten minutes suddenly takes an hour,
+or becomes inexplicably stupid, resume that session and ask why.
+
+## Why Do I Need This When My Platform Has `/code-review`?
+
+Typical `/code-review` is much simpler, and finds fewer problems. Or it
+is a black box you have no control over, running on cheap models,
+putting a ton of noise in front of your eyes — and ten seconds of your
+attention are worth more than ten minutes of inference. Or it is great,
+but really expensive, and still a generic black box.
+
+Almost none of them, at the time of this writing, do automatic
+triage/fixing that holds up.
+
+Or maybe it is in fact just great, and BMad review is inferior. Same
+test as above: take several interesting diffs, run an A/B, and either
+pick one, or make the built-in command an extra lens. If you find
+something that genuinely adds quality findings without creating too
+much noise, it is almost always worth adding as a lens — see
+[Customize the Layers](#customize-the-layers).

--- a/docs/build/test-completed-work.md
+++ b/docs/build/test-completed-work.md
@@ -2,7 +2,7 @@
 title: 'Test Completed Work'
 description: Choose a testing path after implementation — built-in QA for generated coverage, or TEA when you need strategy, traceability, or release gates.
 sidebar:
-  order: 3
+  order: 4
 ---
 
 After a change is implemented, decide whether it needs more automated
@@ -74,8 +74,8 @@ cases, no hardcoded waits, descriptions that read as feature documentation.
 ## Limits
 
 `bmad-qa-generate-e2e-tests` generates tests only. It does not review the
-implementation — that is `bmad-build` during the run, or `bmad-code-review`
-if you want another pass.
+implementation — that is `bmad-build` during the run, or
+[`bmad-code-review`](review-a-change.md) if you want another pass.
 
 It does not produce a test strategy, risk ranking, requirements
 traceability, NFR evidence, or a go/no-go gate. It does not load a PRD or

--- a/docs/build/walk-through-a-change.md
+++ b/docs/build/walk-through-a-change.md
@@ -2,7 +2,7 @@
 title: 'Walk Through a Change'
 description: Use bmad-walkthrough to walk through a finished change and decide whether to approve, rework, or discuss further.
 sidebar:
-  order: 2
+  order: 3
 ---
 
 `bmad-walkthrough` walks you through a finished change — from purpose and
@@ -10,7 +10,7 @@ context into details — so you can decide whether to approve, rework, or
 discuss further. See [how a run works](#run-bmad-walkthrough).
 
 This is human comprehension, not a substitute for the review `bmad-build`
-already ran, or for `bmad-code-review`.
+already ran, or for [`bmad-code-review`](review-a-change.md).
 
 ## When to Use It
 
@@ -129,8 +129,8 @@ perspective:
   reconsider and refine its analysis of a specific area
 - **"party mode on whether this schema migration is safe"** — bring multiple
   agent perspectives into a focused debate
-- **"run code review"** — generate structured agentic findings with
-  adversarial and edge-case analysis
+- **"run code review"** — a triaged agentic review; see
+  [Review a Change](review-a-change.md)
 
 The walkthrough workflow doesn't lock you into a linear path. It gives you
 structure when you want it and gets out of the way when you want to explore.
@@ -151,7 +151,7 @@ author-produced one, but far better than reading changes in file order.
 ## What It Is Not
 
 `bmad-walkthrough` is not the review skill. It does not replace the review
-`bmad-build` already ran, a re-invoke of that run on a done story, or
-`bmad-code-review`. It does not run linters, type checkers, or test suites.
-It does not assign severity scores or produce pass/fail verdicts. It is a
-reading guide that helps a human apply their judgment where it matters most.
+`bmad-build` already ran, or [`bmad-code-review`](review-a-change.md).
+It does not run linters, type checkers, or test suites. It does not
+assign severity scores or produce pass/fail verdicts. It is a reading
+guide that helps a human apply their judgment where it matters most.

--- a/docs/how-to/customize-bmad.md
+++ b/docs/how-to/customize-bmad.md
@@ -260,6 +260,23 @@ persistent_facts = [
 on_complete = "Summarize the brief in three bullets and offer to email it via the gws-gmail-send skill."
 ```
 
+`bmad-code-review` already ships `[[workflow.review_layers]]`. A sparse override looks like this; merge follows the array-of-tables rule above. See [Review a Change](../build/review-a-change.md) for empty `instruction`, `when`, and a new `id`.
+
+```toml
+# _bmad/custom/bmad-code-review.toml
+[[workflow.review_layers]]
+id = "blind-hunter"
+instruction = ""
+[[workflow.review_layers]]
+id = "security-bot"
+name = "Security bot"
+instruction = """
+Run the team reviewer via bash on {diff_file} and return its findings as a Markdown list.
+"""
+```
+
+That does not delete the default row; the skill skips a layer whose `instruction` is empty.
+
 The same field conventions cross the agent/workflow boundary: `activation_steps_prepend`/`activation_steps_append`, `persistent_facts` (with `file:` refs), and menu-style `[[…]]` tables with `code`/`id` for keyed merge. The resolver applies the same four structural rules regardless of the top-level key. SKILL.md references follow the namespace: `{workflow.activation_steps_prepend}`, `{workflow.persistent_facts}`, `{workflow.on_complete}`. Any additional fields a workflow exposes (output paths, toggles, review settings, stage flags) follow the same shape-based merge rules. Read the workflow's `customize.toml` to see what's customizable.
 
 ### Activation Order
@@ -279,7 +296,7 @@ After step 6 the workflow body begins. Use `activation_steps_prepend` when you n
 
 Customization is rolling out incrementally. The fields documented above — `activation_steps_prepend`, `activation_steps_append`, `persistent_facts`, `on_complete` — are the **baseline surface** that every customizable workflow exposes, and they will remain stable across versions. They give you broad-stroke control today: inject pre/post steps, pin foundational context, trigger follow-up actions.
 
-Over time, individual workflows will expose **more targeted customization points** tailored to what that workflow actually does — things like step-specific toggles, stage flags, output template paths, or review gates. When those arrive, they stack on top of the baseline fields rather than replacing them, so customizations you author today keep working.
+Over time, individual workflows will expose **more targeted customization points** tailored to what that workflow actually does — things like step-specific toggles, stage flags, or output template paths. Some already ship: `bmad-code-review` exposes `[[workflow.review_layers]]` today. When more arrive, they stack on top of the baseline fields rather than replacing them, so customizations you author today keep working.
 
 If you need a fine-grained knob that isn't exposed yet, either use `activation_steps_*` and `persistent_facts` to steer behavior, or open an issue describing the specific customization point you want — those requests are what drive which targeted fields get added next.
 

--- a/docs/reference/commands.md
+++ b/docs/reference/commands.md
@@ -98,7 +98,7 @@ Workflow skills run a structured, multi-step process without loading an agent pe
 | `bmad-architecture` | Design system architecture |
 | `bmad-create-epics-and-stories` | Create epics and stories |
 | `bmad-build` | Implement direct intent, an issue, a feature, a fix, or a planned story. See [Build a Change](../build/build-a-change.md) |
-| `bmad-code-review` | Run a code review |
+| `bmad-code-review` | Run a code review. See [Review a Change](../build/review-a-change.md) |
 | `bmad-build-auto` | Automate one unattended iteration of the Build implementation model |
 
 See [Workflow Map](./workflow-map.md) for the complete workflow reference organized by phase.

--- a/docs/reference/workflow-map.md
+++ b/docs/reference/workflow-map.md
@@ -78,6 +78,7 @@ Implementation happens in session-sized units. `bmad-build` handles a unit
 attentively; `bmad-build-auto` handles one unit unattended. Larger planning
 paths create and preserve the context those units need. See
 [Build a Change](../build/build-a-change.md) for the attended path,
+[Review a Change](../build/review-a-change.md) for a standalone review,
 [Walk Through a Change](../build/walk-through-a-change.md) to walk a finished
 change, and [Test Completed Work](../build/test-completed-work.md) to choose a
 testing path.
@@ -86,7 +87,7 @@ testing path.
 | --------------------- | ------------------------------------------------------------------------------ | ------------------------------------------------ |
 | `bmad-build`          | Implement and review one direct intent or planned story with human checkpoints | Implementation record + code                     |
 | `bmad-build-auto`     | Implement and review one unit unattended for a caller or orchestrator          | Implementation record + code + terminal status   |
-| `bmad-code-review`    | Ad hoc review of any code change                                               | Findings + applied patches                       |
+| `bmad-code-review`    | Ad hoc review of any code change. See [Review a Change](../build/review-a-change.md) | Findings + applied patches                       |
 | `bmad-correct-course` | Handle significant mid-sprint changes                                          | Updated plan or re-routing                       |
 | `bmad-retrospective`  | Evidence-based review of a completed epic against its acceptance criteria      | Retro document, action items, acceptance verdict |
 

--- a/website/astro.config.mjs
+++ b/website/astro.config.mjs
@@ -28,6 +28,11 @@ export default defineConfig({
     '/fr/explanation/checkpoint-preview': `${basePath}fr/build/walk-through-a-change/`,
     '/vi-vn/explanation/checkpoint-preview': `${basePath}vi-vn/build/walk-through-a-change/`,
     '/zh-cn/explanation/checkpoint-preview': `${basePath}zh-cn/build/walk-through-a-change/`,
+    '/explanation/adversarial-review': `${basePath}build/review-a-change/`,
+    '/fr/explanation/adversarial-review': `${basePath}build/review-a-change/`,
+    '/cs/explanation/adversarial-review': `${basePath}build/review-a-change/`,
+    '/vi-vn/explanation/adversarial-review': `${basePath}build/review-a-change/`,
+    '/zh-cn/explanation/adversarial-review': `${basePath}build/review-a-change/`,
     '/reference/testing': `${basePath}build/test-completed-work/`,
     '/fr/how-to/non-interactive-installation': `${basePath}fr/how-to/install-bmad/`,
     '/cs/how-to/non-interactive-installation': `${basePath}cs/how-to/install-bmad/`,
@@ -126,6 +131,16 @@ export default defineConfig({
                 'cs-CZ': 'Sestavit změnu',
               },
               slug: 'build/build-a-change',
+            },
+            {
+              label: 'Review a Change',
+              translations: {
+                'vi-VN': 'Rà soát một thay đổi',
+                'zh-CN': '审查一个变更',
+                'fr-FR': 'Examiner un changement',
+                'cs-CZ': 'Zkontrolovat změnu',
+              },
+              slug: 'build/review-a-change',
             },
             {
               label: 'Walk Through a Change',


### PR DESCRIPTION
## What

Add **Review a Change**, the Build-chapter how-to for standalone `bmad-code-review`.

Build a Change keeps the review that `bmad-build` runs inside its own implementation. This page owns someone else's change, a PR, an extra pass, a review bot — plus when to re-run Build on a done spec, why review is expensive on purpose, and `[[workflow.review_layers]]` customization.

## Why

Agentic review was mentioned on Build a Change, the Walk Through and Test disclaimers, the commands and workflow-map catalog rows, Party Mode's Code Review Crew, and the deleted `adversarial-review` explanation — and owned by none of them.

## How

- New English page at `/build/review-a-change/`, listed in the Build sidebar after Build a Change and before Walk Through a Change
- Redirect `/explanation/adversarial-review/` (and the four locale prefixes) to the new page; leave `/build/review-a-completed-change/` on Walk Through
- Link from Build a Change §5, the Walk Through and Test disclaimers, and the two catalog rows
- Add a sparse `review_layers` example to Customize BMad; merge mechanics stay on that page
- Document extra `bmad-build` passes on a `status: done` spec, layer overrides (empty `instruction` disables, `when` gates, a new `id` appends, `instruction` may be bash), and why platform `/code-review` is a different product

Localized markdown is unchanged. Party Mode's Code Review Crew cross-link is recorded for Slice 4.

## Testing

`HUSKY=0 npm ci && npm run quality` passed on `440c6211` in `docs-review-a-change`.

Inspected:

- Built `/build/review-a-change/` and Build sidebar order: Build a Change, Review a Change, Walk Through a Change, Test Completed Work
- Generated redirects from `/explanation/adversarial-review/` and the locale prefixes to `/build/review-a-change/`
- `git diff -- docs/fr docs/cs docs/zh-cn docs/vi-vn` empty
