### PR TITLE
fix(build): avoid redundant resume work

### DIFF
--- a/skills/bmad-build/step-01-clarify-and-route.md
+++ b/skills/bmad-build/step-01-clarify-and-route.md
@@ -17,6 +17,15 @@ Before listing artifacts, resolve existing workflow state in this order. Skip th
 
 1. Explicit argument
    Did the user pass a specific file path, spec name, or clear instruction this message?
+   - If the argument is an exact story identifier such as `N.M`, first search
+     `{{ config.implementation_artifacts }}` for active spec files (`draft`, `ready-for-dev`,
+     `in-progress`, or `in-review`) whose story identity matches both numeric
+     segments exactly. Resolve the frontmatter and story metadata before using
+     filename matching; `1.1` must not match `1.10`. Exactly one match sets
+     `spec_file` and follows the status route below. More than one match HALTs
+     with the ambiguous paths. With no match, continue with normal intent
+     loading and context selection; do not compile epic context merely because
+     the identifier looks like a story.
    - If the user explicitly supplied a spec folder and a story id, with no specific spec file path, set `spec_folder` and `story_id`. Read `{spec_folder}/stories.yaml`; if it is missing or fails to parse, HALT rather than falling back to `{{ config.implementation_artifacts }}`. Find the one entry whose string `id` exactly equals `story_id`; if none exists, HALT rather than falling back. Use that entry's `title` and `description` as the starting intent.
      - Look for files matching `{spec_folder}/stories/{story_id}-*.md`. More than one match → HALT rather than choosing one. Exactly one match → set `spec_file` to that path and process it exactly as if the user had supplied that specific file path, including **Story-key resolution** and the existing status route below. No matches → derive a valid kebab-case slug from the entry's `title` (and `description` if needed), then set `spec_file` = `{spec_folder}/stories/{story_id}-{slug}.md` and proceed to INSTRUCTIONS.
    - If it points to a file that matches the spec template (has `status` frontmatter with a recognized value: draft, ready-for-dev, in-progress, in-review, or done) → set `spec_file`. Before exiting, run **Story-key resolution** (below). Then **EARLY EXIT** to the appropriate step: `draft` → `{{ rendered("step-02-plan.md") }}`, `ready-for-dev`/`in-progress` → `{{ rendered("step-03-implement.md") }}` (or `{{ rendered("step-oneshot.md") }}` when `route` is `oneshot`), `in-review` → `{{ rendered("step-04-review.md") }}`. For `done`, ingest as context and proceed to INSTRUCTIONS — do not resume.

--- a/skills/bmad-build/step-03-implement.md
+++ b/skills/bmad-build/step-03-implement.md
@@ -25,7 +25,32 @@ Change `{spec_file}` status to `in-progress` in the frontmatter before starting 
 
 If `{story_key}` is not empty and `{{ config.implementation_artifacts }}/sprint-status.yaml` exists, read `{{ rendered("sync-sprint-status.md") }}` with `{target_status}` = `in-progress`.
 
-Execute the implementation handoff below: substitute the runtime placeholders (e.g. `{spec_file}`) into it, then follow it verbatim.
+### Resumed-story preflight
+
+If `{spec_file}` already has `baseline_commit` and its execution tasks are all
+checked, run a bounded conformance preflight before launching the implementation
+handoff. Read only the spec's `Code Map`, `Tasks & Acceptance`, `Implementation
+Notes`, and any `Open Questions` or `Review Triage Log` sections. Then inspect
+the current worktree with `git status --short` and `git diff --name-only`, and
+check the mapped files and acceptance commands for evidence of drift or missing
+work.
+
+- If an open question, unresolved review-loop item, missing acceptance evidence,
+  or implementation drift is found, continue to the implementation handoff.
+- If the task checklist is complete, no open question or unresolved review item
+  remains, and the bounded check finds no drift, skip the implementation
+  handoff and proceed directly to Tasks & Acceptance Verification.
+- Checked boxes alone are not proof and must never be the reason to skip the
+  conformance check.
+
+For a resumed story, do not rediscover the original implementation from the
+full baseline diff. Keep the generated diff file-backed and use its path for
+reviewers; the parent verification should consume only `git diff --stat`,
+`git diff --name-only`, the mapped files, and targeted acceptance output.
+
+When the preflight requires implementation, execute the implementation handoff
+below: substitute the runtime placeholders (e.g. `{spec_file}`) into it, then
+follow it verbatim.
 
 {{ workflow.implementation_handoff }}
 
@@ -37,7 +62,7 @@ The handoff directs the subagent to load the spec's `context:` files itself, so 
 
 ### Tasks & Acceptance Verification
 
-Stage the diff and read it first: using the repository's version-control tooling, write a unified diff of all changes since `{baseline_commit}` (from `{spec_file}` frontmatter) — untracked files included — to a uniquely-named file in the system temp directory, set `{diff_file}` to its absolute path, and read that file into your own context. Judge against the diff, not against the implementation subagent's report.
+Stage the diff: using the repository's version-control tooling, write a unified diff of all changes since `{baseline_commit}` (from `{spec_file}` frontmatter) — untracked files included — to a uniquely-named file in the system temp directory, set `{diff_file}` to its absolute path, and pass that path to reviewers. Do not load the complete diff into the parent context. Judge the changed-path summary, mapped files, and targeted verification output rather than the implementation subagent's report alone.
 
 Verify every task in the `## Tasks & Acceptance` section of `{spec_file}` is complete and every acceptance criterion is satisfied. Mark each finished task `[x]`. If any task is not done or any acceptance criterion is not satisfied, finish the missing work before proceeding — and when that changes code, rewrite `{diff_file}` and re-read it.
 

