### PR TITLE
docs(diagrams): let the delivery loop's two slogans carry the accent

### DIFF
--- a/docs-site/scripts/export-readme-diagrams.mjs
+++ b/docs-site/scripts/export-readme-diagrams.mjs
@@ -44,6 +44,7 @@ const RAMP = {
   edge: '#8c96a3',
   ground: '#111418',
   accent: '#7fa0ff',
+  'accent-2': '#e0b25f',
   ok: '#6fcf97',
   'ok-tint': 'rgba(111, 207, 151, 0.1)',
   warn: '#e0b25f',
@@ -67,6 +68,8 @@ const STYLE = `
   .bmad-diagram .panel { fill: none; stroke: ${RAMP.line}; stroke-width: 1; stroke-dasharray: 4 4; }
   .bmad-diagram .panel-title { fill: ${RAMP.accent}; }
   .bmad-diagram .slogan { fill: ${RAMP.accent}; }
+  .bmad-diagram .slogan.alt { fill: ${RAMP['accent-2']}; }
+  .bmad-diagram .rule { fill: none; stroke: ${RAMP.line}; stroke-width: 1; }
   .bmad-diagram .edge { fill: none; stroke: ${RAMP.edge}; stroke-width: 1.5; }
   .bmad-diagram .edge.soft { stroke-width: 1.25; stroke-dasharray: 4 4; opacity: 0.85; }
   .bmad-diagram .edge.lens { opacity: 0.5; }

--- a/docs-site/scripts/export-readme-diagrams.mjs
+++ b/docs-site/scripts/export-readme-diagrams.mjs
@@ -74,6 +74,7 @@ const STYLE = `
     fill: ${RAMP.accent};
   }
   .bmad-diagram .slogan.alt { fill: ${RAMP.muted}; }
+  .bmad-diagram .grid { fill: none; stroke: ${RAMP.line}; stroke-opacity: 0.22; stroke-width: 1; }
   .bmad-diagram .rule { fill: none; stroke: ${RAMP.line}; stroke-width: 1; }
   .bmad-diagram .edge { fill: none; stroke: ${RAMP.edge}; stroke-width: 1.5; }
   .bmad-diagram .edge.soft { stroke-width: 1.25; stroke-dasharray: 4 4; opacity: 0.85; }

