### PR TITLE
fix: make the repo tooling run on a Windows checkout

### DIFF
--- a/test/test-installation-components.js
+++ b/test/test-installation-components.js
@@ -3322,6 +3322,35 @@ async function runTests() {
       assert(!withoutTrailing.endsWith('\n'), 'upsertTomlKey preserves absence of trailing newline');
     }
 
+    // ---- upsertTomlKey: CRLF content -------------------------------------
+    // A file saved by a Windows editor is CRLF. Splitting on `\n` alone leaves
+    // a `\r` on every line, and JS `.` does not match `\r`, so the key pattern
+    // missed and the "replace" path fell through to "append" — writing the key
+    // a second time. TOML rejects that duplicate, taking the config down.
+    {
+      const crlf = '[modules.bmm]\r\nproject_knowledge = "old"\r\nother = 1\r\n';
+      const after = upsertTomlKey(crlf, '[modules.bmm]', 'project_knowledge', '"new"');
+      assert(
+        (after.match(/project_knowledge/g) || []).length === 1,
+        'upsertTomlKey replaces a CRLF key in place instead of duplicating it',
+        after,
+      );
+      assert(after.includes('project_knowledge = "new"'), 'upsertTomlKey writes the new CRLF value');
+      assert(!after.includes('"old"'), 'upsertTomlKey drops the prior CRLF value');
+      assert(!/(?<!\r)\n/.test(after), 'upsertTomlKey keeps a CRLF file entirely CRLF');
+    }
+
+    // ---- upsertTomlKey: CRLF insert paths keep the file's line ending -----
+    {
+      const crlf = '[core]\r\nuser_name = "old"\r\n';
+      const newKey = upsertTomlKey(crlf, '[core]', 'added', '"x"');
+      assert(!/(?<!\r)\n/.test(newKey), 'upsertTomlKey stays CRLF when adding a key');
+      const newSection = upsertTomlKey(crlf, '[modules.bmm]', 'k', '"v"');
+      assert(!/(?<!\r)\n/.test(newSection), 'upsertTomlKey stays CRLF when adding a section');
+      const lf = upsertTomlKey('[core]\nuser_name = "old"\n', '[core]', 'added', '"x"');
+      assert(!lf.includes('\r'), 'upsertTomlKey leaves an LF file untouched by the CRLF handling');
+    }
+
     // ---- applySetOverrides happy path ------------------------------------
     {
       const tmp = await fs.mkdtemp(path.join(os.tmpdir(), 'bmad-applyset-'));
@@ -3889,7 +3918,7 @@ async function runTests() {
     assert(await fs.pathExists(path.join(skill49, 'step-04-review.md')), 'build-auto step sources reach installed skill surface');
     // Compare against build-auto's own shipped command rather than a second hardcoded
     // literal, so the two skills cannot drift apart while both still match this file.
-    const fenced49 = skillSource49.match(/```bash\n([\s\S]*?)```/);
+    const fenced49 = skillSource49.match(/```bash\r?\n([\s\S]*?)```/);
     assert(
       fenced49 !== null && fenced49[1].includes('render_skill.py'),
       'build-auto ships its renderer invocation as a fenced bash command',

--- a/tools/installer/set-overrides.js
+++ b/tools/installer/set-overrides.js
@@ -128,6 +128,12 @@ function sectionHeader(moduleCode) {
  *     trailing blank lines so the section stays tidy).
  *   - If `[section]` doesn't exist, append a new section block at EOF.
  *
+ * Line endings are detected and preserved. Splitting on `\n` alone would
+ * leave a `\r` on the end of every line of a CRLF file, and JavaScript's `.`
+ * does not match `\r`, so the `key = value` pattern below would never match
+ * and an existing key would be appended a second time instead of replaced.
+ * TOML rejects the duplicate, which would take the whole config down.
+ *
  * @param {string} content   existing file content (may be empty)
  * @param {string} section   exact `[section]` header to target
  * @param {string} key
@@ -135,10 +141,10 @@ function sectionHeader(moduleCode) {
  * @returns {string} new content
  */
 function upsertTomlKey(content, section, key, valueToml) {
-  const lines = content.split('\n');
+  const eol = content.includes('\r\n') ? '\r\n' : '\n';
+  const lines = content.split(/\r?\n/);
   // Track whether the file already ended with a newline so we can preserve
-  // that. `split('\n')` on `"a\n"` yields `['a', '']`, which gives us the
-  // marker we need.
+  // that. Splitting `"a\n"` yields `['a', '']`, which gives us the marker.
   const hadTrailingNewline = lines.length > 0 && lines.at(-1) === '';
   if (hadTrailingNewline) lines.pop();
 
@@ -149,7 +155,7 @@ function upsertTomlKey(content, section, key, valueToml) {
     // the file is non-empty so sections stay visually separated.
     if (lines.length > 0 && lines.at(-1).trim() !== '') lines.push('');
     lines.push(section, `${key} = ${valueToml}`);
-    return lines.join('\n') + (hadTrailingNewline ? '\n' : '');
+    return lines.join(eol) + (hadTrailingNewline ? eol : '');
   }
 
   // Find the section's end (next `[...]` header or EOF).
@@ -175,7 +181,7 @@ function upsertTomlKey(content, section, key, valueToml) {
       const commentIdx = tail.search(/\s+#/);
       const commentSuffix = commentIdx === -1 ? '' : tail.slice(commentIdx);
       lines[i] = `${indent}${key} = ${valueToml}${commentSuffix}`;
-      return lines.join('\n') + (hadTrailingNewline ? '\n' : '');
+      return lines.join(eol) + (hadTrailingNewline ? eol : '');
     }
   }
 
@@ -187,9 +193,15 @@ function upsertTomlKey(content, section, key, valueToml) {
     insertAt--;
   }
   lines.splice(insertAt, 0, `${key} = ${valueToml}`);
-  return lines.join('\n') + (hadTrailingNewline ? '\n' : '');
+  return lines.join(eol) + (hadTrailingNewline ? eol : '');
 }
 
+/**
+ * Escape a string for literal use inside a RegExp.
+ *
+ * @param {string} s
+ * @returns {string}
+ */
 function escapeRegExp(s) {
   return s.replaceAll(/[.*+?^${}()|[\]\\]/g, String.raw`\$&`);
 }

--- a/tools/tests/test_validate_skills.py
+++ b/tools/tests/test_validate_skills.py
@@ -4,6 +4,7 @@ import io
 import json
 import os
 import re
+import subprocess
 import sys
 import tempfile
 import unittest
@@ -331,6 +332,10 @@ class TestRules(ProjectCase):
         self.assertTrue(any("{{.name}}" in f["detail"] for f in findings))
         self.assertTrue(any("{{.other}}" in f["detail"] for f in findings))
 
+    @unittest.skipIf(
+        os.name == "nt",
+        "chmod(0) only sets the read-only flag on Windows; the owner can still read",
+    )
     def test_read_err_on_unreadable_file_continues(self):
         skill = self.valid("bmad-perm", {"secret.md": "ok\n"})
         target = skill / "secret.md"
@@ -470,6 +475,68 @@ class TestParsers(unittest.TestCase):
         fm = vs.parse_frontmatter_multiline(content)
         self.assertEqual(fm["name"], "bmad-x")
         self.assertEqual(fm["description"], "line1\n  line2\n  line3")
+
+
+
+class TestPlatformPortability(ProjectCase):
+    """The validator has to reach the same verdict on a Windows checkout."""
+
+    def write_verbatim(self, path: Path, text: str) -> None:
+        """Write with the line endings given, defeating newline translation."""
+        path.parent.mkdir(parents=True, exist_ok=True)
+        with open(path, "w", encoding="utf-8", newline="") as fh:
+            fh.write(text)
+
+    def test_crlf_skill_md_parses_like_its_lf_original(self):
+        # Git for Windows defaults to core.autocrlf=true, so a checkout there is
+        # CRLF throughout. Read with newline="", the fence stayed "\r\n---\r\n",
+        # which find("\n---\n") never matches: every skill came back missing its
+        # name, its description and its body.
+        text = skill_md("bmad-crlf", "Does a thing. Use when the user needs it.")
+        skill = self.skills / "bmad-crlf"
+        self.write_verbatim(skill / "SKILL.md", text.replace("\n", "\r\n"))
+
+        findings = self.findings_for(skill)
+
+        self.assertEqual(findings, [], msg=f"CRLF checkout produced {findings}")
+
+    def test_report_paths_use_forward_slashes(self):
+        # These strings are the JSON skill/file fields and the file= of a GitHub
+        # Actions annotation, which only resolves with forward slashes.
+        self.add_skill(
+            "bmad-sep",
+            skill_md("bmad-sep", "Does a thing. Use when the user needs it."),
+            {"nested/notes.md": "Ship 100% with ETA\n"},
+        )
+
+        _, out, _ = self.run_validator(json_output=True)
+
+        findings = json.loads(out)
+        self.assertTrue(findings)
+        for finding in findings:
+            self.assertNotIn("\\", finding["skill"])
+            self.assertNotIn("\\", finding["file"])
+        self.assertIn("nested/notes.md", out)
+
+    def test_report_survives_a_cp1252_console(self):
+        # The report rules its sections with U+2500, which cp1252 cannot encode.
+        # Unpinned, print() raised before the validator reported anything.
+        self.valid("bmad-pin")
+        env = dict(os.environ)
+        env["PYTHONIOENCODING"] = "cp1252"
+
+        result = subprocess.run(
+            [sys.executable, str(VALIDATOR), str(self.skills / "bmad-pin")],
+            stdout=subprocess.PIPE,
+            stderr=subprocess.PIPE,
+            env=env,
+            check=False,
+        )
+
+        stderr = result.stderr.decode("utf-8", errors="replace")
+        self.assertEqual(result.returncode, 0, msg=stderr)
+        self.assertNotIn("UnicodeEncodeError", stderr)
+        self.assertIn("─", result.stdout.decode("utf-8"))
 
 
 if __name__ == "__main__":

--- a/tools/tests/test_validate_skills.py
+++ b/tools/tests/test_validate_skills.py
@@ -158,6 +158,8 @@ class ProjectCase(unittest.TestCase):
 
 
 class TestRules(ProjectCase):
+    """One case per deterministic rule, driven through validate_skill()."""
+
     def test_skill_01_missing_skill_md(self):
         skill = self.skills / "bmad-empty"
         skill.mkdir()
@@ -319,6 +321,7 @@ class TestRules(ProjectCase):
         self.assertEqual(sum(1 for f in findings if f["line"] == 6), 1)
 
     def test_tpl_01_does_not_strip_code_blocks(self):
+        """TPL-01 reads template files whole, fenced samples included."""
         skill = self.valid(
             "bmad-tpl",
             {
@@ -337,6 +340,7 @@ class TestRules(ProjectCase):
         "chmod(0) only sets the read-only flag on Windows; the owner can still read",
     )
     def test_read_err_on_unreadable_file_continues(self):
+        """An unreadable file is reported as READ-ERR without stopping the scan."""
         skill = self.valid("bmad-perm", {"secret.md": "ok\n"})
         target = skill / "secret.md"
         os.chmod(target, 0)
@@ -465,12 +469,16 @@ class TestCliAndOutput(ProjectCase):
 
 
 class TestParsers(unittest.TestCase):
+    """The frontmatter parsers, exercised directly rather than through a skill."""
+
     def test_parse_frontmatter_null_and_empty(self):
+        """No fence yields None; an empty fence yields an empty dict, not None."""
         self.assertIsNone(vs.parse_frontmatter("no fence\n"))
         self.assertEqual(vs.parse_frontmatter("---\n---\nbody\n"), {})
         self.assertEqual(vs.parse_frontmatter("---\nname: 'quoted'\n---\n"), {"name": "quoted"})
 
     def test_parse_frontmatter_multiline_continuation_and_comments(self):
+        """An indented continuation joins its key; a comment line inside it does not."""
         content = "---\nname: bmad-x\ndescription: line1\n  line2\n# ignored\n  line3\n---\n\nBody\n"
         fm = vs.parse_frontmatter_multiline(content)
         self.assertEqual(fm["name"], "bmad-x")
@@ -488,6 +496,7 @@ class TestPlatformPortability(ProjectCase):
             fh.write(text)
 
     def test_crlf_skill_md_parses_like_its_lf_original(self):
+        """A CRLF checkout must reach the same verdict as the LF original."""
         # Git for Windows defaults to core.autocrlf=true, so a checkout there is
         # CRLF throughout. Read with newline="", the fence stayed "\r\n---\r\n",
         # which find("\n---\n") never matches: every skill came back missing its
@@ -501,6 +510,7 @@ class TestPlatformPortability(ProjectCase):
         self.assertEqual(findings, [], msg=f"CRLF checkout produced {findings}")
 
     def test_report_paths_use_forward_slashes(self):
+        """Report paths are a contract, so they stay POSIX on every platform."""
         # These strings are the JSON skill/file fields and the file= of a GitHub
         # Actions annotation, which only resolves with forward slashes.
         self.add_skill(
@@ -519,6 +529,7 @@ class TestPlatformPortability(ProjectCase):
         self.assertIn("nested/notes.md", out)
 
     def test_report_survives_a_cp1252_console(self):
+        """The report prints in full on a console that cannot encode U+2500."""
         # The report rules its sections with U+2500, which cp1252 cannot encode.
         # Unpinned, print() raised before the validator reported anything.
         self.valid("bmad-pin")

--- a/tools/tests/test_validate_skills.py
+++ b/tools/tests/test_validate_skills.py
@@ -161,6 +161,7 @@ class TestRules(ProjectCase):
     """One case per deterministic rule, driven through validate_skill()."""
 
     def test_skill_01_missing_skill_md(self):
+        """A directory with no SKILL.md reports SKILL-01 and nothing else."""
         skill = self.skills / "bmad-empty"
         skill.mkdir()
         findings = self.findings_for(skill)
@@ -298,6 +299,7 @@ class TestRules(ProjectCase):
         self.assertEqual(findings_by_rule(self.findings_for(skill), "PATH-02"), [])
 
     def test_seq_02_patterns_one_per_line_and_eta_case(self):
+        """Each time-estimate line is flagged once, and ETA matches case-insensitively."""
         skill = self.valid(
             "bmad-seq",
             {

--- a/tools/validate_skills.py
+++ b/tools/validate_skills.py
@@ -95,6 +95,7 @@ def _finding(
     fix: str,
     line: int | None = None,
 ) -> dict:
+    """Build one finding record, omitting `line` when the rule has no line to cite."""
     item = {
         "rule": rule,
         "title": title,

--- a/tools/validate_skills.py
+++ b/tools/validate_skills.py
@@ -74,8 +74,15 @@ def escape_table_cell(s: str) -> str:
 
 
 def _relpath(to_path: str, start: str) -> str:
+    r"""Path of `to_path` relative to `start`, always with "/" separators.
+
+    These strings are a contract, not a display detail: they are the `skill`
+    and `file` fields of the JSON output and the `file=` of a GitHub Actions
+    annotation, which only resolves to a file with forward slashes. Windows
+    would otherwise emit "src\bmad-x\notes.md" and break both.
+    """
     rel = os.path.relpath(to_path, start)
-    return "" if rel == "." else rel
+    return "" if rel == "." else rel.replace(os.sep, "/")
 
 
 def _finding(
@@ -180,8 +187,16 @@ def parse_frontmatter_multiline(content: str) -> dict[str, str] | None:
 
 
 def safe_read_file(file_path: str, findings: list[dict], rel_file: str | None) -> str | None:
+    r"""Read a skill file as UTF-8 text, with line endings normalized to \n.
+
+    Universal newlines, not newline="": every parse downstream is written
+    against \n -- the frontmatter fence is located with find("\n---\n"), and
+    the rules split on \n -- so a CRLF checkout matches no fence at all and
+    leaves a stray \r on the end of every line. Git for Windows defaults to
+    core.autocrlf=true, so that is the ordinary checkout there.
+    """
     try:
-        with open(file_path, encoding="utf-8", errors="replace", newline="") as f:
+        with open(file_path, encoding="utf-8", errors="replace") as f:
             return f.read()
     except OSError as error:
         findings.append(
@@ -685,7 +700,28 @@ def run(
     return 1 if strict and has_high_plus else 0
 
 
+def pin_utf8(stream) -> None:
+    """Pin a console stream to UTF-8, keeping its own error handler.
+
+    The human-readable report rules its sections with U+2500 box drawing, and
+    findings quote skill names, descriptions and file paths. cp1252 -- the
+    Windows default whenever output is not a terminal -- encodes none of that,
+    so `npm run validate:skills` died in print() before reporting anything.
+
+    errors= is passed through deliberately: reconfigure(encoding=...) alone
+    resets the handler to "strict", which would silently downgrade stderr's
+    backslashreplace default and turn a diagnostic about an undecodable path
+    into a traceback.
+    """
+    reconfigure = getattr(stream, "reconfigure", None)
+    if reconfigure is not None:
+        reconfigure(encoding="utf-8", errors=getattr(stream, "errors", None) or "strict")
+
+
 def main(argv: list[str] | None = None) -> int:
+    """Parse arguments, run the validator, and return its exit code."""
+    pin_utf8(sys.stdout)
+    pin_utf8(sys.stderr)
     parser = argparse.ArgumentParser(description="Validate skill directories against deterministic rules.")
     parser.add_argument("--strict", action="store_true", help="exit 1 on HIGH+ findings")
     parser.add_argument("--json", action="store_true", dest="json_output", help="JSON output")

--- a/tools/validate_skills.py
+++ b/tools/validate_skills.py
@@ -70,6 +70,7 @@ def escape_annotation(s: str) -> str:
 
 
 def escape_table_cell(s: str) -> str:
+    """Escape a value for a markdown table cell, where an unescaped | ends the column."""
     return str(s).replace("|", "\\|")
 
 
@@ -155,6 +156,11 @@ def parse_frontmatter(content: str) -> dict[str, str] | None:
 
 
 def parse_frontmatter_multiline(content: str) -> dict[str, str] | None:
+    """Frontmatter as a dict, folding indented continuation lines into their key.
+
+    None when the block is absent, {} when it is present but empty. A comment
+    line inside a continuation is dropped rather than appended to the value.
+    """
     fm_block = _frontmatter_block(content)
     if fm_block is None:
         return None
@@ -671,6 +677,7 @@ def run(
     strict: bool = False,
     json_output: bool = False,
 ) -> int:
+    """Validate the requested skills, print the report, and return the exit code."""
     src_dir = os.path.join(project_root, "src")
     github_actions = bool(os.environ.get("GITHUB_ACTIONS"))
 


### PR DESCRIPTION
## Problem

On a Windows checkout, several of the repo's own tools do not run. Measured on Windows 11, Git for Windows at its defaults, against `v6.12.0` (05bfbd46), clean checkout, no environment overrides.

The common cause: Git for Windows sets `core.autocrlf=true` by default and this repo ships no `.gitattributes`, so a checkout there is CRLF throughout. Tooling that assumes `\n` then misbehaves in four distinct ways.

### 1. The skill validator dies before reporting anything

`tools/validate_skills.py` never pins stdout. The report rules its sections with `─` (U+2500, 60 of them), which `cp1252` cannot encode, and `cp1252` is the Python default whenever output is not a terminal:

```
  File "tools\validate_skills.py", line 683, in run
    print(output)
UnicodeEncodeError: 'charmap' codec can't encode characters in position 23630-23689
```

### 2. The skill validator reports 150 findings that are not real

`safe_read_file` passed `newline=""`, which turns off universal newlines, so the frontmatter fence stayed `\r\n---\r\n` and `_frontmatter_block`'s `find("\n---\n")` never matched it. Every skill came back missing its name, description and body:

```
   Skills scanned: 50
   Skills with findings: 50
   Total findings: 150      <- SKILL-02 + SKILL-03 + SKILL-07, all false
```

`newline=""` came in with the JS port in #2810, mirroring `fs.readFileSync`. Nothing downstream reads a raw `\r` (the only one is `escape_annotation`, which escapes it).

### 3. Report paths carry the wrong separator

`_relpath` returned the native separator. The `skill` and `file` fields of the JSON output and the `file=` of a GitHub Actions annotation are a contract, and an annotation only resolves with forward slashes. Windows emitted `src\bmad-gha\notes.md`.

### 4. Two installation tests fail, and one installer function is CRLF-unsafe

`test/test-installation-components.js` matched the shipped renderer command with ``/```bash\n(...)/``. With `\r\n` after the fence the match returns `null` and both renderer assertions fail: **493 passed, 2 failed**.

`upsertTomlKey` in `tools/installer/set-overrides.js` split on `"\n"` and rejoined with `"\n"`. On CRLF content every line kept a trailing `\r`, and since JavaScript's `.` does not match `\r`, `^(\s*)key\s*=\s*(.*)$` never matched — so the replace path fell through to append and wrote the key **a second time**:

```
in : [modules.bmm]\r\nproject_knowledge = "old"\r\n
out: [modules.bmm]\r\nproject_knowledge = "old"\r\n...\nproject_knowledge = "new"\n
```

`tomllib` rejects that outright (`Cannot overwrite a value`), which would take the whole config down. The insert paths also left the file with mixed endings.

**This last one is latent, not live.** `applySetOverrides` runs immediately after the installer rewrites both target files with LF (`installer.js:379-381`), so the shipped flow never feeds it CRLF. I could not reproduce it end to end, only at the unit level. Fixing it anyway: the function is exported, and one line of caller ordering is all that separates latent from live.

## Change

- `pin_utf8` on stdout and stderr at `main()` entry, generalizing the helper merged for `brain.py` in #2578. `errors=` is passed through so stderr's `backslashreplace` default is not silently downgraded to `strict`.
- Drop `newline=""` from `safe_read_file`.
- `_relpath` normalizes `os.sep` to `/`.
- Tolerate `\r?` in the renderer-command regex.
- `upsertTomlKey` detects the file's line ending, splits on `/\r?\n/`, and rejoins with what it found.

All five are no-ops on Linux and macOS.

## Result

| | before | after |
|---|---|---|
| `validate_skills.py --strict` | `UnicodeEncodeError` | `0 findings`, exit 0 |
| `tools/tests/test_validate_skills.py` | 16 failed of 33 | 36 passed, 1 skipped |
| `npm run test:install` | 493 passed, 2 failed | 502 passed, 0 failed |

The `0 findings` matches what Linux CI already reports.

## Test

`TestPlatformPortability` covers the Python side, one case per defect: a CRLF `SKILL.md` that must validate clean (genuinely cross-platform — the file is CRLF on Linux too), a report whose paths carry no `\`, and a subprocess run under `PYTHONIOENCODING=cp1252`.

Four new assertions cover `upsertTomlKey`: the replace path and both insert paths on CRLF, plus one that an LF file is untouched by the new handling.

Every case was verified to discriminate: with its own fix reverted the matching test fails, and with it restored the suites are green.

`test_read_err_on_unreadable_file_continues` is skipped on Windows: `chmod(0)` only sets the read-only flag there, so the owner can still read the file and no `READ-ERR` is raised. That is a POSIX permission scenario, not a portability gap.

## Still not included: `.gitattributes`

Worth stating that the fixes above do not make `npm run quality` pass on Windows, because `npm run format:check` fails independently. Prettier's `endOfLine` defaults to `lf` and there is no `.prettierrc` overriding it, so on a CRLF checkout it flags **every** file, including ones no PR has touched:

```
$ npx prettier --check tools/installer/prompts.js tools/installer/ui.js package.json
[warn] tools/installer/prompts.js
[warn] tools/installer/ui.js
[warn] package.json
```

A `.gitattributes` with `* text=auto eol=lf` is the root fix for this whole class and would have prevented all four defects above. I have left it out because it changes every contributor's working tree on their next checkout, which is a call for you rather than a side effect of a bug-fix PR. Happy to add it here or as its own PR if you want it.
