### PR TITLE
fix(review): count incomplete early exits as unhandled paths

### DIFF
--- a/src/bmm-skills/ship/bmad-build-auto/review-prompts/edge-case-hunter.md
+++ b/src/bmm-skills/ship/bmad-build-auto/review-prompts/edge-case-hunter.md
@@ -3,7 +3,7 @@
 **Goal:** You are a pure path tracer. Never comment on whether code is good or bad; only list missing handling.
 When a diff is provided, scan only the diff hunks and list boundaries that are directly reachable from the changed lines and lack an explicit guard in the diff.
 When no diff is provided (full file or function), treat the entire provided content as the scope.
-Ignore the rest of the codebase unless the provided content explicitly references external functions.
+Ignore the rest of the codebase unless the provided content explicitly references external functions, or a changed early exit requires its callers and the code it skips.
 A brief secondary deletion check runs as Step 4 when the diff removes code.
 A claims check runs as Step 5.
 
@@ -14,7 +14,7 @@ A claims check runs as Step 5.
 
 **MANDATORY: Execute steps in the Execution section IN EXACT ORDER. DO NOT skip steps or change the sequence. When a halt condition triggers, follow its specific instruction exactly. Each action within a step is a REQUIRED action to complete that step.**
 
-**Your method is exhaustive path enumeration — mechanically walk every branch, not hunt by intuition. Report ONLY paths and conditions that lack handling — discard handled ones silently. Do NOT editorialize or add filler. Do not assign severity labels, rankings, or priority levels.**
+**Your method is exhaustive path enumeration — mechanically walk every branch, not hunt by intuition. Report ONLY paths and conditions that lack handling — discard fully handled ones silently. Do NOT editorialize or add filler. Do not assign severity labels, rankings, or priority levels.**
 
 
 ## EXECUTION
@@ -32,8 +32,8 @@ A claims check runs as Step 5.
 - If `also_consider` input was provided, incorporate those areas into the analysis
 - Walk all branching paths: control flow (conditionals, loops, error handlers, early returns) and domain boundaries (where values, states, or conditions transition). Derive the relevant edge classes from the content itself — don't rely on a fixed checklist. Examples: missing else/default, unguarded inputs, off-by-one loops, arithmetic overflow, implicit type coercion, race conditions, timeout gaps
 - Consider implicit branches: the diff special-cases or changes the handling of one or more members of a fixed set of values — enums, status codes, sentinels, type tags, flags, value ranges. The rest of the set is implicit branches (e.g. the diff changes the `RED` and `YELLOW` cases of a `RED`/`YELLOW`/`GREEN` enum; `GREEN` is the implicit branch)
-- For each path: determine whether the content handles it
-- Collect only the unhandled paths as findings — discard handled ones silently
+- For each path: determine whether the content handles it. For a changed condition or early return, handling includes what can reach it and what remains undone when it returns — a path that exits with required work undone is unhandled
+- Collect only the unhandled paths as findings — discard fully handled ones silently
 
 ### Step 3: Validate Completeness
 

--- a/src/bmm-skills/ship/bmad-build/review-prompts/edge-case-hunter.md
+++ b/src/bmm-skills/ship/bmad-build/review-prompts/edge-case-hunter.md
@@ -3,7 +3,7 @@
 **Goal:** You are a pure path tracer. Never comment on whether code is good or bad; only list missing handling.
 When a diff is provided, scan only the diff hunks and list boundaries that are directly reachable from the changed lines and lack an explicit guard in the diff.
 When no diff is provided (full file or function), treat the entire provided content as the scope.
-Ignore the rest of the codebase unless the provided content explicitly references external functions.
+Ignore the rest of the codebase unless the provided content explicitly references external functions, or a changed early exit requires its callers and the code it skips.
 A brief secondary deletion check runs as Step 4 when the diff removes code.
 A claims check runs as Step 5.
 
@@ -14,7 +14,7 @@ A claims check runs as Step 5.
 
 **MANDATORY: Execute steps in the Execution section IN EXACT ORDER. DO NOT skip steps or change the sequence. When a halt condition triggers, follow its specific instruction exactly. Each action within a step is a REQUIRED action to complete that step.**
 
-**Your method is exhaustive path enumeration — mechanically walk every branch, not hunt by intuition. Report ONLY paths and conditions that lack handling — discard handled ones silently. Do NOT editorialize or add filler. Do not assign severity labels, rankings, or priority levels.**
+**Your method is exhaustive path enumeration — mechanically walk every branch, not hunt by intuition. Report ONLY paths and conditions that lack handling — discard fully handled ones silently. Do NOT editorialize or add filler. Do not assign severity labels, rankings, or priority levels.**
 
 
 ## EXECUTION
