### PR TITLE
feat(docs-site): validate redirects against the built site

### DIFF
--- a/docs-site/astro.config.mjs
+++ b/docs-site/astro.config.mjs
@@ -72,7 +72,7 @@ export default defineConfig({
     '/cs/explanation/named-agents': `${basePath}cs/customize/customize-bmad/`,
     '/fr/how-to/non-interactive-installation': `${basePath}fr/how-to/install-bmad/`,
     '/cs/how-to/non-interactive-installation': `${basePath}cs/how-to/install-bmad/`,
-    '/ko-kr/how-to/non-interactive-installation': `${basePath}ko-kr/how-to/install-bmad/`,
+    '/ko-kr/how-to/non-interactive-installation': `${basePath}ko-kr/start/install-bmad/`,
     '/vi-vn/how-to/non-interactive-installation': `${basePath}vi-vn/how-to/install-bmad/`,
     '/zh-cn/how-to/non-interactive-installation': `${basePath}zh-cn/how-to/install-bmad/`,
   },

--- a/docs-site/package.json
+++ b/docs-site/package.json
@@ -13,7 +13,7 @@
     "lint": "eslint scripts test --max-warnings=0",
     "lint:fix": "eslint scripts test --fix",
     "preview": "astro preview",
-    "test": "node test/test-site-url.mjs && node test/test-rehype-plugins.mjs",
+    "test": "node test/test-site-url.mjs && node test/test-rehype-plugins.mjs && node test/test-validate-redirects.mjs",
     "test:implementation-model": "node test/test-validate-published-implementation-model.mjs",
     "validate-links": "node scripts/validate-doc-links.js",
     "validate-sidebar": "node scripts/validate-sidebar-order.js"

--- a/docs-site/scripts/build-docs.mjs
+++ b/docs-site/scripts/build-docs.mjs
@@ -12,6 +12,7 @@ import fs from 'node:fs';
 import path from 'node:path';
 import { fileURLToPath } from 'node:url';
 import { validatePublishedImplementationModel } from './validate-published-implementation-model.mjs';
+import { validateRedirects } from './validate-redirects.mjs';
 
 // =============================================================================
 // Configuration
@@ -78,6 +79,12 @@ function buildAstroSite() {
   console.log('  → Checking published implementation model...');
   validatePublishedImplementationModel(siteDir);
   console.log('    Published implementation model check passed');
+  console.log('  → Checking redirects...');
+  const redirectCount = validateRedirects(path.join(SITE_ROOT, 'astro.config.mjs'), {
+    docsDir: path.join(PROJECT_ROOT, 'docs'),
+    siteDir,
+  });
+  console.log(`    ${redirectCount} redirects resolve to built pages`);
 
   console.log();
   console.log(`  \u001B[32m✓\u001B[0m Astro build complete`);

--- a/docs-site/scripts/validate-redirects.mjs
+++ b/docs-site/scripts/validate-redirects.mjs
@@ -1,0 +1,93 @@
+/**
+ * Redirect validator.
+ *
+ * Reads the `redirects` block of astro.config.mjs and checks each entry
+ * against the source docs and the built site:
+ *   - the target must exist as a built page
+ *   - the target must not itself be a redirect
+ *   - the source must not still exist as a doc file
+ *
+ * Runs as part of the docs build. Standalone usage after a build:
+ *   node docs-site/scripts/validate-redirects.mjs
+ */
+
+import fs from 'node:fs';
+import path from 'node:path';
+import { fileURLToPath } from 'node:url';
+
+const REDIRECT_LINE_RE = /^\s*'(\/[^']*)':\s*`\$\{basePath\}([^`]*)`,?\s*$/;
+
+/**
+ * Extract redirect entries from the astro config source.
+ * @param {string} configSource - Contents of astro.config.mjs.
+ * @returns {{ from: string, to: string }[]} Entries; `to` is relative to the site base.
+ */
+export function parseRedirects(configSource) {
+  const block = configSource.match(/^\s*redirects:\s*\{\r?\n([\s\S]*?)^\s*\},/m);
+  if (!block) throw new Error('No redirects block found in astro.config.mjs');
+
+  const redirects = [];
+  for (const line of block[1].split(/\r?\n/)) {
+    if (line.trim() === '') continue;
+    const match = line.match(REDIRECT_LINE_RE);
+    if (!match) throw new Error(`Unrecognized redirect line: ${line.trim()}`);
+    redirects.push({ from: match[1], to: match[2] });
+  }
+  return redirects;
+}
+
+/**
+ * Check redirect entries against the docs source tree and the built site.
+ * @param {{ from: string, to: string }[]} redirects
+ * @param {{ docsDir: string, siteDir: string }} dirs
+ * @returns {string[]} One message per problem; empty when all entries are valid.
+ */
+export function findRedirectProblems(redirects, { docsDir, siteDir }) {
+  const problems = [];
+
+  for (const { from, to } of redirects) {
+    const sourceBase = path.join(docsDir, from);
+    if (fs.existsSync(`${sourceBase}.md`) || fs.existsSync(path.join(sourceBase, 'index.md'))) {
+      problems.push(`${from} -> ${to}: source still exists as a doc page`);
+    }
+
+    const targetPage = path.join(siteDir, to, 'index.html');
+    if (!fs.existsSync(targetPage)) {
+      problems.push(`${from} -> ${to}: target was not built`);
+    } else if (fs.readFileSync(targetPage, 'utf-8').includes('http-equiv="refresh"')) {
+      problems.push(`${from} -> ${to}: target is itself a redirect`);
+    }
+  }
+
+  return problems;
+}
+
+/**
+ * Validate the redirects in a config file. Throws with every problem listed.
+ * @param {string} configPath - Path to astro.config.mjs.
+ * @param {{ docsDir: string, siteDir: string }} dirs
+ * @returns {number} Number of redirects checked.
+ */
+export function validateRedirects(configPath, dirs) {
+  const redirects = parseRedirects(fs.readFileSync(configPath, 'utf-8'));
+  const problems = findRedirectProblems(redirects, dirs);
+  if (problems.length > 0) {
+    throw new Error(`Invalid redirects in ${path.basename(configPath)}:\n  ${problems.join('\n  ')}`);
+  }
+  return redirects.length;
+}
+
+if (process.argv[1] && path.resolve(process.argv[1]) === fileURLToPath(import.meta.url)) {
+  const siteRoot = path.resolve(path.dirname(fileURLToPath(import.meta.url)), '..');
+  const projectRoot = path.resolve(siteRoot, '..');
+  try {
+    const count = validateRedirects(path.join(siteRoot, 'astro.config.mjs'), {
+      docsDir: path.join(projectRoot, 'docs'),
+      siteDir: path.join(projectRoot, 'build', 'site'),
+    });
+    console.log(`All ${count} redirects valid.`);
+  } catch (error) {
+    console.error(error.message);
+    process.exit(1);
+  }
+}

