### PR TITLE
docs: document all test scripts in test/README.md

### DIFF
--- a/test/README.md
+++ b/test/README.md
@@ -8,6 +8,9 @@ Tests for the BMAD-METHOD tooling infrastructure.
 # Run all quality checks
 npm run quality
 
+# Run the full test suite
+npm test
+
 # Run individual test suites
 npm run test:install    # Installation component tests
 npm run test:refs       # File reference CSV tests
@@ -28,11 +31,87 @@ Validates that the installer compiles and assembles agents correctly.
 
 Tests the CSV-based file reference validation logic.
 
+### Installer Channel Resolution Tests
+
+**File**: `test/test-installer-channels.js`
+
+Unit tests for the installer's channel planning and resolution modules
+(`channel-plan.js`, `channel-resolver.js`).
+
+### Source URL Parsing Tests
+
+**File**: `test/test-parse-source-urls.js`
+
+Verifies `CustomModuleManager.parseSource()` handles Git URLs across
+arbitrary hosts and path shapes.
+
+### Rehype Plugin Tests
+
+**File**: `test/test-rehype-plugins.mjs`
+
+Tests the `rehype-markdown-links` and `rehype-base-paths` plugins used to
+build the docs site.
+
+### Shim Policy Tests
+
+**File**: `test/test-shim-policy.js`
+
+Tests deprecated-skill shim discovery, retention, and removal logic in the
+installer.
+
+### Site URL Tests
+
+**File**: `test/test-site-url.mjs`
+
+Regression tests for the docs site's `getSiteUrl()` resolver.
+
+### Sprint-Status Template Sync
+
+**File**: `test/test-template-sync.js`
+
+Keeps the sprint-status template vendored by `bmad-retrospective` byte-identical
+to the source owned by `bmad-sprint-planning`.
+
+### Published Implementation Model Tests
+
+**File**: `test/test-validate-published-implementation-model.mjs`
+
+Tests `validatePublishedImplementationModel()`.
+
+### Skill Validation Tests
+
+**File**: `test/test-validate-skills.js`
+
+Tests `validateSkill()` against fixtures, focused on description quality
+(SKILL-06) and its deprecated-skill exemption.
+
+### Workflow Path Regex Tests
+
+**File**: `test/test-workflow-path-regex.js`
+
+Tests that `ModuleManager`'s source and install workflow path regexes extract
+the correct capture groups (module name and workflow sub-path).
+
+### Build Auto Renderer Tests
+
+**File**: `test/test-build-auto-renderer.js`
+
+Black-box tests for the shared immutable snapshot renderer used by
+`bmad-build-auto` and `bmad-build`.
+
+### Adversarial Review Tests
+
+**Directory**: `test/adversarial-review-tests/`
+
+A separate, manually-run eval suite for the `bmad-review` skill's
+`also_consider` input. See its own [README](adversarial-review-tests/README.md).
+
 ## Test Fixtures
 
 Located in `test/fixtures/`:
 
 ```text
 test/fixtures/
-└── file-refs-csv/    # Fixtures for file reference CSV tests
+├── file-refs-csv/     # Fixtures for file reference CSV tests
+└── validate-skills/   # Fixtures for skill validation tests
 ```


### PR DESCRIPTION
## What
`test/README.md` only documented 2 of the 13 test scripts that currently exist under `test/` (plus its fixtures and the separate adversarial-review eval suite). This adds a short entry for each undocumented script and fixture directory.

## Why
Several test files (channel resolution, source URL parsing, rehype plugins, shim policy, site URL, template sync, published implementation model, skill validation, workflow path regex, and the build-auto renderer) had no description in the README, making it hard to know what coverage already exists before adding new tests.

## How
- Added a `### <Name>` section with file path and one-line description for each undocumented `test/*.js` and `test/*.mjs` script
- Added `test/fixtures/validate-skills/` to the fixtures tree (was missing)
- Linked to `test/adversarial-review-tests/README.md` for the separate manual eval suite
- Added `npm test` to Quick Start alongside the existing `npm run quality`

## Testing
Ran `npm run lint:md` and the full `npm test` suite (via the repo's pre-commit hook) — both pass. This is a documentation-only change with no code modifications.