--- a/docs-site/scripts/export-readme-diagrams.mjs
+++ b/docs-site/scripts/export-readme-diagrams.mjs
@@ -44,7 +44,6 @@ const RAMP = {
   edge: '#8c96a3',
   ground: '#111418',
   accent: '#7fa0ff',
-  'accent-2': '#e0b25f',
   ok: '#6fcf97',
   'ok-tint': 'rgba(111, 207, 151, 0.1)',
   warn: '#e0b25f',
@@ -67,8 +66,14 @@ const STYLE = `
   .bmad-diagram .band { fill: ${RAMP.surface}; stroke: ${RAMP.line}; stroke-opacity: 0.28; stroke-width: 1; }
   .bmad-diagram .panel { fill: none; stroke: ${RAMP.line}; stroke-width: 1; stroke-dasharray: 4 4; }
   .bmad-diagram .panel-title { fill: ${RAMP.accent}; }
-  .bmad-diagram .slogan { fill: ${RAMP.accent}; }
-  .bmad-diagram .slogan.alt { fill: ${RAMP['accent-2']}; }
+  .bmad-diagram .slogan {
+    font-family: ${MONO};
+    font-size: 16px;
+    letter-spacing: 0.085em;
+    text-transform: uppercase;
+    fill: ${RAMP.accent};
+  }
+  .bmad-diagram .slogan.alt { fill: ${RAMP.muted}; }
   .bmad-diagram .rule { fill: none; stroke: ${RAMP.line}; stroke-width: 1; }
   .bmad-diagram .edge { fill: none; stroke: ${RAMP.edge}; stroke-width: 1.5; }
   .bmad-diagram .edge.soft { stroke-width: 1.25; stroke-dasharray: 4 4; opacity: 0.85; }

--- a/docs-site/scripts/export-readme-diagrams.mjs
+++ b/docs-site/scripts/export-readme-diagrams.mjs
@@ -66,6 +66,7 @@ const STYLE = `
   .bmad-diagram .band { fill: ${RAMP.surface}; stroke: ${RAMP.line}; stroke-opacity: 0.28; stroke-width: 1; }
   .bmad-diagram .panel { fill: none; stroke: ${RAMP.line}; stroke-width: 1; stroke-dasharray: 4 4; }
   .bmad-diagram .panel-title { fill: ${RAMP.accent}; }
+  .bmad-diagram .slogan { fill: ${RAMP.accent}; }
   .bmad-diagram .edge { fill: none; stroke: ${RAMP.edge}; stroke-width: 1.5; }
   .bmad-diagram .edge.soft { stroke-width: 1.25; stroke-dasharray: 4 4; opacity: 0.85; }
   .bmad-diagram .edge.lens { opacity: 0.5; }

--- a/docs-site/src/diagrams/bmad-delivery-loop.svg
+++ b/docs-site/src/diagrams/bmad-delivery-loop.svg
@@ -1,4 +1,4 @@
-<svg class="bmad-diagram" xmlns="http://www.w3.org/2000/svg" width="1120" height="460" viewBox="0 0 1120 460" role="img" aria-labelledby="title description">
+<svg class="bmad-diagram" xmlns="http://www.w3.org/2000/svg" width="1120" height="466" viewBox="0 0 1120 466" role="img" aria-labelledby="title description">
   <title id="title">The BMad delivery loop</title>
   <desc id="description">Three kinds of input enter the delivery loop at different points: a vague notion enters at Clarify, a big clear idea enters at Plan, and a small change goes straight to Build and verify. The loop continues through Learn and adjust, which feeds back into planning as the work evolves.</desc>
   <defs>
@@ -10,17 +10,22 @@
     </marker>
   </defs>
 
-  <!-- The two band labels sit outside the drawing's group and are the only
-       things the shift below does not move. Each is held 40 units clear of the
-       nearest mark: before this the title's baseline fell three units BELOW the
-       big bulb's top ray while the lower band had 35 units of air, so the pair
-       read as carelessly placed rather than as a frame. -->
+  <!-- The two slogans frame the drawing, so they are a matched pair: same size,
+       same weight, same accent, each held 40 units clear of the nearest mark.
+       They sit outside the drawing's group and are the only things the shift
+       below does not move.
+
+       The original said these in colour - gold above, pale blue below - and
+       carried them larger than the body around them. Dropping every colour to
+       make one drawing serve both themes took that with it and left two grey
+       lines nobody read. The accent is the theme's one colour, so it is what
+       says this here. -->
   <g text-anchor="middle">
-    <text x="560" y="28" fill="var(--dg-ink)" font-size="17.5" font-weight="700" letter-spacing="1.5" data-i18n="start-anywhere">START ANYWHERE</text>
-    <text x="560" y="444" fill="var(--dg-muted)" font-size="18" font-weight="600" letter-spacing="1.4" data-i18n="right-sized-for-the-work-in-front-">RIGHT-SIZED FOR THE WORK IN FRONT OF YOU</text>
+    <text class="slogan" x="560" y="31" font-size="22" font-weight="700" letter-spacing="1.8" data-i18n="start-anywhere">START ANYWHERE</text>
+    <text class="slogan" x="560" y="450" font-size="22" font-weight="700" letter-spacing="1.8" data-i18n="right-sized-for-the-work-in-front-">RIGHT-SIZED FOR THE WORK IN FRONT OF YOU</text>
   </g>
 
-  <g transform="translate(0 43)">
+  <g transform="translate(0 46)">
 
   <!-- Entry drops: each input lands where it enters the loop. These carry
        the accent, because where a piece of work joins is the one thing this

--- a/docs-site/src/diagrams/bmad-delivery-loop.svg
+++ b/docs-site/src/diagrams/bmad-delivery-loop.svg
@@ -1,4 +1,4 @@
-<svg class="bmad-diagram" xmlns="http://www.w3.org/2000/svg" width="1120" height="477" viewBox="0 0 1120 477" role="img" aria-labelledby="title description">
+<svg class="bmad-diagram" xmlns="http://www.w3.org/2000/svg" width="1120" height="465" viewBox="0 0 1120 465" role="img" aria-labelledby="title description">
   <title id="title">The BMad delivery loop</title>
   <desc id="description">Three kinds of input enter the delivery loop at different points: a vague notion enters at Clarify, a big clear idea enters at Plan, and a small change goes straight to Build and verify. The loop continues through Learn and adjust, which feeds back into planning as the work evolves.</desc>
   <defs>
@@ -10,24 +10,30 @@
     </marker>
   </defs>
 
-  <!-- Two banners closing on a hairline, which is how every section on the
-       marketing site ends. The rules run the drawing's own measure, 60 to 1060,
-       so the banners sit on the same grid as the boxes rather than floating
-       over it.
+  <!-- Two banners closing on a hairline, which is how every section of the
+       marketing site closes. The rules run the drawing's own measure, 60 to
+       1060, so the banners sit on the boxes' grid rather than floating over it.
 
-       The original said these in colour, gold above and pale blue below, and
-       carried them larger than the body around them. Dropping every colour so
-       one drawing could serve both themes took that with it and left two grey
-       lines nobody read. They are the only sentences here; a reader who skips
-       them gets four boxes and no argument. -->
+       The type is the site's label register, not a heading: IBM Plex Mono,
+       uppercase, weight 400, wide tracking. It is set larger than the site's
+       own 11px because this spans a metre of drawing rather than sitting over
+       a paragraph, but the register is the site's.
+
+       Colour follows the same rule the site uses for these labels - accent for
+       one that carries weight, muted for one that orients. So the opening takes
+       the accent, which is also what the three entry drops below it are drawn
+       in, and the closing summary sits quiet. An earlier pass gave the closing
+       line the site's copper; copper there is only ever a status - tag-warn,
+       the gate's CONCERNS heading, a flagged row - so it said "this is a
+       problem" about the diagram's own conclusion. -->
   <g text-anchor="middle">
-    <text class="slogan" x="560" y="31" font-size="22" font-weight="700" letter-spacing="1.8" data-i18n="start-anywhere">START ANYWHERE</text>
-    <path class="rule" d="M60 47H1060"/>
-    <path class="rule" d="M60 430H1060"/>
-    <text class="slogan alt" x="560" y="462" font-size="22" font-weight="700" letter-spacing="1.8" data-i18n="right-sized-for-the-work-in-front-">RIGHT-SIZED FOR THE WORK IN FRONT OF YOU</text>
+    <text class="slogan" x="560" y="27" data-i18n="start-anywhere">START ANYWHERE</text>
+    <path class="rule" d="M60 41H1060"/>
+    <path class="rule" d="M60 424H1060"/>
+    <text class="slogan alt" x="560" y="450" data-i18n="right-sized-for-the-work-in-front-">RIGHT-SIZED FOR THE WORK IN FRONT OF YOU</text>
   </g>
 
-  <g transform="translate(0 52)">
+  <g transform="translate(0 46)">
 
   <!-- Entry drops: each input lands where it enters the loop. These carry
        the accent, because where a piece of work joins is the one thing this

--- a/docs-site/src/diagrams/bmad-delivery-loop.svg
+++ b/docs-site/src/diagrams/bmad-delivery-loop.svg
@@ -33,6 +33,12 @@
     <text class="slogan alt" x="560" y="450" data-i18n="right-sized-for-the-work-in-front-">RIGHT-SIZED FOR THE WORK IN FRONT OF YOU</text>
   </g>
 
+  <!-- The field the original ruled behind the drawing, at its pitch: 70 apart
+       one way, 140 the other. It is held between the two hairlines so it reads
+       as what the banners enclose, and drawn in the line token at low opacity,
+       so it is a texture on either ramp rather than the fixed blue it was. -->
+  <path class="grid" d="M0 111H1120M0 181H1120M0 251H1120M0 321H1120M0 391H1120M140 41V424M280 41V424M420 41V424M560 41V424M700 41V424M840 41V424M980 41V424"/>
+
   <g transform="translate(0 46)">
 
   <!-- Entry drops: each input lands where it enters the loop. These carry
@@ -57,22 +63,29 @@
        A bulb the theme cannot colour has to be drawn as one: the earlier
        version leaned on gold to say "idea", and a circle over a tab in the
        body ink read as neither. The filament, the tapered neck and the ribbed
-       screw base carry it instead, so it stays a bulb on either ground. -->
-  <circle cx="425" cy="66" r="26" fill="var(--dg-surface)" stroke="var(--dg-ink)" stroke-width="2.5"/>
-  <path d="M417 84V76C417 66 433 66 433 76V84" fill="none" stroke="var(--dg-ink)" stroke-width="2" stroke-linecap="round"/>
-  <path d="M414.5 89L417 95M435.5 89L433 95" stroke="var(--dg-ink)" stroke-width="2.5" stroke-linecap="round"/>
-  <rect class="node" x="417" y="95" width="16" height="10" rx="1.5" stroke="var(--dg-ink)" stroke-width="2.5"/>
-  <path d="M417 98.5H433M417 101.5H433" stroke="var(--dg-ink)" stroke-width="1.2"/>
-  <path d="M401 42L394 35M449 42L456 35M425 34V25" stroke="var(--dg-ink)" stroke-width="2.5" stroke-linecap="round"/>
+       screw base carry it instead, so it stays a bulb on either ground.
+
+       Lit in the accent, the same hue as the entry drop below it. The original
+       drew its bulbs, its entry arrows and its opening line all in one gold,
+       and the loop itself in a cyan; accenting the drops alone had left the
+       bulbs outside a family they belong to. The cloud stays muted, as it was
+       there too - a vague notion is not yet an idea, and should not glow like
+       one. -->
+  <circle cx="425" cy="66" r="26" fill="var(--dg-surface)" stroke="var(--dg-accent)" stroke-width="2.5"/>
+  <path d="M417 84V76C417 66 433 66 433 76V84" fill="none" stroke="var(--dg-accent)" stroke-width="2" stroke-linecap="round"/>
+  <path d="M414.5 89L417 95M435.5 89L433 95" stroke="var(--dg-accent)" stroke-width="2.5" stroke-linecap="round"/>
+  <rect class="node" x="417" y="95" width="16" height="10" rx="1.5" stroke="var(--dg-accent)" stroke-width="2.5"/>
+  <path d="M417 98.5H433M417 101.5H433" stroke="var(--dg-accent)" stroke-width="1.2"/>
+  <path d="M401 42L394 35M449 42L456 35M425 34V25" stroke="var(--dg-accent)" stroke-width="2.5" stroke-linecap="round"/>
 
   <!-- Small change: small bulb. The same construction, one size down; the
        base takes a single rib rather than two, which is all that reads. -->
-  <circle cx="695" cy="80" r="14" fill="var(--dg-surface)" stroke="var(--dg-ink)" stroke-width="2"/>
-  <path d="M691 88V84C691 78 699 78 699 84V88" fill="none" stroke="var(--dg-ink)" stroke-width="1.5" stroke-linecap="round"/>
-  <path d="M689.5 92L690.5 96M700.5 92L699.5 96" stroke="var(--dg-ink)" stroke-width="2" stroke-linecap="round"/>
-  <rect class="node" x="690" y="96" width="10" height="7" rx="1.2" stroke="var(--dg-ink)" stroke-width="2"/>
-  <path d="M690 99.5H700" stroke="var(--dg-ink)" stroke-width="1"/>
-  <path d="M681.5 66.5L676.5 61.5M708.5 66.5L713.5 61.5M695 62V55" stroke="var(--dg-ink)" stroke-width="2" stroke-linecap="round"/>
+  <circle cx="695" cy="80" r="14" fill="var(--dg-surface)" stroke="var(--dg-accent)" stroke-width="2"/>
+  <path d="M691 88V84C691 78 699 78 699 84V88" fill="none" stroke="var(--dg-accent)" stroke-width="1.5" stroke-linecap="round"/>
+  <path d="M689.5 92L690.5 96M700.5 92L699.5 96" stroke="var(--dg-accent)" stroke-width="2" stroke-linecap="round"/>
+  <rect class="node" x="690" y="96" width="10" height="7" rx="1.2" stroke="var(--dg-accent)" stroke-width="2"/>
+  <path d="M690 99.5H700" stroke="var(--dg-accent)" stroke-width="1"/>
+  <path d="M681.5 66.5L676.5 61.5M708.5 66.5L713.5 61.5M695 62V55" stroke="var(--dg-accent)" stroke-width="2" stroke-linecap="round"/>
 
   <g text-anchor="middle">
     <text x="155" y="94" fill="var(--dg-muted)" font-size="32" font-weight="700" data-i18n="label">?</text>

--- a/docs-site/src/diagrams/bmad-delivery-loop.svg
+++ b/docs-site/src/diagrams/bmad-delivery-loop.svg
@@ -1,4 +1,4 @@
-<svg class="bmad-diagram" xmlns="http://www.w3.org/2000/svg" width="1120" height="466" viewBox="0 0 1120 466" role="img" aria-labelledby="title description">
+<svg class="bmad-diagram" xmlns="http://www.w3.org/2000/svg" width="1120" height="477" viewBox="0 0 1120 477" role="img" aria-labelledby="title description">
   <title id="title">The BMad delivery loop</title>
   <desc id="description">Three kinds of input enter the delivery loop at different points: a vague notion enters at Clarify, a big clear idea enters at Plan, and a small change goes straight to Build and verify. The loop continues through Learn and adjust, which feeds back into planning as the work evolves.</desc>
   <defs>
@@ -10,22 +10,24 @@
     </marker>
   </defs>
 
-  <!-- The two slogans frame the drawing, so they are a matched pair: same size,
-       same weight, same accent, each held 40 units clear of the nearest mark.
-       They sit outside the drawing's group and are the only things the shift
-       below does not move.
+  <!-- Two banners closing on a hairline, which is how every section on the
+       marketing site ends. The rules run the drawing's own measure, 60 to 1060,
+       so the banners sit on the same grid as the boxes rather than floating
+       over it.
 
-       The original said these in colour - gold above, pale blue below - and
-       carried them larger than the body around them. Dropping every colour to
-       make one drawing serve both themes took that with it and left two grey
-       lines nobody read. The accent is the theme's one colour, so it is what
-       says this here. -->
+       The original said these in colour, gold above and pale blue below, and
+       carried them larger than the body around them. Dropping every colour so
+       one drawing could serve both themes took that with it and left two grey
+       lines nobody read. They are the only sentences here; a reader who skips
+       them gets four boxes and no argument. -->
   <g text-anchor="middle">
     <text class="slogan" x="560" y="31" font-size="22" font-weight="700" letter-spacing="1.8" data-i18n="start-anywhere">START ANYWHERE</text>
-    <text class="slogan" x="560" y="450" font-size="22" font-weight="700" letter-spacing="1.8" data-i18n="right-sized-for-the-work-in-front-">RIGHT-SIZED FOR THE WORK IN FRONT OF YOU</text>
+    <path class="rule" d="M60 47H1060"/>
+    <path class="rule" d="M60 430H1060"/>
+    <text class="slogan alt" x="560" y="462" font-size="22" font-weight="700" letter-spacing="1.8" data-i18n="right-sized-for-the-work-in-front-">RIGHT-SIZED FOR THE WORK IN FRONT OF YOU</text>
   </g>
 
-  <g transform="translate(0 46)">
+  <g transform="translate(0 52)">
 
   <!-- Entry drops: each input lands where it enters the loop. These carry
        the accent, because where a piece of work joins is the one thing this

--- a/docs-site/src/styles/custom.css
+++ b/docs-site/src/styles/custom.css
@@ -555,6 +555,21 @@ starlight-toc h2,
   fill: var(--dg-muted);
 }
 
