### PR TITLE
fix(build-auto): a follow-up pass recommends another only for a patched high

### DIFF
--- a/src/bmm-skills/ship/bmad-build-auto/step-01-clarify-and-route.md
+++ b/src/bmm-skills/ship/bmad-build-auto/step-01-clarify-and-route.md
@@ -2,6 +2,7 @@
 spec_file: '' # set at runtime once a route resolves it; some HALT branches exit before it is set
 spec_folder: '' # set at runtime under folder+id dispatch only
 story_id: '' # set at runtime under folder+id dispatch only
+followup_pass: '' # set at runtime when a `done` spec is re-dispatched for a follow-up review pass; empty on a first pass
 ---
 
 # Step 1: Clarify and Route
@@ -21,7 +22,7 @@ If the invocation prompt explicitly points to an existing spec file with recogni
 - `ready-for-dev` or `in-progress` → `[[bmad-snapshot:step-03-implement.md]]`
 - `in-review` → `[[bmad-snapshot:step-04-review.md]]`
 - `blocked` → HALT with status `blocked` and blocking condition `blocked spec supplied`.
-- `done` → set `review_loop_iteration` to `0` in the frontmatter, then **EARLY EXIT** to `[[bmad-snapshot:step-04-review.md]]` for a fresh review pass. (A `done` spec is a completed run, so this starts a follow-up review, not a resumption.)
+- `done` → set `review_loop_iteration` to `0` in the frontmatter and set `followup_pass` to `true`, then **EARLY EXIT** to `[[bmad-snapshot:step-04-review.md]]` for a fresh review pass. (A `done` spec is a completed run, so this starts a follow-up review, not a resumption.)
 
 If the invocation prompt instead supplies a spec folder and a story id, with no specific spec file path, this is a **folder+id dispatch**: set `spec_folder` (a `{project-root}`-relative or absolute path) and `story_id` from the prompt. Any further prompt text (e.g. `invoke_dev_with` guidance the caller appended) is additional planning context to carry into step-02 — not a competing description of what to implement.
 
@@ -31,7 +32,7 @@ Look for files matching `{spec_folder}/stories/{story_id}-*.md` (id-prefix match
 - **If more than one matches**, HALT with status `blocked` and blocking condition `ambiguous story file match`.
 - **If exactly one matches**, set `spec_file` to that path.
   - `draft` (planning was interrupted mid-flight): accumulate cross-story context before resuming — load every other file matching `{spec_folder}/stories/*.md` (every match except `{spec_file}` itself), regardless of `status`, and carry forward each one's **Code Map**, **Design Notes**, **Spec Change Log**, **Tasks & Acceptance** checklist state, and **Auto Run Result** details, where present, as additional planning context for step-02. Then **EARLY EXIT** to `[[bmad-snapshot:step-02-plan.md]]`.
-  - Any other recognized `status`: **EARLY EXIT** using the same routing as above, including the `review_loop_iteration` reset for `done`. One difference: a `blocked` story HALTs with blocking condition `story already blocked`, not `blocked spec supplied` — the caller did not supply this file; build-auto found it by id.
+  - Any other recognized `status`: **EARLY EXIT** using the same routing as above, including the `review_loop_iteration` reset and `followup_pass` for `done`. One difference: a `blocked` story HALTs with blocking condition `story already blocked`, not `blocked spec supplied` — the caller did not supply this file; build-auto found it by id.
   - `status` missing or unrecognized: HALT with status `blocked` and blocking condition `unrecognized status in existing story file`.
 - **If none matches**, this is the first dispatch for `{story_id}`. The entry's `title` and `description` are the resolved intent. If `{spec_folder}/SPEC.md` does not exist, HALT with status `blocked` and blocking condition `no epic spec found`. Otherwise load it and the files listed in its `companions:` frontmatter as planning context, then accumulate cross-story context the same way as the `draft` case above — load every file matching `{spec_folder}/stories/*.md` (none yet exists for `{story_id}` at this point, so nothing is excluded), regardless of `status`, carrying forward the same fields, where present, as additional planning context for step-02. Then continue to INSTRUCTIONS item 3 below — not `step-03-implement.md`, item 3 of the numbered list in this file (items 1 and 2 do not apply — context and intent are already resolved; item 1.A.5's previous-story continuity scan in particular never runs here, since folder+id dispatch already skips items 1 and 2 entirely — the cross-story accumulation above is its replacement for this dispatch mode).
 

--- a/src/bmm-skills/ship/bmad-build-auto/step-04-review.md
+++ b/src/bmm-skills/ship/bmad-build-auto/step-04-review.md
@@ -87,7 +87,7 @@ Write the following details to `{spec_file}` under `## Auto Run Result`:
 - Summary of implemented change
 - Files changed with one-line descriptions
 - Review findings breakdown: patches applied, items deferred, and every rejected finding with its recorded reason
-- Follow-up review recommendation: count only this pass's entries triaged `patch`, at entry verdict — never deferred or `false` ones. `true` if any patched entry was `high`, or if two or more `medium` entries were patched; otherwise `false`. Record the patched counts by verdict.
+- Follow-up review recommendation: default `false`. Count only this pass's entries triaged `patch`, at entry verdict — never deferred or `false` ones. On a first pass, `true` if any patched entry was `high`, or if two or more `medium` entries were patched. On a follow-up pass (`{followup_pass}` = `true`), `true` only if this pass patched a `high` — otherwise the work has converged; patch volume is never grounds. A `true` names the specific unverified risk under `## Auto Run Result`; if none can be named, it is `false`. Record the patched counts by verdict.
 - Verification performed, including command outcomes or manual inspection notes
 - Any residual risks
 


### PR DESCRIPTION
## Why

Re-running `bmad-build-auto` against a `done` spec starts a follow-up review, but step-04 grades its recommendation by the first-pass rule (any patched `high`, or two patched `medium`s). A follow-up that patches a couple of mediums therefore recommends yet another pass, and an orchestrator honoring the flag keeps scheduling reviews of work that has converged. In #2805's field data this was 6 review-2 sessions — median 23m each, ~2.3h and 3.6M weighted tokens — that a converged loop never needed.

## What

- Step-01 sets a new `followup_pass` runtime field whenever it routes a `done` spec (both direct dispatch and folder+id), alongside the existing `review_loop_iteration` reset.
- Step-04 splits the recommendation rule: first pass unchanged (`high`, or two `medium`s); a follow-up pass recommends another only when it patched a `high`. Patch volume is never grounds.
- A `true` recommendation must name the specific unverified risk under `## Auto Run Result`; if none can be named, it is `false`.

Instruction text only; 2 files, +4/−3. `test:renderer` 24/24, markdownlint clean.

## Relation to #2805

Extracted and adapted from that branch (`2bafb3fb`, credit @pbean), without its carry-forward machinery — this stands alone. If #2805 lands later, its version of the step-04 sentence supersedes this one cleanly (the only textual delta is its `carried` clause).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01WZiiqsZWdJadbBeq9eeys9
