### PR TITLE
feat(review): add handle-lifetime and call-declaration checks to edge-case hunter

### DIFF
--- a/src/bmm-skills/ship/bmad-build-auto/review-prompts/edge-case-hunter.md
+++ b/src/bmm-skills/ship/bmad-build-auto/review-prompts/edge-case-hunter.md
@@ -32,6 +32,8 @@ A claims check runs as Step 5.
 - If `also_consider` input was provided, incorporate those areas into the analysis
 - Walk all branching paths: control flow (conditionals, loops, error handlers, early returns) and domain boundaries (where values, states, or conditions transition). Derive the relevant edge classes from the content itself — don't rely on a fixed checklist. Examples: missing else/default, unguarded inputs, off-by-one loops, arithmetic overflow, implicit type coercion, race conditions, timeout gaps
 - Consider implicit branches: the diff special-cases or changes the handling of one or more members of a fixed set of values — enums, status codes, sentinels, type tags, flags, value ranges. The rest of the set is implicit branches (e.g. the diff changes the `RED` and `YELLOW` cases of a `RED`/`YELLOW`/`GREEN` enum; `GREEN` is the implicit branch)
+- Consider handle lifetime: when the changed code re-checks, re-fetches, or re-validates something it already held — a handle, index, id, pointer — the re-check exists because an intervening call can invalidate it. Identify that call, what it does to the thing held, and what the changed code silently skips when the re-check fails
+- For each call site the diff adds or changes — in test files as well as production code — read the callee's declaration and check the call against it: argument count, order, types, and defaults. Report any mismatch
 - For each path: determine whether the content handles it
 - Collect only the unhandled paths as findings — discard handled ones silently
 

--- a/src/bmm-skills/ship/bmad-build/review-prompts/edge-case-hunter.md
+++ b/src/bmm-skills/ship/bmad-build/review-prompts/edge-case-hunter.md
@@ -32,6 +32,8 @@ A claims check runs as Step 5.
 - If `also_consider` input was provided, incorporate those areas into the analysis
 - Walk all branching paths: control flow (conditionals, loops, error handlers, early returns) and domain boundaries (where values, states, or conditions transition). Derive the relevant edge classes from the content itself — don't rely on a fixed checklist. Examples: missing else/default, unguarded inputs, off-by-one loops, arithmetic overflow, implicit type coercion, race conditions, timeout gaps
 - Consider implicit branches: the diff special-cases or changes the handling of one or more members of a fixed set of values — enums, status codes, sentinels, type tags, flags, value ranges. The rest of the set is implicit branches (e.g. the diff changes the `RED` and `YELLOW` cases of a `RED`/`YELLOW`/`GREEN` enum; `GREEN` is the implicit branch)
+- Consider handle lifetime: when the changed code re-checks, re-fetches, or re-validates something it already held — a handle, index, id, pointer — the re-check exists because an intervening call can invalidate it. Identify that call, what it does to the thing held, and what the changed code silently skips when the re-check fails
+- For each call site the diff adds or changes — in test files as well as production code — read the callee's declaration and check the call against it: argument count, order, types, and defaults. Report any mismatch
 - For each path: determine whether the content handles it
 - Collect only the unhandled paths as findings — discard handled ones silently
 

--- a/src/bmm-skills/ship/bmad-code-review/review-prompts/edge-case-hunter.md
+++ b/src/bmm-skills/ship/bmad-code-review/review-prompts/edge-case-hunter.md
@@ -32,6 +32,8 @@ A claims check runs as Step 5 when the launch message names a claims file.
 - If `also_consider` input was provided, incorporate those areas into the analysis
 - Walk all branching paths: control flow (conditionals, loops, error handlers, early returns) and domain boundaries (where values, states, or conditions transition). Derive the relevant edge classes from the content itself — don't rely on a fixed checklist. Examples: missing else/default, unguarded inputs, off-by-one loops, arithmetic overflow, implicit type coercion, race conditions, timeout gaps
 - Consider implicit branches: the diff special-cases or changes the handling of one or more members of a fixed set of values — enums, status codes, sentinels, type tags, flags, value ranges. The rest of the set is implicit branches (e.g. the diff changes the `RED` and `YELLOW` cases of a `RED`/`YELLOW`/`GREEN` enum; `GREEN` is the implicit branch)