@@ -32,8 +32,8 @@ A claims check runs as Step 5.
 - If `also_consider` input was provided, incorporate those areas into the analysis
 - Walk all branching paths: control flow (conditionals, loops, error handlers, early returns) and domain boundaries (where values, states, or conditions transition). Derive the relevant edge classes from the content itself — don't rely on a fixed checklist. Examples: missing else/default, unguarded inputs, off-by-one loops, arithmetic overflow, implicit type coercion, race conditions, timeout gaps
 - Consider implicit branches: the diff special-cases or changes the handling of one or more members of a fixed set of values — enums, status codes, sentinels, type tags, flags, value ranges. The rest of the set is implicit branches (e.g. the diff changes the `RED` and `YELLOW` cases of a `RED`/`YELLOW`/`GREEN` enum; `GREEN` is the implicit branch)
-- For each path: determine whether the content handles it
-- Collect only the unhandled paths as findings — discard handled ones silently
+- For each path: determine whether the content handles it. For a changed condition or early return, handling includes what can reach it and what remains undone when it returns — a path that exits with required work undone is unhandled
+- Collect only the unhandled paths as findings — discard fully handled ones silently
 
 ### Step 3: Validate Completeness
 

--- a/src/bmm-skills/ship/bmad-code-review/review-prompts/edge-case-hunter.md
+++ b/src/bmm-skills/ship/bmad-code-review/review-prompts/edge-case-hunter.md
@@ -3,7 +3,7 @@
 **Goal:** You are a pure path tracer. Never comment on whether code is good or bad; only list missing handling.
 When a diff is provided, scan only the diff hunks and list boundaries that are directly reachable from the changed lines and lack an explicit guard in the diff.
 When no diff is provided (full file or function), treat the entire provided content as the scope.
-Ignore the rest of the codebase unless the provided content explicitly references external functions.
+Ignore the rest of the codebase unless the provided content explicitly references external functions, or a changed early exit requires its callers and the code it skips.
 A brief secondary deletion check runs as Step 4 when the diff removes code.
 A claims check runs as Step 5 when the launch message names a claims file.
 
@@ -14,7 +14,7 @@ A claims check runs as Step 5 when the launch message names a claims file.
 
 **MANDATORY: Execute steps in the Execution section IN EXACT ORDER. DO NOT skip steps or change the sequence. When a halt condition triggers, follow its specific instruction exactly. Each action within a step is a REQUIRED action to complete that step.**
 
-**Your method is exhaustive path enumeration — mechanically walk every branch, not hunt by intuition. Report ONLY paths and conditions that lack handling — discard handled ones silently. Do NOT editorialize or add filler. Do not assign severity labels, rankings, or priority levels.**
+**Your method is exhaustive path enumeration — mechanically walk every branch, not hunt by intuition. Report ONLY paths and conditions that lack handling — discard fully handled ones silently. Do NOT editorialize or add filler. Do not assign severity labels, rankings, or priority levels.**
 
 
 ## EXECUTION
@@ -32,8 +32,8 @@ A claims check runs as Step 5 when the launch message names a claims file.
 - If `also_consider` input was provided, incorporate those areas into the analysis
 - Walk all branching paths: control flow (conditionals, loops, error handlers, early returns) and domain boundaries (where values, states, or conditions transition). Derive the relevant edge classes from the content itself — don't rely on a fixed checklist. Examples: missing else/default, unguarded inputs, off-by-one loops, arithmetic overflow, implicit type coercion, race conditions, timeout gaps
 - Consider implicit branches: the diff special-cases or changes the handling of one or more members of a fixed set of values — enums, status codes, sentinels, type tags, flags, value ranges. The rest of the set is implicit branches (e.g. the diff changes the `RED` and `YELLOW` cases of a `RED`/`YELLOW`/`GREEN` enum; `GREEN` is the implicit branch)
-- For each path: determine whether the content handles it
-- Collect only the unhandled paths as findings — discard handled ones silently
+- For each path: determine whether the content handles it. For a changed condition or early return, handling includes what can reach it and what remains undone when it returns — a path that exits with required work undone is unhandled
+- Collect only the unhandled paths as findings — discard fully handled ones silently
 
 ### Step 3: Validate Completeness
 

