### PR TITLE
docs: move Finish an Epic to the Build chapter

### DIFF
--- a/docs/build/finish-an-epic.md
+++ b/docs/build/finish-an-epic.md
@@ -2,7 +2,7 @@
 title: 'Finish an Epic'
 description: Close out a finished epic by reading the evidence it left — the diff, the commits, the specs — and judging the result instead of trusting memory.
 sidebar:
-  order: 8
+  order: 5
 ---
 
 Run `bmad-retrospective` when an epic is done. It reads what the epic
@@ -26,7 +26,7 @@ is fresh and the session logs have not been cleared.
 - **Aggregate defects**: the architecture that drifted, the helper written
   twice, the file that grew a little in every session.
 - **Diff-scope review**: it hands the epic's diff to
-  [`bmad-review`](../build/review-a-change.md), weighting the seams between
+  [`bmad-review`](./review-a-change.md), weighting the seams between
   stories where no single session saw both sides.
 - **Spec reconciliation**: where the built code diverged from what the epic
   and PRD described.
@@ -50,7 +50,7 @@ show. It won't invent a root cause or a pattern the code doesn't back up.
 
 Retrospective accepts either sprint tracking from the project path or the
 spec folder from the epic path in
-[Choose a Planning Path](./choose-a-planning-path.md).
+[Choose a Planning Path](../plan/choose-a-planning-path.md).
 
 | Epic input          | Inventory and completion state                                     | Retrospective output                                                               |
 | ------------------- | ------------------------------------------------------------------ | ---------------------------------------------------------------------------------- |

--- a/docs/plan/break-work-into-stories-and-track-it.md
+++ b/docs/plan/break-work-into-stories-and-track-it.md
@@ -19,7 +19,7 @@ Story Breakdown; a project with a PRD gets epics and stories, then
 
 For a spec-backed epic, `stories.yaml` is the whole tracking file. Build
 creates each story's implementation record under the spec folder, and
-[Finish an Epic](./finish-an-epic.md) reads `stories.yaml` as the inventory.
+[Finish an Epic](../build/finish-an-epic.md) reads `stories.yaml` as the inventory.
 No sprint-status file is involved.
 
 For a project, `bmad-create-epics-and-stories` works with you as a product
@@ -88,4 +88,4 @@ Old names still work: `bmad-check-implementation-readiness` and
 Implement each story with [`bmad-build`](../build/build-a-change.md), or with
 [`bmad-build-auto`](../reference/build-auto.md) once the decisions are stable.
 When the epic's stories are done, close it with
-[Finish an Epic](./finish-an-epic.md).
+[Finish an Epic](../build/finish-an-epic.md).

--- a/docs/plan/choose-a-planning-path.md
+++ b/docs/plan/choose-a-planning-path.md
@@ -114,7 +114,7 @@ record under the spec folder and keeps it linked to the parent spec.
 Verify the stories together, not only one at a time. Then run
 `bmad-retrospective` with the spec folder. Retrospective reads `stories.yaml`
 as the epic inventory and judges the combined result against the parent spec.
-See [Finish an Epic](./finish-an-epic.md).
+See [Finish an Epic](../build/finish-an-epic.md).
 
 ### 2. Start Project-Sized Work
 
@@ -126,7 +126,7 @@ Prepare only the planning the project actually needs from the table above
 owns which document and where sign-off happens). Then run `bmad-spec` per epic,
 track the stories with
 [Break Work into Stories and Track It](./break-work-into-stories-and-track-it.md),
-and close each epic with [Finish an Epic](./finish-an-epic.md).
+and close each epic with [Finish an Epic](../build/finish-an-epic.md).
 
 These documents coordinate implementation. They do not replace Build. Each
 epic still becomes a sequence of one-session units. Independent epic streams

--- a/docs/reference/workflow-map.md
+++ b/docs/reference/workflow-map.md
@@ -74,7 +74,7 @@ Decide how to build it and break work into stories.
 | `bmad-create-epics-and-stories` | Break requirements into implementable work                                | Epic files with stories                                                                                           |
 | `bmad-sprint-planning`          | Readiness gate before implementation, then story tracking and status view | PASS/CONCERNS/FAIL + `sprint-status.yaml`                                                                         |
 
-For how the readiness gate, deterministic tracking, and status view work together, see [Break Work into Stories and Track It](../plan/break-work-into-stories-and-track-it.md). For closing an epic, see [Finish an Epic](../plan/finish-an-epic.md).
+For how the readiness gate, deterministic tracking, and status view work together, see [Break Work into Stories and Track It](../plan/break-work-into-stories-and-track-it.md). For closing an epic, see [Finish an Epic](../build/finish-an-epic.md).
 
 ## Phase 4: Implementation
 
