### PR TITLE
fix: restore v6 shim activation and forwarding

### DIFF
--- a/docs/explanation/sprint-planning.md
+++ b/docs/explanation/sprint-planning.md
@@ -39,6 +39,6 @@ The LLM keeps the parts that need judgment: deciding which files are epics, weig
 
 ## Migration notes
 
-- `bmad-check-implementation-readiness` has been removed; the `IR` agent menu trigger forwards here.
+- `bmad-check-implementation-readiness` is now a deprecation shim that forwards here with readiness-only intent. Migrate any `_bmad/custom/bmad-check-implementation-readiness.toml` overrides to `_bmad/custom/bmad-sprint-planning.toml`. The `IR` agent menu trigger also forwards here.
 - `bmad-sprint-status` is now a deprecation shim that forwards here with status-view intent. Migrate any `_bmad/custom/bmad-sprint-status.toml` overrides to `_bmad/custom/bmad-sprint-planning.toml`.
 - The output format of `sprint-status.yaml` is unchanged — build's sprint sync and the retrospective tooling read and write it exactly as before.

--- a/src/bmm-skills/plan/bmad-sprint-planning/SKILL.md
+++ b/src/bmm-skills/plan/bmad-sprint-planning/SKILL.md
@@ -9,6 +9,8 @@ You are a senior developer about to commit to this plan. Two moves, in order: fi
 
 ## On Activation
 
+**Forwarded activation:** if a caller invoked you with a stated intent and pre-resolved customization fields (for example, the `bmad-check-implementation-readiness` or `bmad-sprint-status` shim), honor them verbatim — skip your own intent inference, use the supplied values for those named fields, and resolve only the remaining fields from your own `customize.toml`.
+
 1. Resolve customization: `uv run {project-root}/_bmad/scripts/resolve_customization.py --skill {skill-root} --key workflow`. On failure, read `{skill-root}/customize.toml` directly and use defaults.
 2. Execute each entry in `{workflow.activation_steps_prepend}` in order.
 3. Treat every entry in `{workflow.persistent_facts}` as foundational context for the rest of the run. Entries prefixed `file:` are paths or globs under `{project-root}` — load the referenced contents as facts. All other entries are facts verbatim.

--- a/src/bmm-skills/v6-shims/README.md
+++ b/src/bmm-skills/v6-shims/README.md
@@ -4,21 +4,22 @@ Skills in this folder are deprecated skills kept for backward compatibility with
 Some retain their full workflow, while others forward to the skill that replaced them, passing a
 stated intent and pre-resolved customization fields so the target skips its own intent inference.
 
-| Shim                       | Forwards to                          |
-| -------------------------- | ------------------------------------ |
-| `bmad-quick-dev`           | `bmad-build`                         |
-| `bmad-dev-auto`            | `bmad-build-auto`                    |
-| `bmad-create-story`        | Retained in full                     |
-| `bmad-dev-story`           | Retained in full                     |
-| `bmad-create-prd`          | `bmad-prd` (create intent)           |
-| `bmad-edit-prd`            | `bmad-prd` (update intent)           |
-| `bmad-validate-prd`        | `bmad-prd` (validate intent)         |
-| `bmad-create-architecture` | `bmad-architecture` (create intent)  |
-| `bmad-market-research`     | `bmad-deep-recon` (market type)      |
-| `bmad-domain-research`     | `bmad-deep-recon` (domain type)      |
-| `bmad-technical-research`  | `bmad-deep-recon` (technical type)   |
-| `bmad-sprint-status`       | `bmad-sprint-planning` (status view) |
-| `bmad-checkpoint-preview`  | `bmad-walkthrough`                   |
+| Shim                                  | Forwards to                          |
+| ------------------------------------- | ------------------------------------ |
+| `bmad-quick-dev`                      | `bmad-build`                         |
+| `bmad-dev-auto`                       | `bmad-build-auto`                    |
+| `bmad-create-story`                   | Retained in full                     |
+| `bmad-dev-story`                      | Retained in full                     |
+| `bmad-create-prd`                     | `bmad-prd` (create intent)           |
+| `bmad-edit-prd`                       | `bmad-prd` (update intent)           |
+| `bmad-validate-prd`                   | `bmad-prd` (validate intent)         |
+| `bmad-create-architecture`            | `bmad-architecture` (create intent)  |
+| `bmad-market-research`                | `bmad-deep-recon` (market type)      |
+| `bmad-domain-research`                | `bmad-deep-recon` (domain type)      |
+| `bmad-technical-research`             | `bmad-deep-recon` (technical type)   |
+| `bmad-check-implementation-readiness` | `bmad-sprint-planning` (readiness)   |
+| `bmad-sprint-status`                  | `bmad-sprint-planning` (status view) |
+| `bmad-checkpoint-preview`             | `bmad-walkthrough`                   |
 
 Enterprise users may still depend on these IDs, so they ship by default. Removal rides the
 v7 cut — never a 6.x minor.

