### PR TITLE
fix(renderer): halt on persistent override keys the skill does not declare

### DIFF
--- a/docs/customize/customize-bmad.md
+++ b/docs/customize/customize-bmad.md
@@ -70,9 +70,6 @@ Priority 3 (base): the skill's own customize.toml   (shipped defaults)
 ```
 
 `_bmad/custom/` starts empty. Files appear only when someone customizes.
-A key in either file that the skill's `customize.toml` does not declare
-halts the render, so a misspelled or retired key is caught rather than
-ignored.
 
 **Four rules, by shape.** The resolver does not treat fields differently by
 name; the merge depends only on the value's shape:

--- a/docs/customize/customize-bmad.md
+++ b/docs/customize/customize-bmad.md
@@ -70,6 +70,9 @@ Priority 3 (base): the skill's own customize.toml   (shipped defaults)
 ```
 
 `_bmad/custom/` starts empty. Files appear only when someone customizes.
+A key in either file that the skill's `customize.toml` does not declare
+halts the render, so a misspelled or retired key is caught rather than
+ignored.
 
 **Four rules, by shape.** The resolver does not treat fields differently by
 name; the merge depends only on the value's shape:

--- a/skills/bmad/scripts/render_skill.py
+++ b/skills/bmad/scripts/render_skill.py
@@ -110,6 +110,24 @@ def _leaf_paths(table: dict[str, Any], prefix: str = "") -> set[str]:
     return leaves
 
 
+def _declares(defaults: dict[str, Any], path: str) -> bool:
+    node: Any = defaults
+    for part in path.split("."):
+        if not isinstance(node, dict) or part not in node:
+            return False
+        node = node[part]
+    return True
+
+
+def _check_persistent_layers(project_root: Path, skill_dir: Path, defaults: dict[str, Any] | None) -> None:
+    """A persistent override may only set keys the skill declares; a stale or misspelled key halts."""
+    custom_dir = project_root / "_bmad" / "custom"
+    for layer in (custom_dir / f"{skill_dir.name}.toml", custom_dir / f"{skill_dir.name}.user.toml"):
+        undeclared = sorted(path for path in _leaf_paths(load_toml(layer)) if not _declares(defaults or {}, path))
+        if undeclared:
+            raise RenderError(f"{layer} sets keys {skill_dir.name} does not declare: {', '.join(undeclared)}")
+
+
 def _lookup(data: dict[str, Any], dotted_path: str, label: str) -> Any:
     current: Any = data
     for part in dotted_path.split("."):
@@ -532,6 +550,7 @@ def render(
     central = load_central_config(project_root)
     has_customization = bool(overrides is not None or assignments) or (skill_dir / "customize.toml").is_file()
     defaults = load_toml(skill_dir / "customize.toml", required=True) if has_customization else None
+    _check_persistent_layers(project_root, skill_dir, defaults)
     customization = load_customization(project_root, skill_dir) if has_customization else {}
     supplied: set[str] = set()
     if defaults is not None:

--- a/skills/bmad/scripts/tests/test_render_skill.py
+++ b/skills/bmad/scripts/tests/test_render_skill.py
@@ -310,6 +310,36 @@ class RenderSkillTests(unittest.TestCase):
                 with self.assertRaisesRegex(rs.RenderError, "conflicts with earlier --set"):
                     rs.render(ws.project, skill, assignments=assignments)
 
+    def test_undeclared_persistent_key_halts_and_unread_declared_key_renders(self):
+        ws = self._workspace()
+        skill = self._fixture_skill(ws, '[workflow]\nmessage = "base"\nunread = "base"\n', "{{ workflow.message }}")
+        team = ws.bmad / "custom" / f"{skill.name}.toml"
+        user = ws.bmad / "custom" / f"{skill.name}.user.toml"
+        # A declared key this render never reads is still a valid persistent override.
+        user.write_text('[workflow]\nunread = "changed"\n', encoding="utf-8")
+        self.assertEqual(rs.render(ws.project, skill).read_text(), "base")
+        generations = set((ws.bmad / "render" / skill.name).rglob("manifest.json"))
+        for layer, content, expected in (
+            (
+                user,
+                '[workflow]\nmessage = "ok"\nmesage = "typo"\n',
+                r"user\.toml sets keys fixture does not declare: workflow\.mesage$",
+            ),
+            (
+                team,
+                '[[workflow.review_layers]]\nid = "stale"\nname = "Stale"\ninstruction = "x"\n',
+                r"workflow\.review_layers$",
+            ),
+            (team, "[workflow.message]\nnested = true\n", r"workflow\.message\.nested$"),
+            (team, 'message = "top level"\n', r"does not declare: message$"),
+        ):
+            with self.subTest(layer=layer.name, content=content):
+                layer.write_text(content, encoding="utf-8")
+                with self.assertRaisesRegex(rs.RenderError, expected):
+                    rs.render(ws.project, skill)
+                self.assertEqual(set((ws.bmad / "render" / skill.name).rglob("manifest.json")), generations)
+                layer.unlink()
+
     def test_invalid_invocation_halts_before_publication(self):
         invalid = (
             ("--set", "workflow.message"),


### PR DESCRIPTION
## Summary

The renderer validates a customization value only where a template reads it. A key in `_bmad/custom/<skill>.toml` or `<skill>.user.toml` that the shipped `customize.toml` does not declare was therefore merged and dropped silently: a misspelled key, or one a skill has since retired, left the user believing their override was in force.

Before merging the layers, the renderer now walks each persistent file's leaf paths against the shipped defaults and halts naming the file and the undeclared keys:

```
HALT: /project/_bmad/custom/bmad-code-review.user.toml sets keys bmad-code-review does not declare: workflow.review_layers
```

The check asks whether a key is declared, not whether this render read it, so an override of a key that only some rendered variants consume still passes. The existing invocation-override check keeps its stricter "used by this render" rule.

## Verification

- New test covers a misspelled key, a retired list-of-tables key, a table under a scalar default, and a bare top-level key, each halting before any generation is published, plus a declared-but-unread key rendering normally.
- Renderer test suite, ruff, pre-commit, and the full quality gate pass.
- Exercised live in a scratch project: a stale `review_layers` override halts with the file named; a clean render still publishes.
