### PR TITLE
fix(walkthrough): make code references clickable in any host

### DIFF
--- a/skills/bmad-walkthrough/workflow.md
+++ b/skills/bmad-walkthrough/workflow.md
@@ -35,7 +35,7 @@ Activation is complete after all activation steps have run.
 
 ## Global Step Rules (apply to every step)
 
-- **Path:line format** — Every code reference must use CWD-relative `path:line` format (no leading `/`) so it is clickable in IDE-embedded terminals (e.g., `src/auth/middleware.ts:42`).
+- **Code references** — Display every file path and `file:line` reference in whatever form is clickable where you are presenting it (e.g. a code citation or markdown link in chat, a CWD-relative `path:line` with no leading `/` in a terminal). If unsure, use the CWD-relative `path:line` form.
 - **Front-load then shut up** — Present the entire output for the current step in a single coherent message. Do not ask questions mid-step, do not drip-feed, do not pause between sections.
 
 ## Workflow Execution


### PR DESCRIPTION
## Summary

Walkthrough's global path rule was terminal-only (`path:line` for IDE-embedded terminals). Chat hosts need a code citation or markdown link instead.

Match the host-aware wording already used by `bmad-build`: display every file path and `file:line` reference in whatever form is clickable where you are presenting it; fall back to CWD-relative `path:line` if unsure.

Step files and `references/generate-trail.md` still use `path:line` as template placeholders and inherit this rule via "per the global step rules" / "per the standing rule".

## Verification

- `uv run tools/validate_skills.py --strict` passes
- `uv sync --frozen && (cd docs-site && npm ci) && uv run --frozen tools/quality.py` passes
