### PR TITLE
docs(customize): match the TEA catalog entry to Test Completed Work

### DIFF
--- a/docs/customize/add-modules.md
+++ b/docs/customize/add-modules.md
@@ -69,10 +69,11 @@ Build.
 ### Test Architect (TEA)
 
 Test strategy, automation guidance, and release-gate decisions through an
-agent and nine workflows. Compared with the built-in QA skill, TEA adds
-risk-based prioritization and requirements traceability. See
+agent and nine workflows. Its `bmad-testarch-automate` skill generates
+heavier test coverage than the built-in `bmad-qa-generate-e2e-tests`:
+fixtures, more test levels, and knowledge-base patterns. See
 [Test Completed Work](../build/test-completed-work.md) to choose between
-them.
+the two.
 
 - **Code:** `tea`
 - **npm:** [`bmad-method-test-architecture-enterprise`](https://www.npmjs.com/package/bmad-method-test-architecture-enterprise)


### PR DESCRIPTION
The modules page said TEA adds risk-based prioritization and traceability over the built-in QA skill, and linked to Test Completed Work for the choice. That page compares the two generate skills, `bmad-qa-generate-e2e-tests` and `bmad-testarch-automate`, and says nothing about prioritization or traceability. The catalog entry now says what the linked page says.
