### PR TITLE
feat(review): add the review lever and lens sets to build-auto and code-review

### DIFF
--- a/docs/build/review-a-change.md
+++ b/docs/build/review-a-change.md
@@ -78,35 +78,20 @@ patch or defer.
 You get a findings summary. Without a spec, that listing stays in the
 chat. You choose whether to apply patches.
 
-## Customize the Layers
+## Customize the Lenses
 
-The shipped lenses are a starting point. Start `bmad-customize` and
-ask what you can change.
+You can choose review depth: `thorough` or `quick`.
 
-Override `[[workflow.review_layers]]` in
-`_bmad/custom/bmad-code-review.toml`. The skill ships four layers:
-`blind-hunter`, `edge-case-hunter`, `verification-gap`, and
-`acceptance-auditor`. Empty `instruction` on an existing `id` disables
-that layer. A `when` field gates a layer. A new `id` appends.
-`instruction` may be bash.
+**Thorough** is the default: several reviewers, each with a different
+lens. Slow, expensive, tuned to find as many problems as possible.
 
-```toml
-# _bmad/custom/bmad-code-review.toml
-[[workflow.review_layers]]
-id = "blind-hunter"
-instruction = ""
-[[workflow.review_layers]]
-id = "acceptance-auditor"
-when = 'Only when {review_mode} = "full".'
-[[workflow.review_layers]]
-id = "security-bot"
-name = "Security bot"
-instruction = """
-Run the team reviewer via bash on {diff_file} and return its findings as a Markdown list.
-"""
-```
+**Quick** is a single reviewer, several times cheaper and somewhat
+faster. Say `/bmad-code-review quick` to use it for a run.
 
-For how overrides merge, see [Customize BMad](../customize/customize-bmad.md).
+Different situations call for different review breadth, depth and cost.
+You can change the default from thorough to quick, add your own
+reviewers, replace or turn off the ones you get out of the box, run
+some on another model. Start `bmad-customize` and ask what is possible.
 
 ## Why Does Review Take Forever?
 
@@ -119,10 +104,10 @@ Three explanations:
 ### Exhaustive on purpose
 
 The default assumes an average bug escaping into production is worth