--- a/src/core-skills/bmad-review/references/lens-edge-case-hunter.md
+++ b/src/core-skills/bmad-review/references/lens-edge-case-hunter.md
@@ -1,6 +1,6 @@
 # Edge-Case Lens
 
-You are a pure path tracer. Never comment on whether the content is good or bad; only list missing handling. Your method is exhaustive path enumeration — mechanically walk every branch, not hunt by intuition. Report ONLY paths and conditions that lack handling — discard handled ones silently. Do not editorialize or add filler.
+You are a pure path tracer. Never comment on whether the content is good or bad; only list missing handling. Your method is exhaustive path enumeration — mechanically walk every branch, not hunt by intuition. Report ONLY paths and conditions that lack handling — discard fully handled ones silently. Do not editorialize or add filler.
 
 **MANDATORY: Execute the steps below IN EXACT ORDER. DO NOT skip steps or change the sequence. Each action within a step is a REQUIRED action to complete that step.**
 
@@ -8,7 +8,7 @@ You are a pure path tracer. Never comment on whether the content is good or bad;
 
 - When the content is a diff, scan only the diff hunks and list boundaries that are directly reachable from the changed lines and lack an explicit guard in the diff.
 - When it is not a diff (full file, function, or document), the entire provided content is the scope.
-- Ignore the rest of the codebase unless the provided content explicitly references external functions.
+- Ignore the rest of the codebase unless the provided content explicitly references external functions, or a changed early exit requires its callers and the code it skips.
 - When the launch message names a claims file, do NOT read it before Step 4: the path tracing in Steps 1–2 must finish before the narrative is seen.
 
 ## Step 1: Exhaustive path analysis
@@ -18,8 +18,8 @@ Walk every branching path and boundary condition within scope — report only un
 - If `also_consider` areas were provided, incorporate them into the analysis
 - Walk all branching paths: control flow (conditionals, loops, error handlers, early returns) and domain boundaries (where values, states, or conditions transition). Derive the relevant edge classes from the content itself — don't rely on a fixed checklist. Examples: missing else/default, unguarded inputs, off-by-one loops, arithmetic overflow, implicit type coercion, race conditions, timeout gaps
 - Consider implicit branches: the diff special-cases or changes the handling of one or more members of a fixed set of values — enums, status codes, sentinels, type tags, flags, value ranges. The rest of the set is implicit branches (e.g. the diff changes the `RED` and `YELLOW` cases of a `RED`/`YELLOW`/`GREEN` enum; `GREEN` is the implicit branch)
-- For each path: determine whether the content handles it
-- Collect only the unhandled paths as findings — discard handled ones silently
+- For each path: determine whether the content handles it. For a changed condition or early return, handling includes what can reach it and what remains undone when it returns — a path that exits with required work undone is unhandled
+- Collect only the unhandled paths as findings — discard fully handled ones silently
 
 ## Step 2: Validate completeness
 


### PR DESCRIPTION
## Problem

The edge-case-hunter prompt tells the reviewer to "discard handled ones silently" — a pure presence check. A branch whose handling exists but is incomplete passes that check and its analysis ends right there, so a changed condition or early return that exits with required work undone (cleanup skipped, lock held, state half-updated) is never reported.

## Change

In all four copies of the prompt — `bmad-build`, `bmad-build-auto`, `bmad-code-review` review-prompts and the `bmad-review` edge-case lens:

- Fold reachability and left-undone work into the definition of "handled": *"For a changed condition or early return, handling includes what can reach it and what remains undone when it returns — a path that exits with required work undone is unhandled."*
- Narrow the discard rule (preamble and collect bullet) from "handled" to "fully handled", so the discard cannot preempt the new check.
- Extend the existing scope carve-out so the check can be executed as written: *"…unless the provided content explicitly references external functions, or a changed early exit requires its callers and the code it skips."*

The check runs as part of determining "handled" rather than as a sibling instruction, because a sibling instruction would be neutered by the discard happening first. The third bullet closes a conflict the first two introduced: "what can reach it" means the callers, which the old carve-out never covered (callers reference the changed code, not the reverse), and the code after an exit is neither in the hunk nor an external function. Extending the same sentence keeps hunk scope governing everything else rather than adding a rule.

Scope stays mechanical (reachability, completeness of exit) — general "handling is wrong" correctness review remains out of this reviewer's lane. The v6 shim only forwards to the lens, so it needs no change.

`npm run quality` passes (0 errors).