@@ -87,13 +87,13 @@ paths create and preserve the context those units need. See
 change, and [Test Completed Work](../build/test-completed-work.md) to choose a
 testing path.
 
-| Workflow              | Purpose                                                                        | Produces                                         |
-| --------------------- | ------------------------------------------------------------------------------ | ------------------------------------------------ |
-| `bmad-build`          | Implement and review one direct intent or planned story with human checkpoints | Implementation record + code                     |
-| `bmad-build-auto`     | Implement and review one unit unattended for a caller or orchestrator          | Implementation record + code + terminal status   |
+| Workflow              | Purpose                                                                              | Produces                                         |
+| --------------------- | ------------------------------------------------------------------------------------ | ------------------------------------------------ |
+| `bmad-build`          | Implement and review one direct intent or planned story with human checkpoints       | Implementation record + code                     |
+| `bmad-build-auto`     | Implement and review one unit unattended for a caller or orchestrator                | Implementation record + code + terminal status   |
 | `bmad-code-review`    | Ad hoc review of any code change. See [Review a Change](../build/review-a-change.md) | Findings + applied patches                       |
-| `bmad-correct-course` | Handle significant mid-sprint changes                                          | Updated plan or re-routing                       |
-| `bmad-retrospective`  | Evidence-based review of a completed epic against its acceptance criteria      | Retro document, action items, acceptance verdict |
+| `bmad-correct-course` | Handle significant mid-sprint changes                                                | Updated plan or re-routing                       |
+| `bmad-retrospective`  | Evidence-based review of a completed epic against its acceptance criteria            | Retro document, action items, acceptance verdict |
 
 ### Direct and Planned Entry
 

--- a/website/astro.config.mjs
+++ b/website/astro.config.mjs
@@ -43,7 +43,7 @@ export default defineConfig({
     '/explanation/why-solutioning-matters': `${basePath}plan/design-ux-and-architecture/`,
     '/explanation/preventing-agent-conflicts': `${basePath}plan/design-ux-and-architecture/`,
     '/explanation/sprint-planning': `${basePath}plan/break-work-into-stories-and-track-it/`,
-    '/explanation/retrospective': `${basePath}plan/finish-an-epic/`,
+    '/explanation/retrospective': `${basePath}build/finish-an-epic/`,
     '/fr/how-to/non-interactive-installation': `${basePath}fr/how-to/install-bmad/`,
     '/cs/how-to/non-interactive-installation': `${basePath}cs/how-to/install-bmad/`,
     '/ko-kr/how-to/non-interactive-installation': `${basePath}ko-kr/how-to/install-bmad/`,
@@ -183,6 +183,16 @@ export default defineConfig({
               },
               slug: 'build/test-completed-work',
             },
+            {
+              label: 'Finish an Epic',
+              translations: {
+                'vi-VN': 'Hoàn tất một epic',
+                'zh-CN': '完成一个 Epic',
+                'fr-FR': 'Terminer un epic',
+                'cs-CZ': 'Dokončit epic',
+              },
+              slug: 'build/finish-an-epic',
+            },
           ],
         },
         {
@@ -264,16 +274,6 @@ export default defineConfig({
                 'cs-CZ': 'Rozdělit práci na story a sledovat ji',
               },
               slug: 'plan/break-work-into-stories-and-track-it',
-            },
-            {
-              label: 'Finish an Epic',
-              translations: {
-                'vi-VN': 'Hoàn tất một epic',
-                'zh-CN': '完成一个 Epic',
-                'fr-FR': 'Terminer un epic',
-                'cs-CZ': 'Dokončit epic',
-              },
-              slug: 'plan/finish-an-epic',
             },
           ],
         },


### PR DESCRIPTION
Moves Finish an Epic from the Plan chapter to the Build chapter.

The retrospective reads what the coding sessions produced (the diff, the commits, the story records), hands the code to review, and issues a verdict on built work. That is Build-side work on built code, so the page sits beside Build a Change, Review a Change, and Test Completed Work rather than at the end of Plan Larger Work.

- `docs/plan/finish-an-epic.md` → `docs/build/finish-an-epic.md`, sidebar order 5
- Sidebar entry moved from the Plan group to the Build group; Plan is now seven pages
- `/explanation/retrospective` redirect now targets `/build/finish-an-epic/`
- Inbound links retargeted (chooser, stories page, workflow map)

Validation: `docs:validate-sidebar` 0 errors, `docs:validate-links` clean, `docs:build` clean with the redirect artifact verified, `npm run quality` passing.
