### PR TITLE
refactor(walkthrough): run through the skill renderer

### DIFF
--- a/skills/bmad-walkthrough/SKILL.md
+++ b/skills/bmad-walkthrough/SKILL.md
@@ -3,60 +3,12 @@ name: bmad-walkthrough
 description: 'Walk the user through reviewing a change: what it is for, what to look at closely, and how to test it. Use when the user says "walkthrough", "walk me through this change", or "human review"'
 ---
 
-# Walkthrough Workflow
+Run the following command exactly once without changing the current working directory. Replace `{project-root}` with the absolute path to the project root and `{skill-root}` with the absolute path to this skill's directory:
 
-**Goal:** Guide a human through reviewing a change — from purpose and context into details.
+```bash
+uv run --no-cache "{project-root}/_bmad/scripts/render_skill.py" --project-root "{project-root}" --skill "{skill-root}"
+```
 
-**Your Role:** You are assisting the user in reviewing a change.
-
-## Conventions
-
-- Bare paths (e.g. `step-01-orientation.md`) resolve from the skill root.
-- `{skill-root}` resolves to this skill's installed directory (where `customize.toml` lives).
-- `{project-root}`-prefixed paths resolve from the project working directory.
-- `{skill-name}` resolves to the skill directory's basename.
-
-## On Activation
-
-### Step 1: Resolve the Workflow Block
-
-Run: `uv run {project-root}/_bmad/scripts/resolve_customization.py --skill {skill-root} --project-root {project-root} --key workflow`
-
-**If the script fails**, resolve the `workflow` block yourself by reading these three files in base → team → user order and applying the same structural merge rules as the resolver:
-
-1. `{skill-root}/customize.toml` — defaults
-2. `{project-root}/_bmad/custom/{skill-name}.toml` — team overrides
-3. `{project-root}/_bmad/custom/{skill-name}.user.toml` — personal overrides
-
-Any missing file is skipped. Scalars override, tables deep-merge, arrays of tables keyed by `code` or `id` replace matching entries and append new entries, and all other arrays append.
-
-### Step 2: Execute Prepend Steps
-
-Execute each entry in `{workflow.activation_steps_prepend}` in order before proceeding.
-
-### Step 3: Load Persistent Facts
-
-Treat every entry in `{workflow.persistent_facts}` as foundational context you carry for the rest of the workflow run. Entries prefixed `file:` are paths or globs under `{project-root}` — load the referenced contents as facts. All other entries are facts verbatim.
-
-### Step 4: Load Config
-
-Run: `uv run {project-root}/_bmad/scripts/resolve_config.py --project-root {project-root} --key modules.bmm.implementation_artifacts --key modules.bmm.planning_artifacts`
-
-### Step 5: Greet the User
-
-Greet the user.
-
-### Step 6: Execute Append Steps
-
-Execute each entry in `{workflow.activation_steps_append}` in order.
-
-Activation is complete. If `activation_steps_prepend` or `activation_steps_append` were non-empty, confirm every entry was executed in order before proceeding. Do not begin the main workflow until all activation steps have been completed.
-
-## Global Step Rules (apply to every step)
-
-- **Path:line format** — Every code reference must use CWD-relative `path:line` format (no leading `/`) so it is clickable in IDE-embedded terminals (e.g., `src/auth/middleware.ts:42`).
-- **Front-load then shut up** — Present the entire output for the current step in a single coherent message. Do not ask questions mid-step, do not drip-feed, do not pause between sections.
-
-## FIRST STEP
-
-Read fully and follow `steps/step-01-orientation.md` to begin.
+- On success, read and follow the one absolute `workflow.md` instruction printed to stdout.
+- If `{project-root}/_bmad/scripts/render_skill.py` is not found, this BMad installation is not set up yet: read the installed `bmad` skill's SKILL.md (a sibling of this skill's directory) and follow its setup flow, then run the command above once more.
+- On any other failure (including `uv` being unavailable), report the command output and HALT. Do not run any workflow source directly.