+/* A ruled field behind a drawing. Faint enough to be texture, never structure:
+   at this opacity it survives both ramps without competing with the edges. */
+.bmad-diagram .grid {
+  fill: none;
+  stroke: var(--dg-line);
+  stroke-opacity: 0.35;
+  stroke-width: 1;
+}
+
+/* The dark line sits further from its ground than the light one does, so the
+   same opacity reads as structure there rather than texture. */
+:root[data-theme='dark'] .bmad-diagram .grid {
+  stroke-opacity: 0.22;
+}
+
 .bmad-diagram .rule {
   fill: none;
   stroke: var(--dg-line);

--- a/docs-site/src/styles/custom.css
+++ b/docs-site/src/styles/custom.css
@@ -376,10 +376,6 @@ starlight-toc h2,
   --dg-edge: var(--bmad-muted-ink-2);
   --dg-ground: var(--bmad-white);
   --dg-accent: var(--bmad-accent);
-  /* The site's copper, and the nearest thing this palette holds to the gold the
-     delivery loop used to open with. Paired with the accent it gives a drawing
-     two framing hues without inventing one. */
-  --dg-accent-2: var(--bmad-copper);
   --dg-ok: #1f6b3b;
   --dg-ok-tint: #edf6f0;
   --dg-warn: #8a5a00;
@@ -399,9 +395,6 @@ starlight-toc h2,
   --dg-muted: #8c96a3;
   --dg-edge: #8c96a3;
   --dg-ground: var(--bmad-dark);
-  /* the copper lifted for a dark ground; `--bmad-copper` itself is far too dark
-     to read here, and the ramp has no on-dark variant of it */
-  --dg-accent-2: #e0b25f;
   --dg-ok: #6fcf97;
   --dg-ok-tint: rgba(111, 207, 151, 0.1);
   --dg-warn: #e0b25f;
@@ -540,16 +533,26 @@ starlight-toc h2,
   fill: var(--dg-accent);
 }
 
-/* A line that frames a drawing rather than labelling part of it, closing on a
-   hairline the way every section of the marketing site does. Reserved for the
-   one or two a diagram is allowed, so the hues stay scarce; `alt` is the second
-   of a pair, so the two ends of a drawing do not read as the same statement. */
+/* The two lines that frame a drawing rather than label part of it, closing on
+   a hairline the way every section of the marketing site closes.
+
+   This is the site's label register, not a heading: mono, uppercase, weight
+   400, wide tracking. Colour follows the site's own rule for these - the accent
+   for a label that carries weight, muted for one that only orients - so a
+   drawing's opening and its closing summary are told apart without a second
+   hue. The site has no second hue to borrow: its copper is a status colour
+   (`tag-warn`, the gate's CONCERNS heading) and reads as a problem anywhere
+   else. */
 .bmad-diagram .slogan {
+  font-family: var(--bmad-mono);
+  font-size: 16px;
+  letter-spacing: 0.085em;
+  text-transform: uppercase;
   fill: var(--dg-accent);
 }
 
 .bmad-diagram .slogan.alt {
-  fill: var(--dg-accent-2);
+  fill: var(--dg-muted);
 }
 
 .bmad-diagram .rule {

--- a/docs-site/src/styles/custom.css
+++ b/docs-site/src/styles/custom.css
@@ -533,6 +533,12 @@ starlight-toc h2,
   fill: var(--dg-accent);
 }
 
+/* A line that frames a drawing rather than labelling part of it. Reserved for
+   the one or two a diagram is allowed, so the accent stays scarce. */
+.bmad-diagram .slogan {
+  fill: var(--dg-accent);
+}
+
 /* ---------------------------------------------------------------
    Asides
    A tinted plate, an icon and a heading in the hue — the shape the

--- a/docs-site/src/styles/custom.css
+++ b/docs-site/src/styles/custom.css
@@ -376,6 +376,10 @@ starlight-toc h2,
   --dg-edge: var(--bmad-muted-ink-2);
   --dg-ground: var(--bmad-white);
   --dg-accent: var(--bmad-accent);
+  /* The site's copper, and the nearest thing this palette holds to the gold the
+     delivery loop used to open with. Paired with the accent it gives a drawing
+     two framing hues without inventing one. */
+  --dg-accent-2: var(--bmad-copper);
   --dg-ok: #1f6b3b;
   --dg-ok-tint: #edf6f0;
   --dg-warn: #8a5a00;
@@ -395,6 +399,9 @@ starlight-toc h2,
   --dg-muted: #8c96a3;
   --dg-edge: #8c96a3;
   --dg-ground: var(--bmad-dark);