+- Consider handle lifetime: when the changed code re-checks, re-fetches, or re-validates something it already held — a handle, index, id, pointer — the re-check exists because an intervening call can invalidate it. Identify that call, what it does to the thing held, and what the changed code silently skips when the re-check fails
+- For each call site the diff adds or changes — in test files as well as production code — read the callee's declaration and check the call against it: argument count, order, types, and defaults. Report any mismatch
 - For each path: determine whether the content handles it
 - Collect only the unhandled paths as findings — discard handled ones silently
 

--- a/src/core-skills/bmad-review/references/lens-edge-case-hunter.md
+++ b/src/core-skills/bmad-review/references/lens-edge-case-hunter.md
@@ -18,6 +18,8 @@ Walk every branching path and boundary condition within scope — report only un
 - If `also_consider` areas were provided, incorporate them into the analysis
 - Walk all branching paths: control flow (conditionals, loops, error handlers, early returns) and domain boundaries (where values, states, or conditions transition). Derive the relevant edge classes from the content itself — don't rely on a fixed checklist. Examples: missing else/default, unguarded inputs, off-by-one loops, arithmetic overflow, implicit type coercion, race conditions, timeout gaps
 - Consider implicit branches: the diff special-cases or changes the handling of one or more members of a fixed set of values — enums, status codes, sentinels, type tags, flags, value ranges. The rest of the set is implicit branches (e.g. the diff changes the `RED` and `YELLOW` cases of a `RED`/`YELLOW`/`GREEN` enum; `GREEN` is the implicit branch)
+- Consider handle lifetime: when the changed code re-checks, re-fetches, or re-validates something it already held — a handle, index, id, pointer — the re-check exists because an intervening call can invalidate it. Identify that call, what it does to the thing held, and what the changed code silently skips when the re-check fails
+- For each call site the diff adds or changes — in test files as well as production code — read the callee's declaration and check the call against it: argument count, order, types, and defaults. Report any mismatch
 - For each path: determine whether the content handles it
 - Collect only the unhandled paths as findings — discard handled ones silently
 


### PR DESCRIPTION
## What

Two path-analysis bullets in the edge-case hunter, applied to all four copies (`bmad-build`, `bmad-build-auto`, `bmad-code-review` review-prompts and the `bmad-review` edge-case lens):

- **Handle lifetime.** When changed code re-checks, re-fetches, or re-validates something it already held — a handle, index, id, pointer — the re-check exists because an intervening call can invalidate it. Identify that call, what it does to the thing held, and what the changed code silently skips when the re-check fails. This targets use-after-invalidation: the hunter's branch walk reads a guarded exit as "handled" and never asks what made the guard necessary.

- **Call vs declaration.** For each call site the diff adds or changes — tests included — check the call against the callee's declaration: argument count, order, types, defaults. Arity mismatches previously had no owning layer anywhere in the method.

## Evidence

Isolated-layer probes on the review-bench commit (`ui @ 970a801a0`, 15 single-layer runs total, archived in `review-bench/_runs/run_ui_2026-08-30_ech-earlyexit-ab/`):

- The lifetime rule is the only prompt of four tested whose runs named the invalidating call behind ground-truth Bug B (`ShouldDiscardEmptiedDashboardObject`): 2 of 3 runs vs 0 of 12 for every other prompt (Fisher exact p = 0.029). B catch rate 2/3 vs baseline 1/3 (not significant alone; the mechanism naming is the signal).
- The declaration rule produced the first bmad-lineage catch of ground-truth Bug C (a two-arg call to a three-parameter function that fails to compile) after its first version, scoped only by implication to production code, checked production call sites and skipped the test file; the "tests included" wording is what fixed it.

Caveats recorded in the run report: single bench commit, small n, self-scored — these rules were validated against the failures they were designed for, so their real test is the next unseen review. Two probe runs showed a displacement effect (a variant winning its specialty while missing the crash bug the baseline usually catches); worth watching in full-method runs.

`npm run quality` passes (0 errors).