--- a/src/bmm-skills/v6-shims/bmad-check-implementation-readiness/SKILL.md
+++ b/src/bmm-skills/v6-shims/bmad-check-implementation-readiness/SKILL.md
@@ -1,0 +1,27 @@
+---
+name: bmad-check-implementation-readiness
+description: 'Deprecated — forwards to bmad-sprint-planning (readiness check)'
+metadata:
+  lifecycle: shim
+---
+
+# DEPRECATED — forwards to bmad-sprint-planning (readiness check)
+
+This skill was consolidated into `bmad-sprint-planning`, which now checks implementation readiness before generating sprint tracking. It is retained as a thin compatibility shim so existing invocations by name and `_bmad/custom/bmad-check-implementation-readiness.toml` override files keep working. New work should invoke `bmad-sprint-planning` directly with a request to check implementation readiness.
+
+## On Activation
+
+1. Resolve customization: `uv run {project-root}/_bmad/scripts/resolve_customization.py --skill {skill-root} --key workflow`. This picks up any `{project-root}/_bmad/custom/bmad-check-implementation-readiness.toml` and `bmad-check-implementation-readiness.user.toml` overrides for the legacy fields (`activation_steps_prepend`, `activation_steps_append`, `persistent_facts`, `on_complete`).
+
+2. Load `{project-root}/_bmad/bmm/config.yaml` (and `config.user.yaml` if present) to resolve `{user_name}` and `{communication_language}`.
+
+3. Emit a deprecation notice to the user in `{communication_language}`:
+
+   > Notice: `bmad-check-implementation-readiness` is deprecated and will be removed in v7. It now forwards to `bmad-sprint-planning`, whose readiness mode covers everything this skill did. To silence this notice, invoke `bmad-sprint-planning` directly next time (e.g. "check implementation readiness") and migrate any `_bmad/custom/bmad-check-implementation-readiness.toml` overrides to `_bmad/custom/bmad-sprint-planning.toml`.
+
+4. Invoke `bmad-sprint-planning` with the following context. Pass these as the activating context so it honors them instead of resolving its own customization from scratch:
+   - **Intent:** `readiness` — run the readiness gate only, report its result, and stop without generating sprint tracking.
+   - **Pre-resolved legacy customization** — use these in place of resolving from `bmad-sprint-planning`'s own `customize.toml` for the four legacy fields: `activation_steps_prepend`, `activation_steps_append`, `persistent_facts`, and `on_complete` = the resolved values from step 1.
+   - **Original user input:** forward whatever the user said when invoking this skill verbatim.
+
+   `bmad-sprint-planning` takes the workflow from here. Do not execute any further steps in this shim.

--- a/src/bmm-skills/v6-shims/bmad-check-implementation-readiness/customize.toml
+++ b/src/bmm-skills/v6-shims/bmad-check-implementation-readiness/customize.toml
@@ -1,0 +1,11 @@
+# DO NOT EDIT -- overwritten on every update.
+#
+# Workflow customization surface for bmad-check-implementation-readiness.
+# Mirrors the agent customization shape under the [workflow] namespace.
+
+[workflow]
+
+activation_steps_prepend = []
+activation_steps_append = []
+persistent_facts = []
+on_complete = ""

--- a/src/bmm-skills/v6-shims/bmad-domain-research/customize.toml
+++ b/src/bmm-skills/v6-shims/bmad-domain-research/customize.toml
@@ -1,0 +1,11 @@
+# DO NOT EDIT -- overwritten on every update.
+#
+# Workflow customization surface for bmad-domain-research. Mirrors the
+# agent customization shape under the [workflow] namespace.
+
+[workflow]
+
+activation_steps_prepend = []
+activation_steps_append = []
+persistent_facts = []
+on_complete = ""

--- a/src/bmm-skills/v6-shims/bmad-market-research/customize.toml
+++ b/src/bmm-skills/v6-shims/bmad-market-research/customize.toml
@@ -1,0 +1,11 @@
+# DO NOT EDIT -- overwritten on every update.
+#
+# Workflow customization surface for bmad-market-research. Mirrors the
+# agent customization shape under the [workflow] namespace.
+
+[workflow]
+
+activation_steps_prepend = []
+activation_steps_append = []
+persistent_facts = []
+on_complete = ""

--- a/src/bmm-skills/v6-shims/bmad-technical-research/customize.toml
+++ b/src/bmm-skills/v6-shims/bmad-technical-research/customize.toml
@@ -1,0 +1,11 @@
+# DO NOT EDIT -- overwritten on every update.
+#
+# Workflow customization surface for bmad-technical-research. Mirrors the
+# agent customization shape under the [workflow] namespace.
+
+[workflow]
+
+activation_steps_prepend = []
+activation_steps_append = []
+persistent_facts = []
+on_complete = ""