--- a/skills/bmad-walkthrough/references/generate-trail.md
+++ b/skills/bmad-walkthrough/references/generate-trail.md
@@ -2,8 +2,6 @@
 
 Generate a review trail from the diff and codebase context. A generated trail is lower quality than an author-produced one, but far better than none.
 
-## Follow Global Step Rules in SKILL.md
-
 ## INSTRUCTIONS
 
 1. Get the full diff against the appropriate baseline (same rules as Surface Area Stats in step-01).

--- a/skills/bmad-walkthrough/step-01-orientation.md
+++ b/skills/bmad-walkthrough/step-01-orientation.md
@@ -2,8 +2,6 @@
 
 Display: `[Orientation] → Walkthrough → Detail Pass → Testing`
 
-## Follow Global Step Rules in SKILL.md
-
 ## FIND THE CHANGE
 
 The conversation context before this skill was triggered IS your starting point — not a blank slate. Check in this order — stop as soon as the change is identified:
@@ -17,7 +15,7 @@ The conversation context before this skill was triggered IS your starting point 
    Do the last few messages reveal what change the user wants reviewed? Look for spec paths, commit refs, branches, PRs, or descriptions of a change. Use the same routing as above.
 
 3. **Sprint tracking**
-   Check for a sprint status file (`*sprint-status*`) in `{implementation_artifacts}` or `{planning_artifacts}`. If found, scan for stories with status `review`:
+   Check for a sprint status file (`*sprint-status*`) in `{{.implementation_artifacts}}` or `{{.planning_artifacts}}`. If found, scan for stories with status `review`:
    - Exactly one → suggest it and confirm with the user.
    - Multiple → present as numbered options.
    - None → fall through.
@@ -40,7 +38,7 @@ Never ask extra questions beyond what the cascade prescribes. If a step above al
 Once a change is identified from any source above, fill in the complementary artifact:
 
 - If you have a spec, look for `baseline_commit` in its frontmatter to determine the diff baseline.
-- If you have a commit or branch, check `{implementation_artifacts}` for a spec whose `baseline_commit` is an ancestor of that commit/branch (i.e., the spec describes work done on top of that baseline).
+- If you have a commit or branch, check `{{.implementation_artifacts}}` for a spec whose `baseline_commit` is an ancestor of that commit/branch (i.e., the spec describes work done on top of that baseline).
 - If you found both a spec and a commit/branch, use both.
 
 ## DETERMINE WHAT YOU HAVE
@@ -98,8 +96,8 @@ Omit any metric you cannot compute rather than guessing.
 
 ## FALLBACK TRAIL GENERATION
 
-If review mode is not `full-trail`, read fully and follow `references/generate-trail.md` to build one from the diff. Then return here and continue to NEXT. If trail generation fails (e.g., git unavailable), the original review mode is preserved — step-02 handles this with its non-trail path.
+If review mode is not `full-trail`, read fully and follow `[[bmad-snapshot:references/generate-trail.md]]` to build one from the diff. Then return here and continue to NEXT. If trail generation fails (e.g., git unavailable), the original review mode is preserved — step-02 handles this with its non-trail path.
 
 ## NEXT
 
-Read fully and follow `steps/step-02-walkthrough.md`
+Read fully and follow `[[bmad-snapshot:step-02-walkthrough.md]]`

--- a/skills/bmad-walkthrough/step-02-walkthrough.md
+++ b/skills/bmad-walkthrough/step-02-walkthrough.md
@@ -2,7 +2,7 @@
 
 Display: `Orientation → [Walkthrough] → Detail Pass → Testing`
 
-## Follow Global Step Rules in SKILL.md
+## Step Rules
 
 - Organize by **concern**, not by file. A concern is a cohesive design intent — e.g., "input validation," "state management," "API contract." One file may appear under multiple concerns; one concern may span multiple files.
 - The walkthrough activates **design judgment**, not correctness checking. Frame each concern as "here's what this change does and why" — the human evaluates whether it's the right approach for the system.
