### PR TITLE
ci(coderabbit): turn off the docstring coverage check

### DIFF
--- a/.coderabbit.yaml
+++ b/.coderabbit.yaml
@@ -18,6 +18,11 @@ reviews:
   commit_status: false
   collapse_walkthrough: true  # `walkthrough: false` is not a schema key; this is the real knob
   poem: false
+  pre_merge_checks:
+    # Docstring coverage is on by default at an 80% threshold; the renderer's
+    # private helpers carry none and no repo rule asks for them.
+    docstrings:
+      mode: 'off'
   auto_review:
     enabled: true
     drafts: false  # Don't review drafts automatically


### PR DESCRIPTION
CodeRabbit enables docstring coverage by default at an 80% threshold and warned on #2844 because the renderer's private helpers carry no docstrings. No repository rule asks for them, so the warning is noise on every Python change. Greptile has no equivalent check, so nothing needs mirroring in `greptile.json`.