### PR TITLE
chore(issues): update the version hint in the bug report template

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug-report.yaml
+++ b/.github/ISSUE_TEMPLATE/bug-report.yaml
@@ -76,8 +76,9 @@ body:
     id: version
     attributes:
       label: BMad Version
-      description: 'Check with: npx bmad-method --version or check package.json'
-      placeholder: e.g., 6.0.0-Beta.4
+      description: Ask your agent for `bmad update`. On 6.12 (npm install), run `npx
+        bmad-method --version`.
+      placeholder: e.g., 6.13.0
     validations:
       required: true
 


### PR DESCRIPTION
The BMad Version hint in the bug report template pointed at `npx bmad-method --version` and `package.json`, which exist only for the 6.12 npm install. It now covers both installs: `bmad update` for skills installs, `npx bmad-method --version` for 6.12. Placeholder bumped to 6.13.0.

The line wrap is yamlfix's; the field value is unchanged.