@@ -80,10 +80,10 @@ When you're ready, say **next** and I'll surface the highest-risk spots.
 
 If at any point the human signals they want to make a decision about this {change_type} (e.g., "let's ship it", "this needs a rethink", "I'm done reviewing", or anything suggesting they're ready to decide), confirm their intent:
 
-- If they want to **approve and ship** → read fully and follow `steps/step-05-wrapup.md`
-- If they want to **reject and rework** → read fully and follow `steps/step-05-wrapup.md`
+- If they want to **approve and ship** → read fully and follow `[[bmad-snapshot:step-05-wrapup.md]]`
+- If they want to **reject and rework** → read fully and follow `[[bmad-snapshot:step-05-wrapup.md]]`
 - If you misread them → acknowledge and continue the current step.
 
 ## NEXT
 
-Default: read fully and follow `steps/step-03-detail-pass.md`
+Default: read fully and follow `[[bmad-snapshot:step-03-detail-pass.md]]`

--- a/skills/bmad-walkthrough/step-03-detail-pass.md
+++ b/skills/bmad-walkthrough/step-03-detail-pass.md
@@ -2,7 +2,7 @@
 
 Display: `Orientation → Walkthrough → [Detail Pass] → Testing`
 
-## Follow Global Step Rules in SKILL.md
+## Step Rules
 
 - The detail pass surfaces what the human should **think about**, not what the code got wrong. Machine hardening already handled correctness. This activates risk awareness.
 - The LLM detects risk category by pattern. The human judges significance. Do not assign severity scores or numeric rankings — ordering by blast radius (below) is sequencing for readability, not a severity judgment.
@@ -83,8 +83,8 @@ You've seen the design and the risk landscape. From here:
 
 If at any point the human signals they want to make a decision about this {change_type} (e.g., "let's ship it", "this needs a rethink", "I'm done reviewing", or anything suggesting they're ready to decide), confirm their intent:
 
-- If they want to **approve and ship** → read fully and follow `steps/step-05-wrapup.md`
-- If they want to **reject and rework** → read fully and follow `steps/step-05-wrapup.md`
+- If they want to **approve and ship** → read fully and follow `[[bmad-snapshot:step-05-wrapup.md]]`
+- If they want to **reject and rework** → read fully and follow `[[bmad-snapshot:step-05-wrapup.md]]`
 - If you misread them → acknowledge and continue the current step.
 
 ## TARGETED RE-REVIEW
@@ -103,4 +103,4 @@ The human can trigger multiple targeted re-reviews. Each time, present new findi
 
 ## NEXT
 
-Read fully and follow `steps/step-04-testing.md`
+Read fully and follow `[[bmad-snapshot:step-04-testing.md]]`

--- a/skills/bmad-walkthrough/step-04-testing.md
+++ b/skills/bmad-walkthrough/step-04-testing.md
@@ -2,7 +2,7 @@
 
 Display: `Orientation → Walkthrough → Detail Pass → [Testing]`
 
-## Follow Global Step Rules in SKILL.md
+## Step Rules
 
 - This is **experiential**, not analytical. The detail pass asked "did you think about X?" — this says "you could see X with your own eyes."
 - Do not prescribe. The human decides whether observing the behavior is worth their time. Frame suggestions as options, not obligations.
@@ -71,4 +71,4 @@ You've seen the change and how to verify it. When you're ready to make a call, j
 
 ## NEXT
 
-When the human signals they're ready to make a decision about this {change_type}, read fully and follow `steps/step-05-wrapup.md`
+When the human signals they're ready to make a decision about this {change_type}, read fully and follow `[[bmad-snapshot:step-05-wrapup.md]]`

--- a/skills/bmad-walkthrough/step-05-wrapup.md
+++ b/skills/bmad-walkthrough/step-05-wrapup.md
@@ -2,8 +2,6 @@
 
 Display: `Orientation → Walkthrough → Detail Pass → Testing → [Wrap-Up]`
 
-## Follow Global Step Rules in SKILL.md
-
 ## PROMPT FOR DECISION
 
 ```
@@ -25,6 +23,6 @@ HALT — do not proceed until the user makes their choice.
 
 ## On Complete
 
-Run: `uv run {project-root}/_bmad/scripts/resolve_customization.py --skill {skill-root} --project-root {project-root} --key workflow.on_complete`
+If anything appears below, follow it as the final terminal instruction before exiting; otherwise exit normally.
 
-If the resolved `workflow.on_complete` is non-empty, follow it as the final terminal instruction before exiting.
+{workflow.on_complete}

--- a/skills/bmad-walkthrough/workflow.md
+++ b/skills/bmad-walkthrough/workflow.md
@@ -1,0 +1,47 @@
+# Walkthrough Workflow
+
+**Goal:** Guide a human through reviewing a change — from purpose and context into details.
+
+**Your Role:** You are assisting the user in reviewing a change.
+
+**CRITICAL:** If a step directs you to another snapshot file, read it fully and follow it. No exceptions.
+
+## Conventions
+
+- Every operational cross-file reference in this workflow is an absolute snapshot path. Open it directly; do not resolve it relative to a skill directory.
+- `{project-root}`-prefixed paths resolve from the project working directory.
+
+## On Activation
+
+### Step 1: Execute Prepend Steps
+
+Execute each of these steps in order before proceeding (`_None._` means skip):
+
+{workflow.activation_steps_prepend}
+
+### Step 2: Load Persistent Facts
+
+Treat every entry below as foundational context you carry for the rest of the workflow run. Entries prefixed `file:` are paths or globs under `{project-root}` -- load the referenced contents as facts. All other entries are facts verbatim (`_None._` means none):
+
+{workflow.persistent_facts}
+
+### Step 3: Execute Append Steps
+
+Execute each of these steps in order (`_None._` means skip):
+
+{workflow.activation_steps_append}
+
+Activation is complete after all activation steps have run.
+
+## Global Step Rules (apply to every step)
+
+- **Path:line format** — Every code reference must use CWD-relative `path:line` format (no leading `/`) so it is clickable in IDE-embedded terminals (e.g., `src/auth/middleware.ts:42`).
+- **Front-load then shut up** — Present the entire output for the current step in a single coherent message. Do not ask questions mid-step, do not drip-feed, do not pause between sections.
+
+## Workflow Execution
+
+Follow the step files in order. Read one step fully, execute it, then load the next step only when directed. Do not skip, reorder, or pre-load steps.
+
+## FIRST STEP
+
+Read fully and follow: `[[bmad-snapshot:step-01-orientation.md]]` to begin.


### PR DESCRIPTION
## Summary

Make `bmad-walkthrough` a rendered skill, the same way `bmad-build` and `bmad-build-auto` already are.

- `SKILL.md` becomes the `render_skill.py` launcher; a new `workflow.md` carries the goal, conventions, activation, and global step rules.
- Step files move from `steps/` to the skill root, matching build's flat layout.
- Cross-file references become `[[bmad-snapshot:...]]` tokens, so the rendered copy carries absolute paths.
- Artifact directories use `{{.implementation_artifacts}}` / `{{.planning_artifacts}}` instead of a runtime `resolve_config.py` call.
- Wrap-up embeds `{workflow.on_complete}` at render time instead of calling `resolve_customization.py`.
- Per-step "Follow Global Step Rules in SKILL.md" headings become "Step Rules" where they had content and are dropped where empty; the "Greet the User" activation step is dropped on purpose: it produced a content-free message before orientation, and build and build-auto have no greeting either.

## Verification

- `uv run tools/validate_skills.py --strict` passes.
- `test_render_skill.py` passes; full `tools/quality.py` gate passes.
- Rendered the skill against a real project: no unresolved tokens, absolute step paths, artifact directories filled in.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_0128o6EeTofMcZEFwZcqgbnP