--- a/skills/bmad-build/step-03-implement.md
+++ b/skills/bmad-build/step-03-implement.md
@@ -30,10 +30,11 @@ If `{story_key}` is not empty and `{{ config.implementation_artifacts }}/sprint-
 If `{spec_file}` already has `baseline_commit` and its execution tasks are all
 checked, run a bounded conformance preflight before launching the implementation
 handoff. Read only the spec's `Code Map`, `Tasks & Acceptance`, `Implementation
-Notes`, and any `Open Questions` or `Review Triage Log` sections. Then inspect
-the current worktree with `git status --short` and `git diff --name-only`, and
-check the mapped files and acceptance commands for evidence of drift or missing
-work.
+Notes`, `Verification`, and any `Open Questions` or `Review Triage Log` sections.
+Then inspect the current worktree with `git status --short` and `git diff
+--name-only`, and check the mapped files and acceptance commands for evidence of
+drift or missing work. When `baseline_commit` is `NO_VCS`, skip the Git worktree
+inspection and run the `## Verification` acceptance commands directly instead.
 
 - If an open question, unresolved review-loop item, missing acceptance evidence,
   or implementation drift is found, continue to the implementation handoff.
@@ -62,9 +63,9 @@ The handoff directs the subagent to load the spec's `context:` files itself, so 
 
 ### Tasks & Acceptance Verification
 
-Stage the diff: using the repository's version-control tooling, write a unified diff of all changes since `{baseline_commit}` (from `{spec_file}` frontmatter) — untracked files included — to a uniquely-named file in the system temp directory, set `{diff_file}` to its absolute path, and pass that path to reviewers. Do not load the complete diff into the parent context. Judge the changed-path summary, mapped files, and targeted verification output rather than the implementation subagent's report alone.
+Stage the diff: using the repository's version-control tooling, write a unified diff of all changes since `{baseline_commit}` (from `{spec_file}` frontmatter) — untracked files included — to a uniquely-named file in the system temp directory, set `{diff_file}` to its absolute path, and pass that path to reviewers. When `{baseline_commit}` is `NO_VCS`, there is nothing to stage: skip this step and report an explicit no-VCS result in place of the diff. Do not load the complete diff into the parent context. Judge the changed-path summary, mapped files, and targeted verification output rather than the implementation subagent's report alone.
 
-Verify every task in the `## Tasks & Acceptance` section of `{spec_file}` is complete and every acceptance criterion is satisfied. Mark each finished task `[x]`. If any task is not done or any acceptance criterion is not satisfied, finish the missing work before proceeding — and when that changes code, rewrite `{diff_file}` and re-read it.
+Verify every task in the `## Tasks & Acceptance` section of `{spec_file}` is complete and every acceptance criterion is satisfied. Mark each finished task `[x]`. If any task is not done or any acceptance criterion is not satisfied, finish the missing work before proceeding — and when that changes code, rewrite `{diff_file}` so it reflects the updated tree, then pass the updated path to reviewers.
 
 ### Matrix Test Audit
 


### PR DESCRIPTION
## What
Avoid redundant context compilation and implementation dispatch when resuming an active story whose checked tasks still conform to the current worktree. Keep the review diff file-backed for large changes.

## Why
Story-identifier resumes currently do not resolve active specs before context compilation, and completed work is dispatched again without a bounded conformance check. This adds avoidable model work and can make review consume unrelated history.
Fixes #2849

## How
- Resolve exact story identities before epic-context compilation.
- Add a bounded resumed-story preflight before implementation dispatch.
- Keep the complete diff in a temporary file and use summaries for parent verification.

## Testing
Validated strict skill and file-reference checks, 60 focused validator tests, base/after behavioral assertions, and `git diff --check`. The full pre-commit quality gate could not initialize its remote Ruff hook because GitHub was unreachable from the runner.