### PR TITLE
docs(plan): correct course syncs sprint-status after approval

### DIFF
--- a/docs/plan/break-work-into-stories-and-track-it.md
+++ b/docs/plan/break-work-into-stories-and-track-it.md
@@ -89,8 +89,10 @@ Run `bmad-correct-course` when a change is too big for one story to absorb: a
 requirement turned out to be wrong, an architecture decision has to change, or
 a dependency changed. It reads the PRD, epics, architecture, and UX documents,
 assesses the impact, and produces a sprint change proposal — what changes,
-what stays, and in what order. Apply the proposal, then re-run Story Breakdown
-or `bmad-sprint-planning` for the affected epics. Finished work stays
+what stays, and in what order. Once you approve it, it updates
+`sprint-status.yaml` and hands the document edits off. Apply them, then create
+the new or changed stories. For a large restructure, re-run Story Breakdown or
+`bmad-sprint-planning` for the affected epics instead. Finished work stays
 finished.
 
 ## What Comes Next


### PR DESCRIPTION
The Correct Course paragraph read as if the skill only wrote a proposal and left all bookkeeping to the user. Checklist item 6.4 still updates `sprint-status.yaml` once the proposal is approved, so the docs now say so, and keep the story-breakdown re-run as the path for large restructures only.