### PR TITLE
docs(changelog): add v6.12.0 entry and sync marketplace.json

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -14,7 +14,7 @@
       "displayName": "BMad Method Analyze Plan Build",
       "source": "./",
       "description": "Full-lifecycle AI development framework — agents and workflows for product analysis, planning, architecture, and implementation.",
-      "version": "6.11.0",
+      "version": "6.12.0",
       "author": {
         "name": "Brian (BMad) Madison"
       },

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,24 @@
 # Changelog
 
+## v6.12.0 - 2026-09-03
+
+**Build decides how much ceremony a change needs after investigating it, not before.** Simple changes now get a two-section spec and finish in one session.
+
+**Review triage logs a verdict and evidence for every finding**, so nothing gets dropped silently. Several review bugs went with it: layers that returned nothing, serial launches, and re-reviews redoing settled work.
+
+### 💥 Breaking
+
+* `persistent_facts` ships empty. Re-add `project-context.md` to your override if you relied on the auto-load.
+* `{diff_output}` is now `{diff_file}`. Update custom review overrides.
+* Deprecated shims are opt-in on fresh installs. Pass `--shims` to keep them.
+* `bmad-checkpoint-preview` is now `bmad-walkthrough` (`CK` → `WT`). The old ID still forwards.
+* Build no longer auto-triggers on interactive edits, git bookkeeping, or formatting chores.
+* `llms.txt` and `llms-full.txt` are no longer published.
+
+### Also
+
+`bmad-project-context` now adopts a handwritten `AGENTS.md` instead of rewriting it. Polytoken, Grok, and ZCode added to the installer. Docs reorganized by task, Korean translation added. Fixes across customization resolution, review dispatch, and Windows encoding.
+
 ## v6.11.0 - 2026-08-09
 
 ### ✨ Headline


### PR DESCRIPTION
Release prep for v6.12.0, covering the 71 PRs merged since v6.11.0.

- Adds the `v6.12.0` CHANGELOG entry
- Bumps `.claude-plugin/marketplace.json` to `6.12.0`

`package.json` is deliberately left at `6.11.0` — `publish.yaml` bumps it via `npm version` as part of the release run.

Neither changed path is on `publish.yaml`'s push trigger, so merging this does not fire a `@next` prerelease. After merge, the release runs with:

```bash
gh workflow run publish.yaml --ref main -f channel=latest -f bump=minor
```

`minor` matches the 15 feature PRs in the range.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01CCE1y6eZatpxq5dkghG2zu