-more than an hour of inference. You can turn that down, or off — see
-[Customize the Layers](#customize-the-layers). Turning review off is
-reasonable for a throwaway prototype. A long review can also run
-offline.
+more than an hour of inference. You can turn that down — see
+[Customize the Lenses](#customize-the-lenses). Skipping review in
+`bmad-build` is reasonable for a throwaway prototype. A long review can
+also run offline.
 
 It is a bad idea to let teammates look at unreviewed LLM-generated
 code. It is a worse idea to put that code into production without the
@@ -173,4 +158,4 @@ test as above: take several interesting diffs, run an A/B, and either
 pick one, or make the built-in command an extra lens. If you find
 something that genuinely adds quality findings without creating too
 much noise, it is almost always worth adding as a lens — see
-[Customize the Layers](#customize-the-layers).
+[Customize the Lenses](#customize-the-lenses).

--- a/docs/customize/customize-bmad.md
+++ b/docs/customize/customize-bmad.md
@@ -219,25 +219,13 @@ on_complete = "Summarize the brief in three bullets and offer to email it via th
 ```
 
 Individual workflows add fields on top — output paths, templates, toggles —
-and each follows the shape rules above. `bmad-code-review` ships
-`[[workflow.review_layers]]`, keyed by `id`. This override disables one
-shipped layer and adds another; the skill skips a layer whose
-`instruction` is empty, so nothing is deleted. See
-[Review a Change](../build/review-a-change.md) for empty `instruction`,
-`when`, and a new `id`.
+and each follows the shape rules above. For example, `bmad-code-review`
+exposes `review`, the default review depth:
 
 ```toml
 # _bmad/custom/bmad-code-review.toml
-[[workflow.review_layers]]
-id = "blind-hunter"
-instruction = ""
-
-[[workflow.review_layers]]
-id = "security-bot"
-name = "Security bot"
-instruction = """
-Run the team reviewer via bash on {diff_file} and return its findings as a Markdown list.
-"""
+[workflow]
+review = "quick"
 ```
 
 Read a workflow's `customize.toml` to see the fields it exposes. If the

--- a/skills/bmad-build-auto/SKILL.md
+++ b/skills/bmad-build-auto/SKILL.md
@@ -10,6 +10,7 @@ uv run --no-cache "{project-root}/_bmad/scripts/render_skill.py" --project-root 
 ```
 
 - When the invocation names a route (`oneshot` or `full`), append `--set workflow.route=<value>` to the command.
+- When the invocation names a review selection (`none`, `quick`, or `thorough`; "skip review" or "no review" mean `none`), append `--set workflow.review=<value>` to the command.
 - On success, read and follow the one absolute `workflow.md` instruction printed to stdout.
 - If `{project-root}/_bmad/scripts/render_skill.py` is not found, this BMad installation is not set up yet: read the installed `bmad` skill's SKILL.md (a sibling of this skill's directory) and follow its setup flow, then run the command above once more.
 - On any other failure (including `uv` being unavailable), report the command output and HALT. Do not run any workflow source directly.

--- a/skills/bmad-build-auto/customize.toml
+++ b/skills/bmad-build-auto/customize.toml
@@ -61,14 +61,35 @@ Launch a subagent with no prior conversation context, with this prompt:
 > When done, report what you changed, how you verified it, and anything left incomplete or risky.
 """
 
-# Review layers for the review step. `instruction` is the layer's whole
-# execution recipe — subagents by default, but an override may run anything
-# (e.g. an external reviewer via bash). {diff_file} and {claims_file} are
-# substituted at run time; both are paths, and {diff_file} is the unified diff
-# file the layer reads. `when` (optional) gates a layer; empty `instruction`
-# disables it.
+# Review selection: "none" launches no lens and skips triage, "quick" runs
+# quick_lenses, "thorough" runs thorough_lenses, "auto" follows the resolved
+# route — oneshot selects quick, full selects thorough.
 
-[[workflow.review_layers]]
+review = "auto"
+
+# Review lenses for the review step, in two sets the review selection picks
+# between. `instruction` is the lens's whole execution recipe — subagents by
+# default, but an override may run anything (e.g. an external reviewer via
+# bash). {diff_file}, {claims_file}, {spec_file}, and {verbatim_intent} are
+# substituted at run time; the first three are paths, and {diff_file} is the
+# unified diff file the lens reads. `when` (optional) gates a lens; empty
+# `instruction` disables it.
+
+[[workflow.quick_lenses]]
+id = "quick"
+name = "Quick"
+instruction = """
+Launch a context-free subagent with this prompt:
+
+Read `{spec_file}` — the story or spec holding the acceptance criteria and intent; it is empty when there is none — and the files its frontmatter `context:` lists. Read the agent instruction files (`AGENTS.md`, `CLAUDE.md`, or equivalents) at the repository root and in the directories the diff touches; those are the rules. Then read the unified diff at `{diff_file}` — it is the change under review.
+
+Report unmet acceptance criteria, broken rules, and bugs. Each finding: the location, what goes wrong, and evidence checked against the surrounding code. Output a Markdown list of findings only — no severity, priority, or ranking.
+
+Do not invoke any skill, and do not spawn subagents of your own — you are the reviewer. Return your findings as text in your final message; do not route them through any findings-reporting tool the host may offer.
+
+"""
+
+[[workflow.thorough_lenses]]
 id = "blind-hunter"
 name = "Blind Hunter"
 instruction = """
@@ -87,7 +108,7 @@ Do not invoke any skill, and do not spawn subagents of your own — you are the 
 
 """
 
-[[workflow.review_layers]]
+[[workflow.thorough_lenses]]
 id = "edge-case-hunter"
 name = "Edge Case Hunter"
 instruction = """
@@ -103,7 +124,7 @@ Do not invoke any skill, and do not spawn subagents of your own — you are the 
 
 """
 
-[[workflow.review_layers]]
+[[workflow.thorough_lenses]]
 id = "verification-gap"
 name = "Verification Gap Reviewer"
 instruction = """
@@ -117,7 +138,7 @@ Do not invoke any skill, and do not spawn subagents of your own — you are the 
 
 """
 
-[[workflow.review_layers]]
+[[workflow.thorough_lenses]]
 id = "intent-alignment"
 name = "Intent Alignment Auditor"
 instruction = """

--- a/skills/bmad-build-auto/spec-template.md
+++ b/skills/bmad-build-auto/spec-template.md
@@ -5,6 +5,9 @@ created: '{date}'
 status: 'draft' # draft | ready-for-dev | in-progress | in-review | done | blocked
 route: '' # oneshot | full — set by step-02
 route_source: '' # pinned | auto — set with route by step-02
+review: '' # none | quick | thorough — set by step-04
+review_source: '' # pinned | auto — set with review by step-04
+lenses_ran: [] # ids of the lenses launched, set by step-04
 review_loop_iteration: 0 # incremented by step-04 before each review loopback
 followup_review_recommended: false # set by step-04 on status: done — true if the LLM decided another review pass is worthwhile
 context: [] # optional: `{project-root}/`-prefixed paths to project-wide standards/docs the implementation agent should load. Keep short — only what isn't already distilled into the spec body.

--- a/skills/bmad-build-auto/step-04-review.md
+++ b/skills/bmad-build-auto/step-04-review.md
@@ -1,3 +1,10 @@
+{% if workflow.review == "auto" and workflow.route == "oneshot" %}
+{% set review = "quick" %}
+{% elif workflow.review == "auto" and workflow.route == "full" %}
+{% set review = "thorough" %}
+{% else %}
+{% set review = workflow.review %}
+{% endif %}
 # Step 4: Review
 
 ## RULES
@@ -9,30 +16,59 @@
 
 Change `{spec_file}` status to `in-review` in the frontmatter before continuing.
 
+{% if workflow.review == "none" %}
+Write `review: 'none'`, `review_source: 'pinned'`, and `lenses_ran: []` to `{spec_file}` frontmatter.
+{% elif workflow.review == "quick" or workflow.review == "thorough" %}
+Write `review: '{{ workflow.review }}'` and `review_source: 'pinned'` to `{spec_file}` frontmatter.
+{% elif workflow.route == "oneshot" %}
+Write `review: 'quick'` and `review_source: 'auto'` to `{spec_file}` frontmatter.
+{% elif workflow.route == "full" %}
+Write `review: 'thorough'` and `review_source: 'auto'` to `{spec_file}` frontmatter.
+{% else %}
+Write `review` to `{spec_file}` frontmatter from its `route`: `quick` when `route` is `oneshot`, `thorough` when `full`; `review_source: 'auto'`.
+{% endif %}
+{% if review != "none" %}
+
 ### Stage the Diff
 
-Read `{baseline_revision}` from `{spec_file}` frontmatter. If `{baseline_revision}` is missing or `NO_VCS`, use best effort to determine what changed. Otherwise use the repository's version-control tooling to rewrite `{diff_file}` — the temp file staged in step-03, or a uniquely-named file in the system temp directory when this run has none — with a unified diff of all changes since `{baseline_revision}`, untracked files included. The review layers read that file; the diff text is never pasted into their prompts.
+Read `{baseline_revision}` from `{spec_file}` frontmatter. If `{baseline_revision}` is missing or `NO_VCS`, use best effort to determine what changed. Otherwise use the repository's version-control tooling to rewrite `{diff_file}` — the temp file staged in step-03, or a uniquely-named file in the system temp directory when this run has none — with a unified diff of all changes since `{baseline_revision}`, untracked files included. The review lenses read that file; the diff text is never pasted into their prompts.
 
-Set `{claims_file}` = `{spec_file}`. The spec is the change's own account of itself, and it goes to the edge-case layer alone — as a path, so that layer reads it only after its own tracing and the other layers never see it at all.
+Set `{claims_file}` = `{spec_file}`. The spec is the change's own account of itself. It goes to the edge-case lens as a path, read only after its own tracing, and to the Quick lens for its acceptance criteria; no other lens sees it.
 
 Writing `{diff_file}` is the only change this section makes. Do NOT `git add` anything.
 
 ### Review
 
-Runtime placeholders: `{diff_file}` is the diff staged above and `{claims_file}` the narrative staged with it — both paths, substituted absolute so a layer can read them; a launch prompt never carries diff text. `{verbatim_intent}` is the invocation intent exactly as this run received it at step-01; if the run started from an existing spec file rather than a fresh intent, it is the spec's `<intent-contract>` block instead. Before launching a layer, expand its skill-root placeholder to this skill's absolute installed directory; never leave that placeholder unresolved in a child prompt.
+Runtime placeholders: `{diff_file}` is the diff staged above, `{claims_file}` the narrative staged with it, and `{spec_file}` the story file — all paths, substituted absolute so a lens can read them; a launch prompt never carries diff text. `{verbatim_intent}` is the invocation intent exactly as this run received it at step-01; if the run started from an existing spec file rather than a fresh intent, it is the spec's `<intent-contract>` block instead. Before launching a lens, expand its skill-root placeholder to this skill's absolute installed directory; never leave that placeholder unresolved in a child prompt.
 
-Announce skipped layers first, then launch every active layer before handling any layer's result. Try running all active layers simultaneously: substitute the runtime placeholders (e.g. `{diff_file}`) into each layer's instruction. When an instruction launches a reviewer subagent, launch that child with the prompt text after placeholder substitution; do not load the reviewer instruction file yourself. For any other customized instruction, execute it as written. Parallel means several blocking calls awaited together in this turn — never backgrounded or detached, never ending the turn to await results (see workflow.md → Subagents). Spawn every reviewer subagent before reading or reacting to any of their output; begin collection and triage only once all are launched.
+Announce skipped lenses first, then launch every active lens before handling any lens's result. Try running all active lenses simultaneously: substitute the runtime placeholders (e.g. `{diff_file}`) into each lens's instruction. When an instruction launches a reviewer subagent, launch that child with the prompt text after placeholder substitution; do not load the reviewer instruction file yourself. For any other customized instruction, execute it as written. Parallel means several blocking calls awaited together in this turn — never backgrounded or detached, never ending the turn to await results (see workflow.md → Subagents). Spawn every reviewer subagent before reading or reacting to any of their output; begin collection and triage only once all are launched.
 
-{{ workflow.review_layers }}
+{% if review == "quick" %}
+{{ workflow.quick_lenses }}
+{% elif review == "thorough" %}
+{{ workflow.thorough_lenses }}
+{% else %}
+The launch paragraph above applies to the set the mapping selects: read `route` from `{spec_file}` frontmatter — the quick set when it is `oneshot`, the thorough set when it is `full`. Launch only that set.
+
+**Quick set**
+
+{{ workflow.quick_lenses }}
+
+**Thorough set**
+
+{{ workflow.thorough_lenses }}
+{% endif %}
+
+Write `lenses_ran` — the ids launched, in launch order — to `{spec_file}` frontmatter.
 
 ### Classify
 
-1. Once every layer has reported — and not before — render a verdict on each finding, ahead of any deduplication or grouping. Disregard any severity a reviewing subagent assigned — they lack the context to grade.
+1. Once every lens has reported — and not before — render a verdict on each finding, ahead of any deduplication or grouping. Disregard any severity a reviewing subagent assigned — they lack the context to grade.
 
    If `## Review Triage Log` already has rows — a loopback, a resumed review, or a follow-up pass on a `done` spec — check each finding against them first. Same location and same claim as a logged row, and the code there still reads as the row describes: keep the row's verdict and route, write the row again with `carried` in front of the evidence, skip verification, and never patch or defer it again. Verify everything else as below.
 
    For each finding:
-   - A gap finding from the verification-gap layer arrives pre-verified — that layer's evidence rules made it read the tests and run the searches it cites, and triage trusts the claim as filed. Skip verification, render the verdict from the filed evidence, and weigh its filed disposition when routing. Its `Other findings` are verified like everything else.
+   - A gap finding from the verification-gap lens arrives pre-verified — that lens's evidence rules made it read the tests and run the searches it cites, and triage trusts the claim as filed. Skip verification, render the verdict from the filed evidence, and weigh its filed disposition when routing. Its `Other findings` are verified like everything else.
    - **Verify the finding's claim.** At the cited file and line, does the bad outcome the reviewer describes actually occur? Read beyond the changed lines — follow callers, guards upstream, etc — until you can answer yes or no. A different finding about nearby code does not settle this one. Judge whether the problem is real, not whether the proposed fix is plausible. Code that loudly fails on a situation you never showed the program can reach is correct behavior, not a defect.
    - **Render exactly one verdict** from what verification established — the verdict is the whole triage decision; there is no separate keep-or-dismiss.
      - `high` (intolerable), `medium` (tolerable), `low` (cosmetic or negligible) — the bad outcome is real. Assign severity by how much it hurts end users or developers. For developer-only problems (inconsistent design, eroded invariants, duplicated sources of truth), name where it will cause trouble — which caller will diverge, which rule will break. A vague "this is messy" with no named harm is not a severity grade; use `false` or `maybe-false` instead. When the harm is real but you cannot tell how bad, pick the higher grade.
@@ -65,7 +101,7 @@ Announce skipped layers first, then launch every active layer before handling an
    - findings:
      - `[verdict]` `[intent_gap|bad_spec|patch|defer|reject]` <finding summary> — <evidence: the refutation for false, what would settle it for maybe-false, the action taken for patches, why a rejected low was not worth fixing>
    ```
-   Where `{date}` is the current system date. One row per finding from every layer, in the order the layers reported them; `<total>` must equal the number of findings the layers reported — a finding missing from the log is a triage failure. Members of a grouped entry keep their own rows and share the route.
+   Where `{date}` is the current system date. One row per finding from every lens, in the order the lenses reported them; `<total>` must equal the number of findings the lenses reported — a finding missing from the log is a triage failure. Members of a grouped entry keep their own rows and share the route.
 5. Process entries in cascading order. If intent_gap exists, lower entries are moot; follow the intent_gap branch below. If bad_spec exists, lower entries are moot since code will be re-derived. If neither exists, process patch and defer normally. Before each bad_spec loopback, read `{spec_file}` frontmatter `review_loop_iteration` (missing means `0`), increment it by 1, and write it back. If it exceeds 5, append the triage-log entry for this pass, then HALT with status `blocked` and blocking condition `review repair loop exceeded 5 iterations (non-convergence)`.
    - **intent_gap** — Root cause is inside `<intent-contract>`. Save the attempted change as a patch file in `{{ config.implementation_artifacts }}` and reference it from the triage-log entry, then revert code changes. Append the triage-log entry for this pass, then HALT with status `blocked`, blocking condition `intent gap`, and include the unresolved questions and the saved patch path.
    - **bad_spec** — Root cause is outside `<intent-contract>`. Do not modify content inside `<intent-contract>`. Before reverting code: extract KEEP instructions for positive preservation (what worked well and must survive re-derivation). Revert code changes. Read the `## Spec Change Log` in `{spec_file}` and strictly respect all logged constraints when amending the sections outside `<intent-contract>` that contain the root cause. Append a new change-log entry recording: the triggering finding, what was amended, the known-bad state avoided, and the KEEP instructions. Append the triage-log entry for this pass, recording in each bad_spec row the amendment it triggered. Read fully and follow `{{ rendered("step-03-implement.md") }}` to re-derive the code, then this step will run again.
@@ -106,18 +142,27 @@ Announce skipped layers first, then launch every active layer before handling an
          severity: medium # optional — high | medium | low; for a maybe-false entry, its if-true grade plus " (unverified)"
      ```
      After all appends, parse the complete frontmatter as YAML and verify that `deferred` is one list containing every prior item plus the new items with their intended text. Repair serialization errors before continuing.
+{% endif %}
 
 ## Finalize
 
 Write the following details to `{spec_file}` under `## Auto Run Result`:
 - Summary of implemented change
 - Files changed with one-line descriptions
+{% if review != "none" %}
 - Review findings breakdown: patches applied, items deferred, and every rejected finding with its recorded reason
 - Follow-up review recommendation: default `false`. Count only this pass's entries triaged `patch`, at entry verdict — never deferred or `false` ones. On a first pass, `true` if any patched entry was `high`, or if two or more `medium` entries were patched. On a follow-up pass (`{followup_pass}` = `true`), `true` only if this pass patched a `high` — otherwise the work has converged; patch volume is never grounds. A `true` names the specific unverified risk under `## Auto Run Result`; if none can be named, it is `false`. Record the patched counts by verdict.
+{% else %}
+- Review: none, no lenses launched
+{% endif %}
 - Verification performed, including command outcomes or manual inspection notes
 - Any residual risks
 
+{% if review != "none" %}
 Set `{spec_file}` frontmatter `followup_review_recommended` from the computation above.
+{% else %}
+Set `{spec_file}` frontmatter `followup_review_recommended: false`.
+{% endif %}
 
 If version control is unavailable, set `{spec_file}` frontmatter `status: done`, then proceed to HALT.
 

--- a/skills/bmad-build-auto/workflow.md
+++ b/skills/bmad-build-auto/workflow.md
@@ -1,4 +1,5 @@
 {% if workflow.route not in ("oneshot", "full", "auto") %}{{ halt("workflow.route must be oneshot, full, or auto, not " ~ workflow.route) }}{% endif %}
+{% if workflow.review not in ("none", "quick", "thorough", "auto") %}{{ halt("workflow.review must be none, quick, thorough, or auto, not " ~ workflow.review) }}{% endif %}
 # Build Auto Workflow
 
 **Goal:** Turn intent into a hardened, reviewable artifact, without human interaction.

--- a/skills/bmad-code-review/SKILL.md
+++ b/skills/bmad-code-review/SKILL.md
@@ -9,6 +9,7 @@ Run the following command exactly once without changing the current working dire
 uv run --no-cache "{project-root}/_bmad/scripts/render_skill.py" --project-root "{project-root}" --skill "{skill-root}"
 ```
 
+- When the invocation names a review selection (`quick` or `thorough`), append `--set workflow.review=<value>` to the command.
 - On success, read and follow the one absolute `workflow.md` instruction printed to stdout.
 - If `{project-root}/_bmad/scripts/render_skill.py` is not found, this BMad installation is not set up yet: read the installed `bmad` skill's SKILL.md (a sibling of this skill's directory) and follow its setup flow, then run the command above once more.
 - On any other failure (including `uv` being unavailable), report the command output and HALT. Do not run any workflow source directly.

--- a/skills/bmad-code-review/customize.toml
+++ b/skills/bmad-code-review/customize.toml
@@ -38,14 +38,33 @@ persistent_facts = []
 
 on_complete = ""
 
-# Review layers for the review step. `instruction` is the layer's whole
-# execution recipe — subagents by default, but an override may run anything
-# (e.g. an external reviewer via bash). {diff_file}, {claims_file} and {spec_file} are
-# substituted at run time; all are paths, and {diff_file} is the unified
-# diff file the layer reads. `when` (optional) gates a layer; empty
+# Review selection: "quick" runs quick_lenses, "thorough" runs thorough_lenses.
+
+review = "thorough"
+
+# Review lenses for the review step, in two sets the review selection picks
+# between. `instruction` is the lens's whole execution recipe — subagents by
+# default, but an override may run anything (e.g. an external reviewer via
+# bash). {diff_file}, {claims_file}, {spec_file}, and {verbatim_intent} are
+# substituted at run time; the first three are paths, and {diff_file} is the
+# unified diff file the lens reads. `when` (optional) gates a lens; empty
 # `instruction` disables it.
 
-[[workflow.review_layers]]
+[[workflow.quick_lenses]]
+id = "quick"
+name = "Quick"
+instruction = """
+Launch a context-free subagent with this prompt:
+
+Read `{spec_file}` — the story or spec holding the acceptance criteria and intent; it is empty when there is none — and the files its frontmatter `context:` lists. Read the agent instruction files (`AGENTS.md`, `CLAUDE.md`, or equivalents) at the repository root and in the directories the diff touches; those are the rules. Then read the unified diff at `{diff_file}` — it is the change under review.
+
+Report unmet acceptance criteria, broken rules, and bugs. Each finding: the location, what goes wrong, and evidence checked against the surrounding code. Output a Markdown list of findings only — no severity, priority, or ranking.
+
+Do not invoke any skill, and do not spawn subagents of your own — you are the reviewer. Return your findings as text in your final message; do not route them through any findings-reporting tool the host may offer.
+
+"""
+
+[[workflow.thorough_lenses]]
 id = "blind-hunter"
 name = "Blind Hunter"
 instruction = """
@@ -64,7 +83,7 @@ Do not invoke any skill, and do not spawn subagents of your own — you are the 
 
 """
 
-[[workflow.review_layers]]
+[[workflow.thorough_lenses]]
 id = "edge-case-hunter"
 name = "Edge Case Hunter"
 instruction = """
@@ -80,7 +99,7 @@ Do not invoke any skill, and do not spawn subagents of your own — you are the 
 
 """
 
-[[workflow.review_layers]]
+[[workflow.thorough_lenses]]
 id = "verification-gap"
 name = "Verification Gap Reviewer"
 instruction = """
@@ -94,16 +113,19 @@ Do not invoke any skill, and do not spawn subagents of your own — you are the 
 
 """
 
-[[workflow.review_layers]]
-id = "acceptance-auditor"
-name = "Acceptance Auditor"
-when = '{review_mode} = "full"'
+[[workflow.thorough_lenses]]
+id = "intent-alignment"
+name = "Intent Alignment Auditor"
 instruction = """
 Launch a subagent with this prompt:
 
-You are an Acceptance Auditor. Review the provided diff against `{spec_file}` and any loaded context docs. Check for: violations of acceptance criteria, deviations from spec intent, missing implementation of specified behavior, contradictions between spec constraints and actual code. Output findings as a Markdown list. Each finding: one-line title, which AC/constraint it violates, and evidence from the diff.
+You are an intent-alignment auditor. You have no other context about how this change was produced. Here is the verbatim intent this work started from:
 
-Diff: the unified diff at `{diff_file}`. Read that file — it is the content under review.
+{verbatim_intent}
+
+The diff is the unified diff at `{diff_file}`. Read that file — it is the change under review.
+
+Your task is strictly descriptive — do not prescribe additional work. Report: (1) the defensible readings of the intent, enumerated; (2) which reading this diff implements; (3) where the readings and the diff diverge — specifically, which surface the intent's expectations live at versus which surface the diff's changes and its tests exercise.
 
 Do not invoke any skill, and do not spawn subagents of your own — you are the reviewer. Return your findings as text in your final message; do not route them through any findings-reporting tool the host may offer.
 

--- a/skills/bmad-code-review/step-02-review.md
+++ b/skills/bmad-code-review/step-02-review.md
@@ -1,5 +1,5 @@
 ---
-failed_layers: '' # set at runtime: comma-separated list of layers that failed or returned empty
+failed_layers: '' # set at runtime: comma-separated list of lenses that failed or returned empty
 ---
 
 # Step 2: Review
@@ -11,19 +11,23 @@ failed_layers: '' # set at runtime: comma-separated list of layers that failed o
 
 ## INSTRUCTIONS
 
-1. The review layers are listed below. For each layer:
-   - `Run only when` present and not satisfied by the current context (`{review_mode}`, `{spec_file}`) → skip the layer and tell the user, e.g. "Acceptance Auditor skipped — no spec file provided."
-   - otherwise → the layer is active.
+1. The review lenses are listed below. For each lens:
+   - `Run only when` present and not satisfied by the current context (`{review_mode}`, `{spec_file}`) → skip the lens and tell the user which lens was skipped and why.
+   - otherwise → the lens is active.
 
-2. Announce skipped layers first, then launch every active layer before handling any layer's result. Try running all active layers simultaneously: substitute the runtime placeholders (`{diff_file}`, `{claims_file}`, `{spec_file}`) into each layer's instruction. `{diff_file}` is a path: substitute the absolute path and let the layer read the file — a launch prompt never carries diff text, and the child's working directory is not yours. When an instruction launches a reviewer subagent, launch that child with the prompt text after placeholder substitution; do not load the reviewer instruction file yourself. For any other customized instruction, execute it as written. When running layers as subagents, spawn every reviewer before reading or reacting to any of their output; begin collection only once all are launched.
+2. Announce skipped lenses first, then launch every active lens before handling any lens's result. Try running all active lenses simultaneously: substitute the runtime placeholders (`{diff_file}`, `{claims_file}`, `{spec_file}`, `{verbatim_intent}`) into each lens's instruction. `{diff_file}`, `{claims_file}`, and `{spec_file}` are paths: substitute the absolute path and let the lens read the file — a launch prompt never carries diff text, and the child's working directory is not yours. `{verbatim_intent}` is the original intent text as the invocation or conversation supplied it, else the intent section of `{spec_file}`, substituted inline as text. When an instruction launches a reviewer subagent, launch that child with the prompt text after placeholder substitution; do not load the reviewer instruction file yourself. For any other customized instruction, execute it as written. When running lenses as subagents, spawn every reviewer before reading or reacting to any of their output; begin collection only once all are launched.
 
-{{ workflow.review_layers }}
+{% if workflow.review == "quick" %}
+{{ workflow.quick_lenses }}
+{% else %}
+{{ workflow.thorough_lenses }}
+{% endif %}
 
-3. If a layer's instruction requires subagents and none are available, for each such layer write under `{{ config.implementation_artifacts }}` that layer's child prompt with every file it points to — the diff, the claims, the reviewer instruction file — replaced inline by that file's contents, and every other line left exactly as written. That session shares no filesystem with this one, so its prompt has to stand alone; this is the only place you read a reviewer instruction file yourself. Then HALT. Ask the user to run each in a separate session (ideally a different LLM) and paste back the findings. When findings are pasted, treat them as those layers' findings and resume from this point.
+3. If a lens's instruction requires subagents and none are available, for each such lens write under `{{ config.implementation_artifacts }}` that lens's child prompt with every file it points to — the diff, the claims, the reviewer instruction file — replaced inline by that file's contents, and every other line left exactly as written. That session shares no filesystem with this one, so its prompt has to stand alone; this is the only place you read a reviewer instruction file yourself. Then HALT. Ask the user to run each in a separate session (ideally a different LLM) and paste back the findings. When findings are pasted, treat them as those lenses' findings and resume from this point.
 
-4. **Layer failure handling**: If any layer fails, times out, or returns empty results, append the layer's `name` to `failed_layers` (comma-separated) and proceed with findings from the remaining layers.
+4. **Lens failure handling**: If any lens fails, times out, or returns empty results, append the lens's `name` to `failed_layers` (comma-separated) and proceed with findings from the remaining lenses.
 
-5. Collect all findings from the completed layers, keeping track of each finding's originating layer `id`.
+5. Collect all findings from the completed lenses, keeping track of each finding's originating lens `id`.
 
 ## NEXT
 

--- a/skills/bmad-code-review/workflow.md
+++ b/skills/bmad-code-review/workflow.md
@@ -1,3 +1,4 @@
+{% if workflow.review not in ("quick", "thorough") %}{{ halt("workflow.review must be quick or thorough, not " ~ workflow.review) }}{% endif %}
 # Code Review Workflow
 
 **Goal:** Review code changes adversarially. No noise, no filler.


### PR DESCRIPTION
## Summary

Story 5 of the build routing and review controls spec: the review lever in `bmad-build-auto` and `bmad-code-review`.

- Both skills gain a `workflow.review` selector. `bmad-build-auto` accepts `none`, `quick`, `thorough`, and `auto`, where `auto` follows the resolved route (oneshot selects quick, full selects thorough) and is the default. `bmad-code-review` accepts `quick` and `thorough`, defaulting to `thorough`; a review skill with review turned off has nothing to do, so it offers no `none`. An invocation naming a selection passes `--set workflow.review=<value>`; any other value halts the render.
- `review_layers` retires in both skills in favour of two configured, ordered lens sets. `quick_lenses` holds the new Quick lens, an informed review of acceptance criteria, applicable rules, and bugs. `thorough_lenses` holds Blind Hunter, Edge Case Hunter, Verification Gap Reviewer, and Intent Alignment Auditor, identical in both skills. The Acceptance Auditor is removed.
- Templates render only the selected set. Under `auto` route with `auto` review, `bmad-build-auto` renders both sets and the session launches the one the fixed mapping selects. Under `none`, `bmad-build-auto` step-04 drops staging, review, and classify.
- `bmad-build-auto` story frontmatter gains `review`, `review_source`, and `lenses_ran`.
- The review docs describe the two shipped sets, thorough and quick, and point to `bmad-customize` for the rest.

`bmad-build` is untouched; its consolidation into `bmad-code-review` is Story 6.

## Verification

- `validate_skills --strict`, pytest, ruff, pre-commit, and the full quality gate pass.
- Every row of the story's I/O matrix rendered as specified for both skills, including both halt messages; the default `bmad-build-auto` render differs from `dev` only in `spec-template.md` and `step-04-review.md`.
- Exercised end to end in a scratch project: `bmad-code-review` with `quick` found three planted defects in one lens; `bmad-build-auto` with `route=oneshot review=quick` implemented in the main session, ran only Quick, and recorded `review`, `review_source`, `lenses_ran` in the story frontmatter. Eighteen render permutations, override shapes, and malformed values behaved as designed.