--- a/docs-site/test/test-validate-redirects.mjs
+++ b/docs-site/test/test-validate-redirects.mjs
@@ -1,0 +1,123 @@
+/**
+ * Tests for the redirect validator.
+ *
+ * Usage: node docs-site/test/test-validate-redirects.mjs
+ */
+
+import assert from 'node:assert/strict';
+import fs from 'node:fs';
+import os from 'node:os';
+import path from 'node:path';
+import { findRedirectProblems, parseRedirects } from '../scripts/validate-redirects.mjs';
+
+const tests = [];
+
+function test(name, run) {
+  tests.push({ name, run });
+}
+
+const CONFIG = `
+export default defineConfig({
+  outDir: '../build/site',
+  redirects: {
+    '/old/page': \`\${basePath}new/page/\`,
+    '/fr/old/page': \`\${basePath}fr/new/page/\`,
+  },
+  integrations: [],
+});
+`;
+
+function makeFixture(files) {
+  const root = fs.mkdtempSync(path.join(os.tmpdir(), 'bmad-redirects-'));
+  for (const [relativePath, content] of Object.entries(files)) {
+    const fullPath = path.join(root, relativePath);
+    fs.mkdirSync(path.dirname(fullPath), { recursive: true });
+    fs.writeFileSync(fullPath, content);
+  }
+  return { root, docsDir: path.join(root, 'docs'), siteDir: path.join(root, 'site') };
+}
+
+function withFixture(files, run) {
+  const { root, docsDir, siteDir } = makeFixture(files);
+  try {
+    return run({ docsDir, siteDir });
+  } finally {
+    fs.rmSync(root, { recursive: true, force: true });
+  }
+}
+
+test('parses redirect entries relative to the base path', () => {
+  assert.deepEqual(parseRedirects(CONFIG), [
+    { from: '/old/page', to: 'new/page/' },
+    { from: '/fr/old/page', to: 'fr/new/page/' },
+  ]);
+});
+
+test('rejects a redirect line it cannot read', () => {
+  const broken = CONFIG.replace('`${basePath}new/page/`', "'/new/page/'");
+  assert.throws(() => parseRedirects(broken), /Unrecognized redirect line/);
+});
+
+test('passes when targets are built pages and sources are gone', () => {
+  withFixture(
+    {
+      'site/new/page/index.html': '<html></html>',
+      'site/fr/new/page/index.html': '<html></html>',
+    },
+    (dirs) => assert.deepEqual(findRedirectProblems(parseRedirects(CONFIG), dirs), []),
+  );
+});
+
+test('reports a target that was not built', () => {
+  withFixture(
+    {
+      'site/new/page/index.html': '<html></html>',
+    },
+    (dirs) => assert.deepEqual(findRedirectProblems(parseRedirects(CONFIG), dirs), ['/fr/old/page -> fr/new/page/: target was not built']),
+  );
+});
+
+test('reports a target that is itself a redirect', () => {
+  withFixture(
+    {
+      'site/new/page/index.html': '<meta http-equiv="refresh" content="0;url=/elsewhere/">',
+      'site/fr/new/page/index.html': '<html></html>',
+    },
+    (dirs) => assert.deepEqual(findRedirectProblems(parseRedirects(CONFIG), dirs), ['/old/page -> new/page/: target is itself a redirect']),
+  );
+});
+
+test('reports a source that still exists as a doc page', () => {
+  withFixture(
+    {
+      'docs/old/page.md': '# old',
+      'docs/fr/old/page/index.md': '# old',
+      'site/new/page/index.html': '<html></html>',
+      'site/fr/new/page/index.html': '<html></html>',
+    },
+    (dirs) =>
+      assert.deepEqual(findRedirectProblems(parseRedirects(CONFIG), dirs), [
+        '/old/page -> new/page/: source still exists as a doc page',
+        '/fr/old/page -> fr/new/page/: source still exists as a doc page',
+      ]),
+  );
+});
+
+let failures = 0;
+
+for (const { name, run } of tests) {
+  try {
+    run();
+    console.log(`  [32m✓[0m ${name}`);
+  } catch (error) {
+    failures++;
+    console.error(`  [31m✗[0m ${name}: ${error.message}`);
+  }
+}
+
+if (failures > 0) {
+  console.error(`\n${failures} redirect test${failures === 1 ? '' : 's'} failed.`);
+  process.exit(1);
+}
+
+console.log(`\nAll ${tests.length} redirect tests passed.`);


### PR DESCRIPTION
Every redirect in `docs-site/astro.config.mjs` must now point at a page the build produced, must not point at another redirect, and must not shadow a doc file that still exists. The check runs inside the docs build after the Astro output is written, so a bad redirect fails `npm run build`.

The config cannot be imported from plain Node because Starlight ships TypeScript, so the validator reads the redirects block from the config source. Tests cover the parser and each failure mode.

The first commit fixes the one redirect the check found: the Korean `non-interactive-installation` redirect pointed at `ko-kr/how-to/install-bmad/`, which was never built. The page is under `start/`.
