### PR TITLE
feat(review): scale the blind hunter's finding floor with diff size

### DIFF
--- a/src/bmm-skills/ship/bmad-build-auto/customize.toml
+++ b/src/bmm-skills/ship/bmad-build-auto/customize.toml
@@ -59,7 +59,7 @@ Launch a context-free subagent with this prompt:
 
 Conduct a review of CONTENT.
 Look for what's missing, not only what's wrong.
-Find at least ten issues to fix or improve.
+Compute your finding floor N from the diff file's size: N = min(floor(sqrt(kB) + 1), 10), where kB is the file's size in kilobytes. State the arithmetic in one line, then find at least N issues to fix or improve.
 Output a Markdown list of findings only — no severity, priority, or ranking.
 If the content is empty, stop and say so.
 If you have zero findings, re-check and keep thinking; do not stop with an empty list.

--- a/src/bmm-skills/ship/bmad-build/customize.toml
+++ b/src/bmm-skills/ship/bmad-build/customize.toml
@@ -97,7 +97,7 @@ Launch a context-free subagent with this prompt:
 
 Conduct a review of CONTENT.
 Look for what's missing, not only what's wrong.
-Find at least ten issues to fix or improve.
+Compute your finding floor N from the diff file's size: N = min(floor(sqrt(kB) + 1), 10), where kB is the file's size in kilobytes. State the arithmetic in one line, then find at least N issues to fix or improve.
 Output a Markdown list of findings only — no severity, priority, or ranking.
 If the content is empty, stop and say so.
 If you have zero findings, re-check and keep thinking; do not stop with an empty list.
@@ -148,7 +148,7 @@ Launch a context-free subagent with this prompt:
 
 Conduct a review of CONTENT.
 Look for what's missing, not only what's wrong.
-Find at least ten issues to fix or improve.
+Compute your finding floor N from the size of the changes: N = min(floor(sqrt(kB) + 1), 10), where kB is the changed content's size in kilobytes. State the arithmetic in one line, then find at least N issues to fix or improve.
 Output a Markdown list of findings only — no severity, priority, or ranking.
 If the content is empty, stop and say so.
 If you have zero findings, re-check and keep thinking; do not stop with an empty list.

--- a/src/bmm-skills/ship/bmad-code-review/customize.toml
+++ b/src/bmm-skills/ship/bmad-code-review/customize.toml
@@ -53,7 +53,7 @@ Launch a context-free subagent with this prompt:
 
 Conduct a review of CONTENT.
 Look for what's missing, not only what's wrong.
-Find at least ten issues to fix or improve.
+Compute your finding floor N from the diff file's size: N = min(floor(sqrt(kB) + 1), 10), where kB is the file's size in kilobytes. State the arithmetic in one line, then find at least N issues to fix or improve.
 Output a Markdown list of findings only — no severity, priority, or ranking.
 If the content is empty, stop and say so.
 If you have zero findings, re-check and keep thinking; do not stop with an empty list.


### PR DESCRIPTION
## What

The blind hunter's flat "find at least ten issues" becomes a floor scaled to the content under review, self-computed by the hunter from the file it already reads:

> Compute your finding floor N from the diff file's size: N = min(floor(sqrt(kB) + 1), 10), where kB is the file's size in kilobytes. State the arithmetic in one line, then find at least N issues to fix or improve.

Curve: 2 (1–3 kB) → 3 (4–8 kB) → 4 (9–15 kB) → 6 (~30 kB) → capped at 10 from 81 kB. Four sites change: the blind-hunter layers in `bmad-build`, `bmad-build-auto`, and `bmad-code-review` (diff-file form), and `bmad-build`'s oneshot blind hunter (computed from the changed content's size, since the light route has no staged diff file). The stated one-line arithmetic makes the floor auditable in transcripts and leaves the model no room to lawyer the number.

## Why

The flat ten over-asks small diffs and merely matches large ones. Judge-valid finding counts track ~√kB across ground-truthed commits, so a 2 kB rewording owes ~2 real findings, not 10 — the surplus is enumerated off the diff text and paid for again at triage.

Benchmarked as an isolated-hunter A/B on a three-commit size ladder (1.65 / 10.1 / 30.4 kB, 3 runs per arm per commit, judge-scored against code):

- 9/9 scaled runs computed N correctly from the file size.
- Hunter volume down ~40% and cost down 16–31% at the two lower tiers; identical at the cap.
- Every Minor-or-worse finding at the lower tiers survived in the arm's union; the shed findings were Nit-tier.
- The floor is a floor, not a target: runs overshoot it at every size, so the substance core (findings that appear in every run) is unaffected.

## Out of scope

`core-skills/bmad-review/references/lens-adversarial.md` keeps its flat floor — it reviews arbitrary content (documents included) where a byte-size denominator is untested.