+  /* the copper lifted for a dark ground; `--bmad-copper` itself is far too dark
+     to read here, and the ramp has no on-dark variant of it */
+  --dg-accent-2: #e0b25f;
   --dg-ok: #6fcf97;
   --dg-ok-tint: rgba(111, 207, 151, 0.1);
   --dg-warn: #e0b25f;
@@ -533,10 +540,22 @@ starlight-toc h2,
   fill: var(--dg-accent);
 }
 
-/* A line that frames a drawing rather than labelling part of it. Reserved for
-   the one or two a diagram is allowed, so the accent stays scarce. */
+/* A line that frames a drawing rather than labelling part of it, closing on a
+   hairline the way every section of the marketing site does. Reserved for the
+   one or two a diagram is allowed, so the hues stay scarce; `alt` is the second
+   of a pair, so the two ends of a drawing do not read as the same statement. */
 .bmad-diagram .slogan {
   fill: var(--dg-accent);
+}
+
+.bmad-diagram .slogan.alt {
+  fill: var(--dg-accent-2);
+}
+
+.bmad-diagram .rule {
+  fill: none;
+  stroke: var(--dg-line);
+  stroke-width: 1;
 }
 
 /* ---------------------------------------------------------------

--- a/docs/images/bmad-delivery-loop-ko.svg
+++ b/docs/images/bmad-delivery-loop-ko.svg
@@ -1,4 +1,4 @@
-<svg class="bmad-diagram" xmlns="http://www.w3.org/2000/svg" width="1120" height="466" viewBox="0 0 1120 466" role="img" aria-labelledby="title description">
+<svg class="bmad-diagram" xmlns="http://www.w3.org/2000/svg" width="1120" height="477" viewBox="0 0 1120 477" role="img" aria-labelledby="title description">
   <style>
   .bmad-diagram { font-family: -apple-system, 'Segoe UI', Helvetica, Arial, sans-serif; }
   .bmad-diagram text { fill: #e6eaf0; }
@@ -12,6 +12,8 @@
   .bmad-diagram .panel { fill: none; stroke: #404854; stroke-width: 1; stroke-dasharray: 4 4; }
   .bmad-diagram .panel-title { fill: #7fa0ff; }
   .bmad-diagram .slogan { fill: #7fa0ff; }
+  .bmad-diagram .slogan.alt { fill: #e0b25f; }
+  .bmad-diagram .rule { fill: none; stroke: #404854; stroke-width: 1; }
   .bmad-diagram .edge { fill: none; stroke: #8c96a3; stroke-width: 1.5; }
   .bmad-diagram .edge.soft { stroke-width: 1.25; stroke-dasharray: 4 4; opacity: 0.85; }
   .bmad-diagram .edge.lens { opacity: 0.5; }
@@ -33,7 +35,7 @@
     fill: #8c96a3;
   }
   </style>
-  <rect width="1120" height="466" rx="20" fill="#111418"/>
+  <rect width="1120" height="477" rx="20" fill="#111418"/>
   <title id="title">The BMad delivery loop</title>
   <desc id="description">Three kinds of input enter the delivery loop at different points: a vague notion enters at Clarify, a big clear idea enters at Plan, and a small change goes straight to Build and verify. The loop continues through Learn and adjust, which feeds back into planning as the work evolves.</desc>
   <defs>
@@ -45,22 +47,24 @@
     </marker>
   </defs>
 
-  <!-- The two slogans frame the drawing, so they are a matched pair: same size,
-       same weight, same accent, each held 40 units clear of the nearest mark.
-       They sit outside the drawing's group and are the only things the shift
-       below does not move.
+  <!-- Two banners closing on a hairline, which is how every section on the
+       marketing site ends. The rules run the drawing's own measure, 60 to 1060,
+       so the banners sit on the same grid as the boxes rather than floating
+       over it.
 
-       The original said these in colour - gold above, pale blue below - and
-       carried them larger than the body around them. Dropping every colour to
-       make one drawing serve both themes took that with it and left two grey
-       lines nobody read. The accent is the theme's one colour, so it is what
-       says this here. -->
+       The original said these in colour, gold above and pale blue below, and
+       carried them larger than the body around them. Dropping every colour so
+       one drawing could serve both themes took that with it and left two grey
+       lines nobody read. They are the only sentences here; a reader who skips
+       them gets four boxes and no argument. -->
   <g text-anchor="middle">
     <text class="slogan" x="560" y="31" font-size="22" font-weight="700" letter-spacing="1.8" data-i18n="start-anywhere">어디서든 시작</text>
-    <text class="slogan" x="560" y="450" font-size="22" font-weight="700" letter-spacing="1.8" data-i18n="right-sized-for-the-work-in-front-">눈앞의 작업에 꼭 맞는 절차</text>
+    <path class="rule" d="M60 47H1060"/>
+    <path class="rule" d="M60 430H1060"/>
+    <text class="slogan alt" x="560" y="462" font-size="22" font-weight="700" letter-spacing="1.8" data-i18n="right-sized-for-the-work-in-front-">눈앞의 작업에 꼭 맞는 절차</text>
   </g>
 
-  <g transform="translate(0 46)">
+  <g transform="translate(0 52)">
 
   <!-- Entry drops: each input lands where it enters the loop. These carry
        the accent, because where a piece of work joins is the one thing this

--- a/docs/images/bmad-delivery-loop-ko.svg
+++ b/docs/images/bmad-delivery-loop-ko.svg
@@ -1,4 +1,4 @@
-<svg class="bmad-diagram" xmlns="http://www.w3.org/2000/svg" width="1120" height="460" viewBox="0 0 1120 460" role="img" aria-labelledby="title description">
+<svg class="bmad-diagram" xmlns="http://www.w3.org/2000/svg" width="1120" height="466" viewBox="0 0 1120 466" role="img" aria-labelledby="title description">
   <style>
   .bmad-diagram { font-family: -apple-system, 'Segoe UI', Helvetica, Arial, sans-serif; }
   .bmad-diagram text { fill: #e6eaf0; }
@@ -11,6 +11,7 @@
   .bmad-diagram .band { fill: #1a1e24; stroke: #404854; stroke-opacity: 0.28; stroke-width: 1; }
   .bmad-diagram .panel { fill: none; stroke: #404854; stroke-width: 1; stroke-dasharray: 4 4; }
   .bmad-diagram .panel-title { fill: #7fa0ff; }
+  .bmad-diagram .slogan { fill: #7fa0ff; }
   .bmad-diagram .edge { fill: none; stroke: #8c96a3; stroke-width: 1.5; }
   .bmad-diagram .edge.soft { stroke-width: 1.25; stroke-dasharray: 4 4; opacity: 0.85; }
   .bmad-diagram .edge.lens { opacity: 0.5; }
@@ -32,7 +33,7 @@
     fill: #8c96a3;
   }
   </style>
-  <rect width="1120" height="460" rx="20" fill="#111418"/>
+  <rect width="1120" height="466" rx="20" fill="#111418"/>
   <title id="title">The BMad delivery loop</title>
   <desc id="description">Three kinds of input enter the delivery loop at different points: a vague notion enters at Clarify, a big clear idea enters at Plan, and a small change goes straight to Build and verify. The loop continues through Learn and adjust, which feeds back into planning as the work evolves.</desc>
   <defs>
@@ -44,17 +45,22 @@
     </marker>
   </defs>
 
-  <!-- The two band labels sit outside the drawing's group and are the only
-       things the shift below does not move. Each is held 40 units clear of the
-       nearest mark: before this the title's baseline fell three units BELOW the
-       big bulb's top ray while the lower band had 35 units of air, so the pair
-       read as carelessly placed rather than as a frame. -->
+  <!-- The two slogans frame the drawing, so they are a matched pair: same size,
+       same weight, same accent, each held 40 units clear of the nearest mark.
+       They sit outside the drawing's group and are the only things the shift
+       below does not move.
+
+       The original said these in colour - gold above, pale blue below - and
+       carried them larger than the body around them. Dropping every colour to
+       make one drawing serve both themes took that with it and left two grey
+       lines nobody read. The accent is the theme's one colour, so it is what
+       says this here. -->
   <g text-anchor="middle">
-    <text x="560" y="28" fill="#e6eaf0" font-size="17.5" font-weight="700" letter-spacing="1.5" data-i18n="start-anywhere">어디서든 시작</text>
-    <text x="560" y="444" fill="#8c96a3" font-size="18" font-weight="600" letter-spacing="1.4" data-i18n="right-sized-for-the-work-in-front-">눈앞의 작업에 꼭 맞는 절차</text>
+    <text class="slogan" x="560" y="31" font-size="22" font-weight="700" letter-spacing="1.8" data-i18n="start-anywhere">어디서든 시작</text>
+    <text class="slogan" x="560" y="450" font-size="22" font-weight="700" letter-spacing="1.8" data-i18n="right-sized-for-the-work-in-front-">눈앞의 작업에 꼭 맞는 절차</text>
   </g>
 
-  <g transform="translate(0 43)">
+  <g transform="translate(0 46)">
 
   <!-- Entry drops: each input lands where it enters the loop. These carry
        the accent, because where a piece of work joins is the one thing this

--- a/docs/images/bmad-delivery-loop-ko.svg
+++ b/docs/images/bmad-delivery-loop-ko.svg
@@ -1,4 +1,4 @@
-<svg class="bmad-diagram" xmlns="http://www.w3.org/2000/svg" width="1120" height="477" viewBox="0 0 1120 477" role="img" aria-labelledby="title description">
+<svg class="bmad-diagram" xmlns="http://www.w3.org/2000/svg" width="1120" height="465" viewBox="0 0 1120 465" role="img" aria-labelledby="title description">
   <style>
   .bmad-diagram { font-family: -apple-system, 'Segoe UI', Helvetica, Arial, sans-serif; }
   .bmad-diagram text { fill: #e6eaf0; }
@@ -11,8 +11,14 @@
   .bmad-diagram .band { fill: #1a1e24; stroke: #404854; stroke-opacity: 0.28; stroke-width: 1; }
   .bmad-diagram .panel { fill: none; stroke: #404854; stroke-width: 1; stroke-dasharray: 4 4; }
   .bmad-diagram .panel-title { fill: #7fa0ff; }
-  .bmad-diagram .slogan { fill: #7fa0ff; }
-  .bmad-diagram .slogan.alt { fill: #e0b25f; }
+  .bmad-diagram .slogan {
+    font-family: ui-monospace, SFMono-Regular, Menlo, monospace;
+    font-size: 16px;
+    letter-spacing: 0.085em;
+    text-transform: uppercase;
+    fill: #7fa0ff;
+  }
+  .bmad-diagram .slogan.alt { fill: #8c96a3; }
   .bmad-diagram .rule { fill: none; stroke: #404854; stroke-width: 1; }
   .bmad-diagram .edge { fill: none; stroke: #8c96a3; stroke-width: 1.5; }
   .bmad-diagram .edge.soft { stroke-width: 1.25; stroke-dasharray: 4 4; opacity: 0.85; }
@@ -35,7 +41,7 @@
     fill: #8c96a3;
   }
   </style>
-  <rect width="1120" height="477" rx="20" fill="#111418"/>
+  <rect width="1120" height="465" rx="20" fill="#111418"/>
   <title id="title">The BMad delivery loop</title>
   <desc id="description">Three kinds of input enter the delivery loop at different points: a vague notion enters at Clarify, a big clear idea enters at Plan, and a small change goes straight to Build and verify. The loop continues through Learn and adjust, which feeds back into planning as the work evolves.</desc>
   <defs>
@@ -47,24 +53,30 @@
     </marker>
   </defs>
 
-  <!-- Two banners closing on a hairline, which is how every section on the
-       marketing site ends. The rules run the drawing's own measure, 60 to 1060,
-       so the banners sit on the same grid as the boxes rather than floating
-       over it.
+  <!-- Two banners closing on a hairline, which is how every section of the
+       marketing site closes. The rules run the drawing's own measure, 60 to
+       1060, so the banners sit on the boxes' grid rather than floating over it.
 
-       The original said these in colour, gold above and pale blue below, and
-       carried them larger than the body around them. Dropping every colour so
-       one drawing could serve both themes took that with it and left two grey
-       lines nobody read. They are the only sentences here; a reader who skips
-       them gets four boxes and no argument. -->
+       The type is the site's label register, not a heading: IBM Plex Mono,
+       uppercase, weight 400, wide tracking. It is set larger than the site's
+       own 11px because this spans a metre of drawing rather than sitting over
+       a paragraph, but the register is the site's.
+
+       Colour follows the same rule the site uses for these labels - accent for
+       one that carries weight, muted for one that orients. So the opening takes
+       the accent, which is also what the three entry drops below it are drawn
+       in, and the closing summary sits quiet. An earlier pass gave the closing
+       line the site's copper; copper there is only ever a status - tag-warn,
+       the gate's CONCERNS heading, a flagged row - so it said "this is a
+       problem" about the diagram's own conclusion. -->
   <g text-anchor="middle">
-    <text class="slogan" x="560" y="31" font-size="22" font-weight="700" letter-spacing="1.8" data-i18n="start-anywhere">어디서든 시작</text>
-    <path class="rule" d="M60 47H1060"/>
-    <path class="rule" d="M60 430H1060"/>
-    <text class="slogan alt" x="560" y="462" font-size="22" font-weight="700" letter-spacing="1.8" data-i18n="right-sized-for-the-work-in-front-">눈앞의 작업에 꼭 맞는 절차</text>
+    <text class="slogan" x="560" y="27" data-i18n="start-anywhere">어디서든 시작</text>
+    <path class="rule" d="M60 41H1060"/>
+    <path class="rule" d="M60 424H1060"/>
+    <text class="slogan alt" x="560" y="450" data-i18n="right-sized-for-the-work-in-front-">눈앞의 작업에 꼭 맞는 절차</text>
   </g>
 
-  <g transform="translate(0 52)">
+  <g transform="translate(0 46)">
 
   <!-- Entry drops: each input lands where it enters the loop. These carry
        the accent, because where a piece of work joins is the one thing this

--- a/docs/images/bmad-delivery-loop-ko.svg
+++ b/docs/images/bmad-delivery-loop-ko.svg
@@ -19,6 +19,7 @@
     fill: #7fa0ff;
   }
   .bmad-diagram .slogan.alt { fill: #8c96a3; }
+  .bmad-diagram .grid { fill: none; stroke: #404854; stroke-opacity: 0.22; stroke-width: 1; }
   .bmad-diagram .rule { fill: none; stroke: #404854; stroke-width: 1; }
   .bmad-diagram .edge { fill: none; stroke: #8c96a3; stroke-width: 1.5; }
   .bmad-diagram .edge.soft { stroke-width: 1.25; stroke-dasharray: 4 4; opacity: 0.85; }
@@ -76,6 +77,12 @@
     <text class="slogan alt" x="560" y="450" data-i18n="right-sized-for-the-work-in-front-">눈앞의 작업에 꼭 맞는 절차</text>
   </g>
 
+  <!-- The field the original ruled behind the drawing, at its pitch: 70 apart
+       one way, 140 the other. It is held between the two hairlines so it reads
+       as what the banners enclose, and drawn in the line token at low opacity,
+       so it is a texture on either ramp rather than the fixed blue it was. -->
+  <path class="grid" d="M0 111H1120M0 181H1120M0 251H1120M0 321H1120M0 391H1120M140 41V424M280 41V424M420 41V424M560 41V424M700 41V424M840 41V424M980 41V424"/>
+
   <g transform="translate(0 46)">
 
   <!-- Entry drops: each input lands where it enters the loop. These carry
@@ -100,22 +107,29 @@
        A bulb the theme cannot colour has to be drawn as one: the earlier
        version leaned on gold to say "idea", and a circle over a tab in the
        body ink read as neither. The filament, the tapered neck and the ribbed
-       screw base carry it instead, so it stays a bulb on either ground. -->
-  <circle cx="425" cy="66" r="26" fill="#1a1e24" stroke="#e6eaf0" stroke-width="2.5"/>
-  <path d="M417 84V76C417 66 433 66 433 76V84" fill="none" stroke="#e6eaf0" stroke-width="2" stroke-linecap="round"/>
-  <path d="M414.5 89L417 95M435.5 89L433 95" stroke="#e6eaf0" stroke-width="2.5" stroke-linecap="round"/>
-  <rect class="node" x="417" y="95" width="16" height="10" rx="1.5" stroke="#e6eaf0" stroke-width="2.5"/>
-  <path d="M417 98.5H433M417 101.5H433" stroke="#e6eaf0" stroke-width="1.2"/>
-  <path d="M401 42L394 35M449 42L456 35M425 34V25" stroke="#e6eaf0" stroke-width="2.5" stroke-linecap="round"/>
+       screw base carry it instead, so it stays a bulb on either ground.
+
+       Lit in the accent, the same hue as the entry drop below it. The original
+       drew its bulbs, its entry arrows and its opening line all in one gold,
+       and the loop itself in a cyan; accenting the drops alone had left the
+       bulbs outside a family they belong to. The cloud stays muted, as it was
+       there too - a vague notion is not yet an idea, and should not glow like
+       one. -->
+  <circle cx="425" cy="66" r="26" fill="#1a1e24" stroke="#7fa0ff" stroke-width="2.5"/>
+  <path d="M417 84V76C417 66 433 66 433 76V84" fill="none" stroke="#7fa0ff" stroke-width="2" stroke-linecap="round"/>
+  <path d="M414.5 89L417 95M435.5 89L433 95" stroke="#7fa0ff" stroke-width="2.5" stroke-linecap="round"/>
+  <rect class="node" x="417" y="95" width="16" height="10" rx="1.5" stroke="#7fa0ff" stroke-width="2.5"/>
+  <path d="M417 98.5H433M417 101.5H433" stroke="#7fa0ff" stroke-width="1.2"/>
+  <path d="M401 42L394 35M449 42L456 35M425 34V25" stroke="#7fa0ff" stroke-width="2.5" stroke-linecap="round"/>
 
   <!-- Small change: small bulb. The same construction, one size down; the
        base takes a single rib rather than two, which is all that reads. -->
-  <circle cx="695" cy="80" r="14" fill="#1a1e24" stroke="#e6eaf0" stroke-width="2"/>
-  <path d="M691 88V84C691 78 699 78 699 84V88" fill="none" stroke="#e6eaf0" stroke-width="1.5" stroke-linecap="round"/>
-  <path d="M689.5 92L690.5 96M700.5 92L699.5 96" stroke="#e6eaf0" stroke-width="2" stroke-linecap="round"/>
-  <rect class="node" x="690" y="96" width="10" height="7" rx="1.2" stroke="#e6eaf0" stroke-width="2"/>
-  <path d="M690 99.5H700" stroke="#e6eaf0" stroke-width="1"/>
-  <path d="M681.5 66.5L676.5 61.5M708.5 66.5L713.5 61.5M695 62V55" stroke="#e6eaf0" stroke-width="2" stroke-linecap="round"/>
+  <circle cx="695" cy="80" r="14" fill="#1a1e24" stroke="#7fa0ff" stroke-width="2"/>
+  <path d="M691 88V84C691 78 699 78 699 84V88" fill="none" stroke="#7fa0ff" stroke-width="1.5" stroke-linecap="round"/>
+  <path d="M689.5 92L690.5 96M700.5 92L699.5 96" stroke="#7fa0ff" stroke-width="2" stroke-linecap="round"/>
+  <rect class="node" x="690" y="96" width="10" height="7" rx="1.2" stroke="#7fa0ff" stroke-width="2"/>
+  <path d="M690 99.5H700" stroke="#7fa0ff" stroke-width="1"/>
+  <path d="M681.5 66.5L676.5 61.5M708.5 66.5L713.5 61.5M695 62V55" stroke="#7fa0ff" stroke-width="2" stroke-linecap="round"/>
 
   <g text-anchor="middle">
     <text x="155" y="94" fill="#8c96a3" font-size="32" font-weight="700" data-i18n="label">?</text>

--- a/docs/images/bmad-delivery-loop.svg
+++ b/docs/images/bmad-delivery-loop.svg
@@ -1,4 +1,4 @@
-<svg class="bmad-diagram" xmlns="http://www.w3.org/2000/svg" width="1120" height="460" viewBox="0 0 1120 460" role="img" aria-labelledby="title description">
+<svg class="bmad-diagram" xmlns="http://www.w3.org/2000/svg" width="1120" height="466" viewBox="0 0 1120 466" role="img" aria-labelledby="title description">
   <style>
   .bmad-diagram { font-family: -apple-system, 'Segoe UI', Helvetica, Arial, sans-serif; }
   .bmad-diagram text { fill: #e6eaf0; }
@@ -11,6 +11,7 @@
   .bmad-diagram .band { fill: #1a1e24; stroke: #404854; stroke-opacity: 0.28; stroke-width: 1; }
   .bmad-diagram .panel { fill: none; stroke: #404854; stroke-width: 1; stroke-dasharray: 4 4; }
   .bmad-diagram .panel-title { fill: #7fa0ff; }
+  .bmad-diagram .slogan { fill: #7fa0ff; }
   .bmad-diagram .edge { fill: none; stroke: #8c96a3; stroke-width: 1.5; }
   .bmad-diagram .edge.soft { stroke-width: 1.25; stroke-dasharray: 4 4; opacity: 0.85; }
   .bmad-diagram .edge.lens { opacity: 0.5; }
@@ -32,7 +33,7 @@
     fill: #8c96a3;
   }
   </style>
-  <rect width="1120" height="460" rx="20" fill="#111418"/>
+  <rect width="1120" height="466" rx="20" fill="#111418"/>
   <title id="title">The BMad delivery loop</title>
   <desc id="description">Three kinds of input enter the delivery loop at different points: a vague notion enters at Clarify, a big clear idea enters at Plan, and a small change goes straight to Build and verify. The loop continues through Learn and adjust, which feeds back into planning as the work evolves.</desc>
   <defs>
@@ -44,17 +45,22 @@
     </marker>
   </defs>
 
-  <!-- The two band labels sit outside the drawing's group and are the only
-       things the shift below does not move. Each is held 40 units clear of the
-       nearest mark: before this the title's baseline fell three units BELOW the
-       big bulb's top ray while the lower band had 35 units of air, so the pair
-       read as carelessly placed rather than as a frame. -->
+  <!-- The two slogans frame the drawing, so they are a matched pair: same size,
+       same weight, same accent, each held 40 units clear of the nearest mark.
+       They sit outside the drawing's group and are the only things the shift
+       below does not move.
+
+       The original said these in colour - gold above, pale blue below - and
+       carried them larger than the body around them. Dropping every colour to
+       make one drawing serve both themes took that with it and left two grey
+       lines nobody read. The accent is the theme's one colour, so it is what
+       says this here. -->
   <g text-anchor="middle">
-    <text x="560" y="28" fill="#e6eaf0" font-size="17.5" font-weight="700" letter-spacing="1.5" data-i18n="start-anywhere">START ANYWHERE</text>
-    <text x="560" y="444" fill="#8c96a3" font-size="18" font-weight="600" letter-spacing="1.4" data-i18n="right-sized-for-the-work-in-front-">RIGHT-SIZED FOR THE WORK IN FRONT OF YOU</text>
+    <text class="slogan" x="560" y="31" font-size="22" font-weight="700" letter-spacing="1.8" data-i18n="start-anywhere">START ANYWHERE</text>
+    <text class="slogan" x="560" y="450" font-size="22" font-weight="700" letter-spacing="1.8" data-i18n="right-sized-for-the-work-in-front-">RIGHT-SIZED FOR THE WORK IN FRONT OF YOU</text>
   </g>
 
-  <g transform="translate(0 43)">
+  <g transform="translate(0 46)">
 
   <!-- Entry drops: each input lands where it enters the loop. These carry
        the accent, because where a piece of work joins is the one thing this

--- a/docs/images/bmad-delivery-loop.svg
+++ b/docs/images/bmad-delivery-loop.svg
@@ -1,4 +1,4 @@
-<svg class="bmad-diagram" xmlns="http://www.w3.org/2000/svg" width="1120" height="477" viewBox="0 0 1120 477" role="img" aria-labelledby="title description">
+<svg class="bmad-diagram" xmlns="http://www.w3.org/2000/svg" width="1120" height="465" viewBox="0 0 1120 465" role="img" aria-labelledby="title description">
   <style>
   .bmad-diagram { font-family: -apple-system, 'Segoe UI', Helvetica, Arial, sans-serif; }
   .bmad-diagram text { fill: #e6eaf0; }
@@ -11,8 +11,14 @@
   .bmad-diagram .band { fill: #1a1e24; stroke: #404854; stroke-opacity: 0.28; stroke-width: 1; }
   .bmad-diagram .panel { fill: none; stroke: #404854; stroke-width: 1; stroke-dasharray: 4 4; }
   .bmad-diagram .panel-title { fill: #7fa0ff; }
-  .bmad-diagram .slogan { fill: #7fa0ff; }
-  .bmad-diagram .slogan.alt { fill: #e0b25f; }
+  .bmad-diagram .slogan {
+    font-family: ui-monospace, SFMono-Regular, Menlo, monospace;
+    font-size: 16px;
+    letter-spacing: 0.085em;
+    text-transform: uppercase;
+    fill: #7fa0ff;
+  }
+  .bmad-diagram .slogan.alt { fill: #8c96a3; }
   .bmad-diagram .rule { fill: none; stroke: #404854; stroke-width: 1; }
   .bmad-diagram .edge { fill: none; stroke: #8c96a3; stroke-width: 1.5; }
   .bmad-diagram .edge.soft { stroke-width: 1.25; stroke-dasharray: 4 4; opacity: 0.85; }
@@ -35,7 +41,7 @@
     fill: #8c96a3;
   }
   </style>
-  <rect width="1120" height="477" rx="20" fill="#111418"/>
+  <rect width="1120" height="465" rx="20" fill="#111418"/>
   <title id="title">The BMad delivery loop</title>
   <desc id="description">Three kinds of input enter the delivery loop at different points: a vague notion enters at Clarify, a big clear idea enters at Plan, and a small change goes straight to Build and verify. The loop continues through Learn and adjust, which feeds back into planning as the work evolves.</desc>
   <defs>
@@ -47,24 +53,30 @@
     </marker>
   </defs>
 
-  <!-- Two banners closing on a hairline, which is how every section on the
-       marketing site ends. The rules run the drawing's own measure, 60 to 1060,
-       so the banners sit on the same grid as the boxes rather than floating
-       over it.
+  <!-- Two banners closing on a hairline, which is how every section of the
+       marketing site closes. The rules run the drawing's own measure, 60 to
+       1060, so the banners sit on the boxes' grid rather than floating over it.
 
-       The original said these in colour, gold above and pale blue below, and
-       carried them larger than the body around them. Dropping every colour so
-       one drawing could serve both themes took that with it and left two grey
-       lines nobody read. They are the only sentences here; a reader who skips
-       them gets four boxes and no argument. -->
+       The type is the site's label register, not a heading: IBM Plex Mono,
+       uppercase, weight 400, wide tracking. It is set larger than the site's
+       own 11px because this spans a metre of drawing rather than sitting over
+       a paragraph, but the register is the site's.
+
+       Colour follows the same rule the site uses for these labels - accent for
+       one that carries weight, muted for one that orients. So the opening takes
+       the accent, which is also what the three entry drops below it are drawn
+       in, and the closing summary sits quiet. An earlier pass gave the closing
+       line the site's copper; copper there is only ever a status - tag-warn,
+       the gate's CONCERNS heading, a flagged row - so it said "this is a
+       problem" about the diagram's own conclusion. -->
   <g text-anchor="middle">
-    <text class="slogan" x="560" y="31" font-size="22" font-weight="700" letter-spacing="1.8" data-i18n="start-anywhere">START ANYWHERE</text>
-    <path class="rule" d="M60 47H1060"/>
-    <path class="rule" d="M60 430H1060"/>
-    <text class="slogan alt" x="560" y="462" font-size="22" font-weight="700" letter-spacing="1.8" data-i18n="right-sized-for-the-work-in-front-">RIGHT-SIZED FOR THE WORK IN FRONT OF YOU</text>
+    <text class="slogan" x="560" y="27" data-i18n="start-anywhere">START ANYWHERE</text>
+    <path class="rule" d="M60 41H1060"/>
+    <path class="rule" d="M60 424H1060"/>
+    <text class="slogan alt" x="560" y="450" data-i18n="right-sized-for-the-work-in-front-">RIGHT-SIZED FOR THE WORK IN FRONT OF YOU</text>
   </g>
 
-  <g transform="translate(0 52)">
+  <g transform="translate(0 46)">
 
   <!-- Entry drops: each input lands where it enters the loop. These carry
        the accent, because where a piece of work joins is the one thing this

--- a/docs/images/bmad-delivery-loop.svg
+++ b/docs/images/bmad-delivery-loop.svg
@@ -1,4 +1,4 @@
-<svg class="bmad-diagram" xmlns="http://www.w3.org/2000/svg" width="1120" height="466" viewBox="0 0 1120 466" role="img" aria-labelledby="title description">
+<svg class="bmad-diagram" xmlns="http://www.w3.org/2000/svg" width="1120" height="477" viewBox="0 0 1120 477" role="img" aria-labelledby="title description">
   <style>
   .bmad-diagram { font-family: -apple-system, 'Segoe UI', Helvetica, Arial, sans-serif; }
   .bmad-diagram text { fill: #e6eaf0; }
@@ -12,6 +12,8 @@
   .bmad-diagram .panel { fill: none; stroke: #404854; stroke-width: 1; stroke-dasharray: 4 4; }
   .bmad-diagram .panel-title { fill: #7fa0ff; }
   .bmad-diagram .slogan { fill: #7fa0ff; }
+  .bmad-diagram .slogan.alt { fill: #e0b25f; }
+  .bmad-diagram .rule { fill: none; stroke: #404854; stroke-width: 1; }
   .bmad-diagram .edge { fill: none; stroke: #8c96a3; stroke-width: 1.5; }
   .bmad-diagram .edge.soft { stroke-width: 1.25; stroke-dasharray: 4 4; opacity: 0.85; }
   .bmad-diagram .edge.lens { opacity: 0.5; }
@@ -33,7 +35,7 @@
     fill: #8c96a3;
   }
   </style>
-  <rect width="1120" height="466" rx="20" fill="#111418"/>
+  <rect width="1120" height="477" rx="20" fill="#111418"/>
   <title id="title">The BMad delivery loop</title>
   <desc id="description">Three kinds of input enter the delivery loop at different points: a vague notion enters at Clarify, a big clear idea enters at Plan, and a small change goes straight to Build and verify. The loop continues through Learn and adjust, which feeds back into planning as the work evolves.</desc>
   <defs>
@@ -45,22 +47,24 @@
     </marker>
   </defs>
 
-  <!-- The two slogans frame the drawing, so they are a matched pair: same size,
-       same weight, same accent, each held 40 units clear of the nearest mark.
-       They sit outside the drawing's group and are the only things the shift
-       below does not move.
+  <!-- Two banners closing on a hairline, which is how every section on the
+       marketing site ends. The rules run the drawing's own measure, 60 to 1060,
+       so the banners sit on the same grid as the boxes rather than floating
+       over it.
 
-       The original said these in colour - gold above, pale blue below - and
-       carried them larger than the body around them. Dropping every colour to
-       make one drawing serve both themes took that with it and left two grey
-       lines nobody read. The accent is the theme's one colour, so it is what
-       says this here. -->
+       The original said these in colour, gold above and pale blue below, and
+       carried them larger than the body around them. Dropping every colour so
+       one drawing could serve both themes took that with it and left two grey
+       lines nobody read. They are the only sentences here; a reader who skips
+       them gets four boxes and no argument. -->
   <g text-anchor="middle">
     <text class="slogan" x="560" y="31" font-size="22" font-weight="700" letter-spacing="1.8" data-i18n="start-anywhere">START ANYWHERE</text>
-    <text class="slogan" x="560" y="450" font-size="22" font-weight="700" letter-spacing="1.8" data-i18n="right-sized-for-the-work-in-front-">RIGHT-SIZED FOR THE WORK IN FRONT OF YOU</text>
+    <path class="rule" d="M60 47H1060"/>
+    <path class="rule" d="M60 430H1060"/>
+    <text class="slogan alt" x="560" y="462" font-size="22" font-weight="700" letter-spacing="1.8" data-i18n="right-sized-for-the-work-in-front-">RIGHT-SIZED FOR THE WORK IN FRONT OF YOU</text>
   </g>
 
-  <g transform="translate(0 46)">
+  <g transform="translate(0 52)">
 
   <!-- Entry drops: each input lands where it enters the loop. These carry
        the accent, because where a piece of work joins is the one thing this

--- a/docs/images/bmad-delivery-loop.svg
+++ b/docs/images/bmad-delivery-loop.svg
@@ -19,6 +19,7 @@
     fill: #7fa0ff;
   }
   .bmad-diagram .slogan.alt { fill: #8c96a3; }
+  .bmad-diagram .grid { fill: none; stroke: #404854; stroke-opacity: 0.22; stroke-width: 1; }
   .bmad-diagram .rule { fill: none; stroke: #404854; stroke-width: 1; }
   .bmad-diagram .edge { fill: none; stroke: #8c96a3; stroke-width: 1.5; }
   .bmad-diagram .edge.soft { stroke-width: 1.25; stroke-dasharray: 4 4; opacity: 0.85; }
@@ -76,6 +77,12 @@
     <text class="slogan alt" x="560" y="450" data-i18n="right-sized-for-the-work-in-front-">RIGHT-SIZED FOR THE WORK IN FRONT OF YOU</text>
   </g>
 
+  <!-- The field the original ruled behind the drawing, at its pitch: 70 apart
+       one way, 140 the other. It is held between the two hairlines so it reads
+       as what the banners enclose, and drawn in the line token at low opacity,
+       so it is a texture on either ramp rather than the fixed blue it was. -->
+  <path class="grid" d="M0 111H1120M0 181H1120M0 251H1120M0 321H1120M0 391H1120M140 41V424M280 41V424M420 41V424M560 41V424M700 41V424M840 41V424M980 41V424"/>
+
   <g transform="translate(0 46)">
 
   <!-- Entry drops: each input lands where it enters the loop. These carry
@@ -100,22 +107,29 @@
        A bulb the theme cannot colour has to be drawn as one: the earlier
        version leaned on gold to say "idea", and a circle over a tab in the
        body ink read as neither. The filament, the tapered neck and the ribbed
-       screw base carry it instead, so it stays a bulb on either ground. -->
-  <circle cx="425" cy="66" r="26" fill="#1a1e24" stroke="#e6eaf0" stroke-width="2.5"/>
-  <path d="M417 84V76C417 66 433 66 433 76V84" fill="none" stroke="#e6eaf0" stroke-width="2" stroke-linecap="round"/>
-  <path d="M414.5 89L417 95M435.5 89L433 95" stroke="#e6eaf0" stroke-width="2.5" stroke-linecap="round"/>
-  <rect class="node" x="417" y="95" width="16" height="10" rx="1.5" stroke="#e6eaf0" stroke-width="2.5"/>
-  <path d="M417 98.5H433M417 101.5H433" stroke="#e6eaf0" stroke-width="1.2"/>
-  <path d="M401 42L394 35M449 42L456 35M425 34V25" stroke="#e6eaf0" stroke-width="2.5" stroke-linecap="round"/>
+       screw base carry it instead, so it stays a bulb on either ground.
+
+       Lit in the accent, the same hue as the entry drop below it. The original
+       drew its bulbs, its entry arrows and its opening line all in one gold,
+       and the loop itself in a cyan; accenting the drops alone had left the
+       bulbs outside a family they belong to. The cloud stays muted, as it was
+       there too - a vague notion is not yet an idea, and should not glow like
+       one. -->
+  <circle cx="425" cy="66" r="26" fill="#1a1e24" stroke="#7fa0ff" stroke-width="2.5"/>
+  <path d="M417 84V76C417 66 433 66 433 76V84" fill="none" stroke="#7fa0ff" stroke-width="2" stroke-linecap="round"/>
+  <path d="M414.5 89L417 95M435.5 89L433 95" stroke="#7fa0ff" stroke-width="2.5" stroke-linecap="round"/>
+  <rect class="node" x="417" y="95" width="16" height="10" rx="1.5" stroke="#7fa0ff" stroke-width="2.5"/>
+  <path d="M417 98.5H433M417 101.5H433" stroke="#7fa0ff" stroke-width="1.2"/>
+  <path d="M401 42L394 35M449 42L456 35M425 34V25" stroke="#7fa0ff" stroke-width="2.5" stroke-linecap="round"/>
 
   <!-- Small change: small bulb. The same construction, one size down; the
        base takes a single rib rather than two, which is all that reads. -->
-  <circle cx="695" cy="80" r="14" fill="#1a1e24" stroke="#e6eaf0" stroke-width="2"/>
-  <path d="M691 88V84C691 78 699 78 699 84V88" fill="none" stroke="#e6eaf0" stroke-width="1.5" stroke-linecap="round"/>
-  <path d="M689.5 92L690.5 96M700.5 92L699.5 96" stroke="#e6eaf0" stroke-width="2" stroke-linecap="round"/>
-  <rect class="node" x="690" y="96" width="10" height="7" rx="1.2" stroke="#e6eaf0" stroke-width="2"/>
-  <path d="M690 99.5H700" stroke="#e6eaf0" stroke-width="1"/>
-  <path d="M681.5 66.5L676.5 61.5M708.5 66.5L713.5 61.5M695 62V55" stroke="#e6eaf0" stroke-width="2" stroke-linecap="round"/>
+  <circle cx="695" cy="80" r="14" fill="#1a1e24" stroke="#7fa0ff" stroke-width="2"/>
+  <path d="M691 88V84C691 78 699 78 699 84V88" fill="none" stroke="#7fa0ff" stroke-width="1.5" stroke-linecap="round"/>
+  <path d="M689.5 92L690.5 96M700.5 92L699.5 96" stroke="#7fa0ff" stroke-width="2" stroke-linecap="round"/>
+  <rect class="node" x="690" y="96" width="10" height="7" rx="1.2" stroke="#7fa0ff" stroke-width="2"/>
+  <path d="M690 99.5H700" stroke="#7fa0ff" stroke-width="1"/>
+  <path d="M681.5 66.5L676.5 61.5M708.5 66.5L713.5 61.5M695 62V55" stroke="#7fa0ff" stroke-width="2" stroke-linecap="round"/>
 
   <g text-anchor="middle">
     <text x="155" y="94" fill="#8c96a3" font-size="32" font-weight="700" data-i18n="label">?</text>


### PR DESCRIPTION
Follow-up to [#2854](https://github.com/bmad-code-org/BMAD-METHOD/pull/2854), on @alexeyv's feedback about the merged version: *"I would make both slogans stick out more — splash of color, bigger font."*

He is right, and the original backs him up. It set `START ANYWHERE` in gold `#ffe34f` and `RIGHT-SIZED FOR THE WORK IN FRONT OF YOU` in pale blue `#9cc8e2`, both larger relative to the drawing than what replaced them.

Dropping every colour from the diagrams — so one drawing could serve light and dark from one file — took that with it. The two lines went grey and small enough to skip, and they are the only sentences in the drawing: a reader who skips them gets four boxes and no argument.

## What changed

Both slogans take the accent at 22, up from 17.5 and 18, as a matched pair. They had also drifted apart from each other — ink at weight 700 above, muted at weight 600 below — despite doing the same job.

Two colours are not available to a theme with one accent, so the split the original drew (gold for the entry promise, blue for the summary) collapses into one hue used twice. The accent already marks the three entry drops, which is the same idea `START ANYWHERE` states in words, so the coupling is deliberate.

The canvas grows 460 → 466 to hold the larger type at the same 40 units of clearance above and below.

`.slogan` joins the diagram vocabulary in `custom.css` and the export, described as the one or two framing lines a diagram is allowed, so the accent stays scarce.

## Checks

`lint`, `format:check`, `build` and `test` pass. Light and dark both verified, and the Korean export re-rendered since its slogans are longer.

🤖 Generated with [Claude Code](https://claude.com/claude-code)