--- a/test/test-shim-policy.js
+++ b/test/test-shim-policy.js
@@ -30,6 +30,45 @@ async function run() {
   const root = await fs.mkdtemp(path.join(os.tmpdir(), 'bmad-shim-policy-'));
 
   try {
+    const bmmSkillsSource = path.resolve(__dirname, '../src/bmm-skills');
+    const legacyWorkflowDefaults = [
+      'activation_steps_prepend = []',
+      'activation_steps_append = []',
+      'persistent_facts = []',
+      'on_complete = ""',
+    ];
+    for (const shimId of [
+      'bmad-domain-research',
+      'bmad-market-research',
+      'bmad-technical-research',
+      'bmad-check-implementation-readiness',
+    ]) {
+      const customization = await fs.readFile(path.join(bmmSkillsSource, 'v6-shims', shimId, 'customize.toml'), 'utf8');
+      assert.match(customization, /^\[workflow\]$/m, `${shimId} exposes workflow customization`);
+      for (const defaultValue of legacyWorkflowDefaults) {
+        assert.match(customization, new RegExp(`^${defaultValue.replace(/[.*+?^${}()|[\]\\]/g, '\\$&')}$`, 'm'));
+      }
+    }
+
+    const sourceShims = await discoverShims(bmmSkillsSource);
+    assert(
+      sourceShims.some((shim) => shim.id === 'bmad-check-implementation-readiness'),
+      'the consolidated implementation-readiness ID remains discoverable as a lifecycle shim',
+    );
+    const readinessShim = await fs.readFile(
+      path.join(bmmSkillsSource, 'v6-shims', 'bmad-check-implementation-readiness', 'SKILL.md'),
+      'utf8',
+    );
+    assert.match(readinessShim, /\*\*Intent:\*\* `readiness`/, 'the readiness shim forwards readiness-only intent');
+    assert.match(readinessShim, /\*\*Original user input:\*\*/, 'the readiness shim forwards the original request');
+
+    const sprintPlanning = await fs.readFile(path.join(bmmSkillsSource, 'plan', 'bmad-sprint-planning', 'SKILL.md'), 'utf8');
+    assert.match(
+      sprintPlanning,
+      /\*\*Forwarded activation:\*\*[\s\S]*honor them verbatim[\s\S]*resolve only the remaining fields/,
+      'sprint planning honors forwarded intent and supplied customization fields',
+    );
+
     const source = path.join(root, 'source');
     await writeSkill(path.join(source, 'plan', 'active-skill'), 'active-skill');
     await writeSkill(path.join(source, 'plan', 'legacy-name'), 'legacy-name', 'shim');


### PR DESCRIPTION
## What

Add the standard minimal `[workflow]` customization surface to each research shim so the existing resolver command succeeds and continues to merge team and user override files. Add a lifecycle-marked `bmad-check-implementation-readiness` shim with its own customization surface, deprecation notice, original-input forwarding, and an explicit readiness-only intent for `bmad-sprint-planning`. Teach `bmad-sprint-planning` to accept a forwarded intent and honor supplied customization fields verbatim while resolving only unspecified fields, matching the receiving contracts already used by `bmad-prd`, `bmad-deep-recon`, `bmad-architecture`, and `bmad-review`.

The three legacy research shims invoke the required customization resolver without shipping the base `customize.toml`, so activation fails before they can forward to `bmad-deep-recon`. The consolidated `bmad-check-implementation-readiness` ID has no compatibility shim at all even though the v6 shim policy promises legacy IDs until v7. The existing `bmad-sprint-status` shim supplies its intent and resolved legacy fields, but `bmad-sprint-planning` unconditionally resolves and infers again instead of accepting that context. Together these defects break invocation compatibility and silently discard legacy overrides in version 6.11.0.

Fixes #2720

## Why

Add the standard minimal `[workflow]` customization surface to each research shim so the existing resolver command succeeds and continues to merge team and user override files. Add a lifecycle-marked `bmad-check-implementation-readiness` shim with its own customization surface, deprecation notice, original-input forwarding, and an explicit readiness-only intent for `bmad-sprint-planning`. Teach `bmad-sprint-planning` to accept a forwarded intent and honor supplied customization fields verbatim while resolving only unspecified fields, matching the receiving contracts already used by `bmad-prd`, `bmad-deep-recon`, `bmad-architecture`, and `bmad-review`.

## How

-

## Testing

Resolve the `workflow` customization for each of `bmad-domain-research`, `bmad-market-research`, and `bmad-technical-research`; each activation receives the four default legacy fields instead of exiting for a missing required TOML file.
Discover BMM shims from the real source tree with shims enabled; `bmad-check-implementation-readiness` appears as a lifecycle shim, carries its default customization file, and forwards the original request with readiness-only intent.
Invoke `bmad-sprint-planning` through the sprint-status shim with non-default legacy fields; the target uses the forwarded status intent and supplied fields without rerunning intent inference or replacing those values.
Invoke `bmad-sprint-planning` directly with no forwarded context; it retains its existing customization resolution, intent detection, readiness gate, and tracking behavior.
Validate the changed and new skill directories plus repository references; frontmatter, shim inventory, documentation, and referenced paths remain consistent.

AI was used for assistance.
