### PR TITLE
fix(validate-refs): flag single-separator Windows path leaks

### DIFF
--- a/tools/validate-file-refs.js
+++ b/tools/validate-file-refs.js
@@ -67,7 +67,7 @@ const STEP_META = /(?:thisStepFile|nextStepFile|continueStepFile|skipToStepFile|
 const LOAD_DIRECTIVE = /Load[:\s]+`(\.[^`]+)`/g;
 
 // Pattern: absolute path leaks
-const ABS_PATH_LEAK = /(?:\/Users\/|\/home\/|[A-Z]:\\\\)/;
+const ABS_PATH_LEAK = /(?:\/Users\/|\/home\/|\b[A-Za-z]:[\\/])/;
 
 // --- Output Escaping ---
 


### PR DESCRIPTION
## Problem

`ABS_PATH_LEAK` uses `[A-Z]:\\\\`, which in a regex literal is two backslashes, so it only matches the escaped `C:\\Users` form. A plain `C:\Users\...` or `C:/Users/...` is not flagged.

## Fix

Match a drive letter of either case followed by one separator. The `\b` keeps URL schemes like `https://` from matching the forward-slash branch.

`validate:refs --strict` still reports 0 leaks on the repo, so the wider pattern adds no false positives.

Supersedes #2488. Fixes #2487
