### PR TITLE
chore(review): point CodeRabbit at dev and the moved ESLint config

### DIFF
--- a/.coderabbit.yaml
+++ b/.coderabbit.yaml
@@ -22,11 +22,11 @@ reviews:
     enabled: true
     drafts: false  # Don't review drafts automatically
     auto_incremental_review: false  # always review the whole PR, not just new commits
-    base_branches: [main]
+    base_branches: [dev]
   path_filters:
     # --- Shared baseline: tool configs ---
     - '!.coderabbit.yaml'
-    - '!eslint.config.mjs'
+    - '!docs-site/eslint.config.mjs'
     # --- Shared baseline: build output ---
     - '!dist/**'
     - '!build/**'


### PR DESCRIPTION
Two fixes to `.coderabbit.yaml`.

- `base_branches` listed `main`, which is the default branch and needs no listing, while every PR now targets `dev`. CodeRabbit has not reviewed the recent PRs into `dev`; this should bring it back.
- The path filter still excluded `eslint.config.mjs` at the root. It moved to `docs-site/` in #2834, as `greptile.json` already reflects.
