### PR TITLE
fix: make build-auto review converge

### DIFF
--- a/src/bmm-skills/ship/bmad-build-auto/customize.toml
+++ b/src/bmm-skills/ship/bmad-build-auto/customize.toml
@@ -58,11 +58,11 @@ instruction = """
 Launch a context-free subagent with this prompt:
 
 Conduct a review of CONTENT.
-Look for what's missing, not only what's wrong.
-Compute your finding floor N from the diff file's size: N = min(floor(sqrt(kB) + 1), 10), where kB is the file's size in kilobytes. State the arithmetic in one line, then find at least N issues to fix or improve.
+Look for what's missing, not only what's wrong: the input, state, caller, or failure path the change does not handle.
+Report only defects you can demonstrate. Each finding names the file and line, the concrete input or state that reaches it, and the bad outcome that follows. An idea to improve, tidy, or harden with no demonstrated bad outcome is not a finding — leave it out.
+Before you stop, make one more pass asking what is missing. Then stop: an empty list is a valid result, and you do not fill it by lowering the evidence bar.
 Output a Markdown list of findings only — no severity, priority, or ranking.
 If the content is empty, stop and say so.
-If you have zero findings, re-check and keep thinking; do not stop with an empty list.
 
 CONTENT: the unified diff at `{diff_file}`. Read that file — it is the content under review.
 

--- a/src/bmm-skills/ship/bmad-build-auto/step-04-review.md
+++ b/src/bmm-skills/ship/bmad-build-auto/step-04-review.md
@@ -100,7 +100,7 @@ Write the following details to `{spec_file}` under `## Auto Run Result`:
 - Summary of implemented change
 - Files changed with one-line descriptions
 - Review findings breakdown: patches applied, items deferred, and every rejected finding with its recorded reason
-- Follow-up review recommendation: default `false`. Count only this pass's entries triaged `patch`, at entry verdict — never deferred or `false` ones. On a first pass, `true` if any patched entry was `high`, or if two or more `medium` entries were patched. On a follow-up pass (`{followup_pass}` = `true`), `true` only if this pass patched a `high` — otherwise the work has converged; patch volume is never grounds. A `true` names the specific unverified risk under `## Auto Run Result`; if none can be named, it is `false`. Record the patched counts by verdict.
+- Follow-up review recommendation: default `false`. Count only unresolved findings after this pass, including deferred entries and findings that trigger a `bad_spec` loopback; never count entries routed `patch`, `reject`, or `false`. On a first pass, `true` if any unresolved entry is `high`, or if two or more unresolved entries are `medium`. On a follow-up pass (`{followup_pass}` = `true`), `true` only if an unresolved entry is `high`; otherwise the work has converged. A `true` names the specific unresolved risk under `## Auto Run Result`; if no qualifying unresolved finding remains, set it to `false`. Record the unresolved counts by verdict.
 - Verification performed, including command outcomes or manual inspection notes
 - Any residual risks
 

--- a/test/test-build-auto-renderer.js
+++ b/test/test-build-auto-renderer.js
@@ -318,6 +318,18 @@ async function main() {
     assert(review.includes('No active review layers. HALT'), 'all-disabled review HALT missing');
   });
 
+  test('review policy does not manufacture findings or recommend follow-ups for resolved work', () => {
+    const review = fixture();
+    const dir = path.dirname(entry(run(review)));
+    const blindHunter = fs.readFileSync(path.join(dir, 'step-04-review.md'), 'utf8');
+    assert(blindHunter.includes('Report only defects you can demonstrate.'), 'blind hunter lacks an evidence requirement');
+    assert(!blindHunter.includes('Find at least ten issues'), 'blind hunter still requires ten findings');
+    assert(!blindHunter.includes('finding floor'), 'blind hunter still has a finding quota');
+    assert(blindHunter.includes('an empty list is a valid result'), 'blind hunter does not permit convergence');
+    assert(blindHunter.includes('unresolved findings'), 'follow-up policy does not score unresolved findings');
+    assert(blindHunter.includes('otherwise the work has converged'), 'follow-up policy does not define false convergence');
+  });
+
   test('renderer identity changes create a new immutable generation', () => {
     const identity = fixture();
     const original = entry(run(identity));


### PR DESCRIPTION
## What
Update bmad-build-auto review guidance so the blind hunter reports demonstrated defects without a finding quota and follow-up recommendations are based on unresolved findings.

## Why
A mandatory finding floor can manufacture review findings, while counting patched findings treats completed work as evidence for another pass.
Fixes #2772

## How
- Remove the blind-hunter finding quota and require an evidence-backed empty result when appropriate.
- Base follow-up recommendations on unresolved findings, with stricter criteria for follow-up passes.
- Add renderer coverage for convergence and quota behavior.

## Testing
Ran `npm run quality`, including the renderer regression tests and repository validation checks.