### PR TITLE
chore(gitignore): ignore .agents as a file, not only a directory

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -46,7 +46,7 @@ CLAUDE.local.md
 .serena/
 .claude/settings.local.json
 .junie/
-.agents/
+.agents
 .analysis/
 
 


### PR DESCRIPTION
## Summary
- Change `.gitignore` from `.agents/` to `.agents` so a worktree symlink named `.agents` is ignored, matching how `.claude` is already ignored.
- The trailing-slash rule only covered a real directory; harness worktrees link `.agents` at the shared skills tree and git treated that link as untracked.

## Test plan
- [x] `HUSKY=0 npm ci && npm run quality` on this checkout
- [ ] In a worktree with `.agents` → harness `.agents`, `git status` no longer lists `?? .agents`